### PR TITLE
Add non jumpdests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2024-02-21
 * Initial release.
 
+## [Unreleased]
+
 ### Security
 - Add verification for invalid jumps. https://github.com/0xPolygonZero/zk_evm/pull/36

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2024-02-21
 * Initial release.
+
+### Security
+- Add verification for invalid jumps. https://github.com/0xPolygonZero/zk_evm/pull/36

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2024-02-21
-* Initial release.
-
 ## [Unreleased]
 
 ### Security
-- Add verification for invalid jumps. https://github.com/0xPolygonZero/zk_evm/pull/36
+- Add verification for invalid jumps. [#36](https://github.com/0xPolygonZero/zk_evm/pull/36)
+
+## [0.1.0] - 2024-02-21
+* Initial release.

--- a/evm_arithmetization/src/cpu/kernel/asm/core/exception.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/exception.asm
@@ -132,6 +132,8 @@ global invalid_jump_jumpi_destination_common:
     %shr_const(32)
     %jumpi(fault_exception) // This keeps one copy of jump_dest on the stack, but that's fine.
     // jump_dest is a valid address; check if it points to a `JUMP_DEST`.
+    DUP1
+    %verify_non_jumpdest
     %mload_current(@SEGMENT_JUMPDEST_BITS)
     // stack: is_valid_jumpdest
     %jumpi(panic) // Trap should never have been entered.

--- a/evm_arithmetization/src/cpu/kernel/asm/core/jumpdest_analysis.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/jumpdest_analysis.asm
@@ -278,7 +278,7 @@ global write_table_if_jumpdest:
     PUSH 0x8080808080808080808080808080808080808080808080808080808080808080
     AND
     // If we received a proof it MUST be valid or we abort immediately. This
-    // is especially important for non-jupdest proofs. Otherwise a malicious
+    // is especially important for non-jumpdest proofs. Otherwise a malicious
     // prover might mark a valid jumpdest as invalid by providing an invalid proof
     // that makes verify_non_jumpdest return prematurely.
     %assert_eq_const(0x8080808080808080808080808080808080808080808080808080808080808080)
@@ -358,7 +358,7 @@ global verify_non_jumpdest:
     // stack: addr, ctx
     PROVER_INPUT(jumpdest_table::non_jumpdest_proof)
     // stack: proof, addr, ctx,
-    // Chack that proof <= addr as otherwise it allows
+    // Check that proof <= addr as otherwise it allows
     // a malicious prover to leave `@SEGMENT_JUMPDEST_BITS` as 0
     // at position addr while it shouldn't.
     DUP2 DUP2

--- a/evm_arithmetization/src/cpu/kernel/asm/core/jumpdest_analysis.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/jumpdest_analysis.asm
@@ -277,13 +277,16 @@ global write_table_if_jumpdest:
     // pos 0102030405060708091011121314151617181920212223242526272829303132
     PUSH 0x8080808080808080808080808080808080808080808080808080808080808080
     AND
-    %jump_neq_const(0x8080808080808080808080808080808080808080808080808080808080808080, return_pop_opcode)
+    // If we received a proof it MUST be valid or we abort immediately. This
+    // is especially important for non-jupdest proofs. Otherwise a malicious
+    // prover might mark a valid jumpdest as invalid by providing an invalid proof
+    // that makes verify_non_jumpdest return prematurely.
+    %assert_eq_const(0x8080808080808080808080808080808080808080808080808080808080808080)
     POP
     %add_const(32)
 
     // check the remaining path
     %jump(verify_path_and_write_jumpdest_table)
-return_pop_opcode:
     POP
 return:
     // stack: proof_prefix_addr, ctx, jumpdest, retdest

--- a/evm_arithmetization/src/cpu/kernel/asm/core/jumpdest_analysis.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/jumpdest_analysis.asm
@@ -349,11 +349,13 @@ check_proof:
 // Non-deterministacally find the closest opcode to addr
 // and call write_table_if_jumpdest so that `@SEGMENT_JUMPDEST_BITS`
 // will contain a 0 if and only if addr is not a jumpdest
+// stack: addr, retdest
+// stack: (empty)
 global verify_non_jumpdest:
     // stack: addr, retdest
     GET_CONTEXT
     SWAP1
-    // stack: addr, ctx, addr
+    // stack: addr, ctx
     PROVER_INPUT(jumpdest_table::non_jumpdest_proof)
     // stack: proof, addr, ctx,
     // Chack that proof <= addr as otherwise it allows
@@ -363,3 +365,9 @@ global verify_non_jumpdest:
     %assert_le
     %write_table_if_jumpdest
     JUMP
+
+%macro verify_non_jumpdest
+    %stack (addr) -> (addr, %%after)
+    %jump(verify_non_jumpdest)
+%%after:
+%endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/core/jumpdest_analysis.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/jumpdest_analysis.asm
@@ -342,3 +342,21 @@ check_proof:
     %jump(jumpdest_analysis)
 %%after:
 %endmacro
+
+// Non-deterministacally find the closest opcode to addr
+// and call write_table_if_jumpdest so that `@SEGMENT_JUMPDEST_BITS`
+// will contain a 0 if and only if addr is not a jumpdest
+global verify_non_jumpdest:
+    // stack: addr, retdest
+    GET_CONTEXT
+    SWAP1
+    // stack: addr, ctx, addr
+    PROVER_INPUT(jumpdest_table::non_jumpdest_proof)
+    // stack: proof, addr, ctx,
+    // Chack that proof <= addr as otherwise it allows
+    // a malicious prover to leave `@SEGMENT_JUMPDEST_BITS` as 0
+    // at position addr while it shouldn't.
+    DUP2 DUP2
+    %assert_le
+    %write_table_if_jumpdest
+    JUMP

--- a/evm_arithmetization/src/cpu/kernel/asm/core/jumpdest_analysis.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/jumpdest_analysis.asm
@@ -346,7 +346,7 @@ check_proof:
 %%after:
 %endmacro
 
-// Non-deterministacally find the closest opcode to addr
+// Non-deterministically find the closest opcode to addr
 // and call write_table_if_jumpdest so that `@SEGMENT_JUMPDEST_BITS`
 // will contain a 0 if and only if addr is not a jumpdest
 // stack: addr, retdest

--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -1176,7 +1176,7 @@ impl<'a, F: Field> Interpreter<'a, F> {
         self.push(syscall_info)
     }
 
-    fn get_jumpdest_bit(&self, offset: usize) -> U256 {
+    pub(crate) fn get_jumpdest_bit(&self, offset: usize) -> U256 {
         if self.generation_state.memory.contexts[self.context()].segments
             [Segment::JumpdestBits.unscale()]
         .content

--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -152,7 +152,7 @@ pub(crate) fn simulate_cpu_and_get_user_jumps<F: Field>(
 
             interpreter.run();
 
-            log::debug!("jdt = {:?}", interpreter.jumpdest_table);
+            log::trace!("jumpdest table = {:?}", interpreter.jumpdest_table);
 
             interpreter
                 .generation_state

--- a/evm_arithmetization/src/cpu/kernel/tests/core/jumpdest_analysis.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/jumpdest_analysis.rs
@@ -144,7 +144,7 @@ fn test_packed_verification() -> Result<()> {
         interpreter.set_code(CONTEXT, code.clone());
         interpreter.generation_state.jumpdest_table = Some(HashMap::from([(3, vec![1, 33])]));
 
-        interpreter.run()?;
+        assert!(interpreter.run().is_err());
 
         assert!(interpreter.get_jumpdest_bits(CONTEXT).is_empty());
 

--- a/evm_arithmetization/src/cpu/kernel/tests/core/jumpdest_analysis.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/jumpdest_analysis.rs
@@ -153,3 +153,62 @@ fn test_packed_verification() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_verify_non_jumpdest() -> Result<()> {
+    // By default the interpreter will skip jumpdest analysis asm and compute
+    // the jumpdest table bits natively. We avoid that starting 1 line after
+    // performing the missing first PROVER_INPUT "by hand"
+    let verify_non_jumpdest = KERNEL.global_labels["verify_non_jumpdest"];
+    const CONTEXT: usize = 3; // arbitrary
+
+    let add = get_opcode("ADD");
+    let push2 = get_push_opcode(2);
+    let jumpdest = get_opcode("JUMPDEST");
+
+    #[rustfmt::skip]
+    let mut code: Vec<u8> = vec![
+        add,
+        jumpdest,
+        push2,
+        jumpdest, // part of PUSH2
+        jumpdest, // part of PUSH2
+        jumpdest,
+        add,
+        jumpdest,
+    ];
+    code.extend(
+        (0..32)
+            .rev()
+            .map(get_push_opcode)
+            .chain(std::iter::once(jumpdest)),
+    );
+    let code_len = code.len();
+
+    // If we add 1 to each opcode the jumpdest at position 32 is never a valid
+    // jumpdest
+    for i in 8..code_len - 1 {
+        code[i] += 1;
+        let mut interpreter: Interpreter<F> =
+            Interpreter::new_with_kernel(verify_non_jumpdest, vec![]);
+        interpreter.generation_state.registers.context = CONTEXT;
+
+        interpreter.set_code(CONTEXT, code.clone());
+        code[i] -= 1;
+
+        // We check that all non jumpdests are indeed non jumpdests
+        for (j, &opcode) in code
+            .iter()
+            .enumerate()
+            .filter(|&(j, _)| j != 1 && j != 5 && j != 7)
+        {
+            interpreter.generation_state.registers.program_counter = verify_non_jumpdest;
+            interpreter.push(0xDEADBEEFu32.into());
+            interpreter.push(j.into());
+            interpreter.run()?;
+            assert!(interpreter.stack().is_empty());
+            assert_eq!(interpreter.get_jumpdest_bit(j), U256::zero());
+        }
+    }
+    Ok(())
+}

--- a/evm_arithmetization/src/generation/prover_input.rs
+++ b/evm_arithmetization/src/generation/prover_input.rs
@@ -309,7 +309,7 @@ impl<F: Field> GenerationState<F> {
         }
     }
     /// Returns a non-jumpdest proof for the address on the top of the stack. A
-    /// non-jumpdest proof is the clossest address to address on the top of
+    /// non-jumpdest proof is the clossest address to the address on the top of
     /// the stack, if the closses address is >= 32, or zero otherwise.
     fn run_next_non_jumpdest_proof(&mut self) -> Result<U256, ProgramError> {
         let code = self.get_current_code()?;

--- a/evm_arithmetization/src/generation/prover_input.rs
+++ b/evm_arithmetization/src/generation/prover_input.rs
@@ -308,6 +308,7 @@ impl<F: Field> GenerationState<F> {
             ))
         }
     }
+
     /// Returns a non-jumpdest proof for the address on the top of the stack. A
     /// non-jumpdest proof is the clossest address to the address on the top of
     /// the stack, if the closses address is >= 32, or zero otherwise.
@@ -439,8 +440,6 @@ fn get_proofs_and_jumpdests(
 /// Return the largest prev_addr in `code` such that `code[pred_addr]` is an
 /// opcode (and not the argument of some PUSHXX) and pred_addr <= address
 fn get_closest_opcode_address(code: &[u8], address: usize) -> usize {
-    const PUSH1_OPCODE: u8 = 0x60;
-    const PUSH32_OPCODE: u8 = 0x7f;
     let (prev_addr, _) = CodeIterator::until(code, address + 1)
         .last()
         .unwrap_or((0, 0));


### PR DESCRIPTION
This PR adds an extra verification to  `invalid_jump_jumpi_destination_common` that verifies that the jump destination is indeed not a jumpdest. This is done by non-deterministically guessing the closest previous opcode and verifying that  after calling `write_table_if_jumpdest`, the corresponding bit in `@SEGMENT_JUMPDEST_BITS` is still 0.
Closes #27.