### PR TITLE
Bring more dependencies to workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,27 @@ resolver = "2"
 [workspace.dependencies]
 bytes = "1.5.0"
 enum-as-inner = "0.6.0"
+env_logger = "0.10.0"
 ethereum-types = "0.14.1"
 hex = "0.4.3"
 hex-literal = "0.4.1"
 keccak-hash = "0.10.0"
 log = "0.4.20"
 num = "0.4.1"
+rand = "0.8.5"
 rlp = "0.5.2"
 rlp-derive = "0.1.0"
 serde = "1.0.166"
+serde_json = "1.0.96"
+thiserror = "1.0.49"
+
+# plonky2-related dependencies
+# TODO: Switch to versioning whenever possible
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "710225c9e0ac5822b2965ce74951cf000bbb8a2c" }
+plonky2_maybe_rayon = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "710225c9e0ac5822b2965ce74951cf000bbb8a2c" }
+plonky2_util = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "710225c9e0ac5822b2965ce74951cf000bbb8a2c" }
+starky = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "710225c9e0ac5822b2965ce74951cf000bbb8a2c" }
+
 
 [workspace.package]
 edition = "2021"

--- a/evm_arithmetization/Cargo.toml
+++ b/evm_arithmetization/Cargo.toml
@@ -14,23 +14,23 @@ keywords.workspace = true
 [dependencies]
 anyhow = "1.0.40"
 bytes = { workspace = true }
-env_logger = "0.10.0"
-ethereum-types = "0.14.0"
+env_logger = { workspace = true }
+ethereum-types = { workspace = true }
 hex = { workspace = true, optional = true }
 hex-literal = { workspace = true }
 itertools = "0.11.0"
 keccak-hash = { workspace = true }
 log = { workspace = true }
-plonky2_maybe_rayon = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "710225c9e0ac5822b2965ce74951cf000bbb8a2c" }
+plonky2_maybe_rayon = { workspace = true }
 num = { workspace = true }
 num-bigint = "0.4.3"
 once_cell = "1.13.0"
 pest = "2.1.3"
 pest_derive = "2.1.0"
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "710225c9e0ac5822b2965ce74951cf000bbb8a2c" }
-plonky2_util = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "710225c9e0ac5822b2965ce74951cf000bbb8a2c" }
-starky = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "710225c9e0ac5822b2965ce74951cf000bbb8a2c" }
-rand = "0.8.5"
+plonky2 = { workspace = true }
+plonky2_util = { workspace = true }
+starky = { workspace = true }
+rand = { workspace = true }
 rand_chacha = "0.3.1"
 rlp = { workspace = true }
 rlp-derive = { workspace = true }
@@ -38,7 +38,7 @@ serde = { workspace = true, features = ["derive"] }
 static_assertions = "1.1.0"
 hashbrown = { version = "0.14.0" }
 tiny-keccak = "2.0.2"
-serde_json = "1.0"
+serde_json = { workspace = true }
 
 # Local dependencies
 mpt_trie = { version = "0.1.0", path = "../mpt_trie" }

--- a/mpt_trie/Cargo.toml
+++ b/mpt_trie/Cargo.toml
@@ -20,7 +20,7 @@ ethereum-types = { workspace = true }
 hex = { workspace = true }
 keccak-hash = { workspace = true }
 parking_lot = { version = "0.12.1", features = ["serde"] }
-thiserror = "1.0.40"
+thiserror = { workspace = true }
 log = { workspace = true }
 num = { workspace = true, optional = true }
 num-traits = "0.2.15"
@@ -31,10 +31,9 @@ serde = { workspace = true, features = ["derive", "rc"] }
 [dev-dependencies]
 eth_trie = "0.4.0"
 pretty_env_logger = "0.5.0"
-rand = "0.8.5"
-rlp-derive = "0.1.0"
-serde = { version = "1.0.160", features = ["derive"] }
-serde_json = "1.0.96"
+rand = { workspace = true }
+rlp-derive = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = ["trie_debug"]

--- a/proof_gen/Cargo.toml
+++ b/proof_gen/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 ethereum-types = { workspace = true }
 log = { workspace = true }
 paste = "1.0.14"
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "710225c9e0ac5822b2965ce74951cf000bbb8a2c" }
+plonky2 = { workspace = true }
 serde = { workspace = true }
 
 # Local dependencies

--- a/trace_decoder/Cargo.toml
+++ b/trace_decoder/Cargo.toml
@@ -23,7 +23,7 @@ rlp = { workspace = true }
 rlp-derive = { workspace = true }
 serde = { workspace = true }
 serde_with = "3.4.0"
-thiserror = "1.0.49"
+thiserror = { workspace = true }
 
 # Local dependencies
 mpt_trie = { version = "0.1.0", path = "../mpt_trie" }


### PR DESCRIPTION
Some were missed in #14, and in particular the plonky2 deps, my bad. Although only `plonky2` is used across multiple crates here, I've moved all `plonky2` related dependencies at the workspace level for easier version bumping.