### PR TITLE
Additional tooling for allowing aggresive pruning logic

### DIFF
--- a/mpt_trie/src/debug_tools/common.rs
+++ b/mpt_trie/src/debug_tools/common.rs
@@ -1,65 +1,8 @@
 //! Common utilities for the debugging tools.
-use std::fmt::{self, Display};
-
 use crate::{
-    nibbles::{Nibble, Nibbles},
+    nibbles::Nibbles,
     partial_trie::{Node, PartialTrie},
-    utils::TrieNodeType,
 };
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub(super) enum PathSegment {
-    Empty,
-    Hash,
-    Branch(Nibble),
-    Extension(Nibbles),
-    Leaf(Nibbles),
-}
-
-impl Display for PathSegment {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PathSegment::Empty => write!(f, "Empty"),
-            PathSegment::Hash => write!(f, "Hash"),
-            PathSegment::Branch(nib) => write!(f, "Branch({})", nib),
-            PathSegment::Extension(nibs) => write!(f, "Extension({})", nibs),
-            PathSegment::Leaf(nibs) => write!(f, "Leaf({})", nibs),
-        }
-    }
-}
-
-impl PathSegment {
-    pub(super) fn node_type(&self) -> TrieNodeType {
-        match self {
-            PathSegment::Empty => TrieNodeType::Empty,
-            PathSegment::Hash => TrieNodeType::Hash,
-            PathSegment::Branch(_) => TrieNodeType::Branch,
-            PathSegment::Extension(_) => TrieNodeType::Extension,
-            PathSegment::Leaf(_) => TrieNodeType::Leaf,
-        }
-    }
-
-    pub(super) fn get_key_piece_from_seg_if_present(&self) -> Option<Nibbles> {
-        match self {
-            PathSegment::Empty | PathSegment::Hash => None,
-            PathSegment::Branch(nib) => Some(Nibbles::from_nibble(*nib)),
-            PathSegment::Extension(nibs) | PathSegment::Leaf(nibs) => Some(*nibs),
-        }
-    }
-}
-
-pub(super) fn get_segment_from_node_and_key_piece<T: PartialTrie>(
-    n: &Node<T>,
-    k_piece: &Nibbles,
-) -> PathSegment {
-    match TrieNodeType::from(n) {
-        TrieNodeType::Empty => PathSegment::Empty,
-        TrieNodeType::Hash => PathSegment::Hash,
-        TrieNodeType::Branch => PathSegment::Branch(k_piece.get_nibble(0)),
-        TrieNodeType::Extension => PathSegment::Extension(*k_piece),
-        TrieNodeType::Leaf => PathSegment::Leaf(*k_piece),
-    }
-}
 
 /// Get the key piece from the given node if applicable.
 ///
@@ -85,45 +28,5 @@ pub(super) fn get_key_piece_from_node<T: PartialTrie>(n: &Node<T>) -> Nibbles {
     match n {
         Node::Empty | Node::Hash(_) | Node::Branch { .. } => Nibbles::default(),
         Node::Extension { nibbles, child: _ } | Node::Leaf { nibbles, value: _ } => *nibbles,
-    }
-}
-
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
-/// A vector of path segments representing a path in the trie.
-pub struct NodePath(pub(super) Vec<PathSegment>);
-
-impl NodePath {
-    pub(super) fn dup_and_append(&self, seg: PathSegment) -> Self {
-        let mut duped_vec = self.0.clone();
-        duped_vec.push(seg);
-
-        Self(duped_vec)
-    }
-
-    pub(super) fn append(&mut self, seg: PathSegment) {
-        self.0.push(seg);
-    }
-
-    fn write_elem(f: &mut fmt::Formatter<'_>, seg: &PathSegment) -> fmt::Result {
-        write!(f, "{}", seg)
-    }
-}
-
-impl Display for NodePath {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let num_elems = self.0.len();
-
-        // For everything but the last elem.
-        for seg in self.0.iter().take(num_elems.saturating_sub(1)) {
-            Self::write_elem(f, seg)?;
-            write!(f, " --> ")?;
-        }
-
-        // Avoid the extra `-->` for the last elem.
-        if let Some(seg) = self.0.last() {
-            Self::write_elem(f, seg)?;
-        }
-
-        Ok(())
     }
 }

--- a/mpt_trie/src/debug_tools/diff.rs
+++ b/mpt_trie/src/debug_tools/diff.rs
@@ -30,7 +30,8 @@ use std::{fmt::Display, ops::Deref};
 
 use ethereum_types::H256;
 
-use super::common::{get_key_piece_from_node, get_segment_from_node_and_key_piece, NodePath};
+use super::common::get_key_piece_from_node;
+use crate::utils::{get_segment_from_node_and_key_piece, NodePath};
 use crate::{
     nibbles::Nibbles,
     partial_trie::{HashedPartialTrie, Node, PartialTrie},

--- a/mpt_trie/src/debug_tools/diff.rs
+++ b/mpt_trie/src/debug_tools/diff.rs
@@ -31,7 +31,7 @@ use std::{fmt::Display, ops::Deref};
 use ethereum_types::H256;
 
 use super::common::get_key_piece_from_node;
-use crate::utils::{get_segment_from_node_and_key_piece, NodePath};
+use crate::utils::{get_segment_from_node_and_key_piece, TriePath};
 use crate::{
     nibbles::Nibbles,
     partial_trie::{HashedPartialTrie, Node, PartialTrie},
@@ -84,7 +84,7 @@ pub struct DiffPoint {
     /// The depth of the point in both tries.
     pub depth: usize,
     /// The path of the point in both tries.
-    pub path: NodePath,
+    pub path: TriePath,
     /// The node key in both tries.
     pub key: Nibbles,
     /// The node info in the first trie.
@@ -98,7 +98,7 @@ impl DiffPoint {
         child_a: &HashedPartialTrie,
         child_b: &HashedPartialTrie,
         parent_k: Nibbles,
-        path: NodePath,
+        path: TriePath,
     ) -> Self {
         let a_key = parent_k.merge_nibbles(&get_key_piece_from_node(child_a));
         let b_key = parent_k.merge_nibbles(&get_key_piece_from_node(child_b));
@@ -223,7 +223,7 @@ impl DepthNodeDiffState {
         parent_k: &Nibbles,
         child_a: &HashedPartialTrie,
         child_b: &HashedPartialTrie,
-        path: NodePath,
+        path: TriePath,
     ) {
         if field
             .as_ref()
@@ -243,7 +243,7 @@ struct DepthDiffPerCallState<'a> {
     curr_depth: usize,
 
     // Horribly inefficient, but these are debug tools, so I think we get a pass.
-    curr_path: NodePath,
+    curr_path: TriePath,
 }
 
 impl<'a> DepthDiffPerCallState<'a> {
@@ -260,7 +260,7 @@ impl<'a> DepthDiffPerCallState<'a> {
             b,
             curr_key,
             curr_depth,
-            curr_path: NodePath::default(),
+            curr_path: TriePath::default(),
         }
     }
 
@@ -412,7 +412,7 @@ fn get_value_from_node<T: PartialTrie>(n: &Node<T>) -> Option<&Vec<u8>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{create_diff_between_tries, DiffPoint, NodeInfo, NodePath};
+    use super::{create_diff_between_tries, DiffPoint, NodeInfo, TriePath};
     use crate::{
         nibbles::Nibbles,
         partial_trie::{HashedPartialTrie, PartialTrie},
@@ -448,7 +448,7 @@ mod tests {
 
         let expected = DiffPoint {
             depth: 0,
-            path: NodePath(vec![]),
+            path: TriePath(vec![]),
             key: Nibbles::default(),
             a_info: expected_a,
             b_info: expected_b,

--- a/mpt_trie/src/debug_tools/query.rs
+++ b/mpt_trie/src/debug_tools/query.rs
@@ -9,7 +9,7 @@ use super::common::get_key_piece_from_node_pulling_from_key_for_branches;
 use crate::{
     nibbles::Nibbles,
     partial_trie::{Node, PartialTrie, WrappedNode},
-    utils::{get_segment_from_node_and_key_piece, NodePath, PathSegment},
+    utils::{get_segment_from_node_and_key_piece, PathSegment, TriePath},
 };
 
 /// Params controlling how much information is reported in the query output.
@@ -159,7 +159,7 @@ pub struct DebugQueryOutput {
     k: Nibbles,
 
     /// The nodes hit during the query.
-    pub node_path: NodePath,
+    pub node_path: TriePath,
     extra_node_info: Vec<Option<ExtraNodeSegmentInfo>>,
     node_found: bool,
     params: DebugQueryParams,
@@ -199,7 +199,7 @@ impl DebugQueryOutput {
     fn new(k: Nibbles, params: DebugQueryParams) -> Self {
         Self {
             k,
-            node_path: NodePath::default(),
+            node_path: TriePath::default(),
             extra_node_info: Vec::default(),
             node_found: false,
             params,

--- a/mpt_trie/src/debug_tools/query.rs
+++ b/mpt_trie/src/debug_tools/query.rs
@@ -5,13 +5,11 @@ use std::fmt::{self, Display};
 
 use ethereum_types::H256;
 
-use super::common::{
-    get_key_piece_from_node_pulling_from_key_for_branches, get_segment_from_node_and_key_piece,
-    NodePath, PathSegment,
-};
+use super::common::get_key_piece_from_node_pulling_from_key_for_branches;
 use crate::{
     nibbles::Nibbles,
     partial_trie::{Node, PartialTrie, WrappedNode},
+    utils::{get_segment_from_node_and_key_piece, NodePath, PathSegment},
 };
 
 /// Params controlling how much information is reported in the query output.
@@ -159,7 +157,9 @@ fn count_non_empty_branch_children_from_mask(mask: u16) -> usize {
 /// of the path used for searching for a key in the trie.
 pub struct DebugQueryOutput {
     k: Nibbles,
-    node_path: NodePath,
+
+    /// The nodes hit during the query.
+    pub node_path: NodePath,
     extra_node_info: Vec<Option<ExtraNodeSegmentInfo>>,
     node_found: bool,
     params: DebugQueryParams,

--- a/mpt_trie/src/debug_tools/query.rs
+++ b/mpt_trie/src/debug_tools/query.rs
@@ -9,7 +9,7 @@ use super::common::get_key_piece_from_node_pulling_from_key_for_branches;
 use crate::{
     nibbles::Nibbles,
     partial_trie::{Node, PartialTrie, WrappedNode},
-    utils::{get_segment_from_node_and_key_piece, PathSegment, TriePath},
+    utils::{get_segment_from_node_and_key_piece, TriePath, TrieSegment},
 };
 
 /// Params controlling how much information is reported in the query output.
@@ -219,7 +219,7 @@ impl DebugQueryOutput {
     // TODO: Make the output easier to read...
     fn fmt_node_based_on_debug_params(
         f: &mut fmt::Formatter<'_>,
-        seg: &PathSegment,
+        seg: &TrieSegment,
         extra_seg_info: &Option<ExtraNodeSegmentInfo>,
         params: &DebugQueryParams,
     ) -> fmt::Result {

--- a/mpt_trie/src/lib.rs
+++ b/mpt_trie/src/lib.rs
@@ -20,7 +20,7 @@ pub mod partial_trie;
 mod trie_hashing;
 pub mod trie_ops;
 pub mod trie_subsets;
-mod utils;
+pub mod utils;
 
 #[cfg(feature = "trie_debug")]
 pub mod debug_tools;

--- a/mpt_trie/src/lib.rs
+++ b/mpt_trie/src/lib.rs
@@ -17,7 +17,7 @@
 
 pub mod nibbles;
 pub mod partial_trie;
-mod special_query;
+pub mod special_query;
 mod trie_hashing;
 pub mod trie_ops;
 pub mod trie_subsets;

--- a/mpt_trie/src/lib.rs
+++ b/mpt_trie/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod nibbles;
 pub mod partial_trie;
+mod special_query;
 mod trie_hashing;
 pub mod trie_ops;
 pub mod trie_subsets;

--- a/mpt_trie/src/special_query.rs
+++ b/mpt_trie/src/special_query.rs
@@ -1,0 +1,153 @@
+//! Specialized queries that users of the library may need that require
+//! knowledge of the private internal trie state.
+
+use crate::{
+    nibbles::Nibbles,
+    partial_trie::{Node, PartialTrie, WrappedNode},
+    utils::PathSegment,
+};
+
+#[derive(Debug)]
+struct PathSegmentIterator<N: PartialTrie> {
+    curr_node: WrappedNode<N>,
+    curr_key: Nibbles,
+
+    // Although wrapping `curr_node` in an option might be more "Rust like", the logic is a lot
+    // cleaner with a bool.
+    terminated: bool,
+}
+
+impl<T: PartialTrie> Iterator for PathSegmentIterator<T> {
+    type Item = PathSegment;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.terminated {
+            return None;
+        }
+
+        match self.curr_node.as_ref() {
+            Node::Empty => {
+                self.terminated = true;
+                Some(PathSegment::Empty)
+            }
+            Node::Hash(_) => {
+                self.terminated = true;
+                Some(PathSegment::Hash)
+            }
+            Node::Branch { children, .. } => {
+                if self.curr_key.is_empty() {
+                    self.terminated = true;
+                    return None;
+                }
+
+                let nib = self.curr_key.pop_next_nibble_front();
+                self.curr_node = children[nib as usize].clone();
+
+                Some(PathSegment::Branch(nib))
+            }
+            Node::Extension { nibbles, child } => {
+                match self
+                    .curr_key
+                    .nibbles_are_identical_up_to_smallest_count(nibbles)
+                {
+                    false => {
+                        self.terminated = true;
+                        None
+                    }
+                    true => {
+                        pop_nibbles_clamped(&mut self.curr_key, nibbles.count);
+                        let res = Some(PathSegment::Extension(*nibbles));
+                        self.curr_node = child.clone();
+
+                        res
+                    }
+                }
+            }
+            Node::Leaf { nibbles, .. } => {
+                self.terminated = true;
+
+                match self.curr_key == *nibbles {
+                    false => None,
+                    true => Some(PathSegment::Leaf(*nibbles)),
+                }
+            }
+        }
+    }
+}
+
+fn pop_nibbles_clamped(nibbles: &mut Nibbles, n: usize) -> Nibbles {
+    let n_nibs_to_pop = nibbles.count.min(n);
+    nibbles.pop_nibbles_front(n_nibs_to_pop)
+}
+
+// TODO: Move to a blanket impl...
+// TODO: Could make this return an `Iterator` with some work...
+/// Returns all nodes in the trie that are traversed given a query (key).
+///
+/// Note that if the key does not match the entire key of a node (eg. the
+/// remaining key is `0x34` but the next key is a leaf with the key `0x3456`),
+/// then the leaf will not appear in the query output.
+pub fn get_path_for_query<K, T: PartialTrie>(
+    trie: &Node<T>,
+    k: K,
+) -> impl Iterator<Item = PathSegment>
+where
+    K: Into<Nibbles>,
+{
+    PathSegmentIterator {
+        curr_node: trie.clone().into(),
+        curr_key: k.into(),
+        terminated: false,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use super::get_path_for_query;
+    use crate::{nibbles::Nibbles, testing_utils::handmade_trie_1, utils::PathSegment};
+
+    #[test]
+    fn query_iter_works() {
+        let (trie, ks) = handmade_trie_1();
+
+        // ks --> vec![0x1234, 0x1324, 0x132400005_u64, 0x2001, 0x2002];
+        let res = vec![
+            vec![
+                PathSegment::Branch(1),
+                PathSegment::Branch(2),
+                PathSegment::Leaf(0x34.into()),
+            ],
+            vec![
+                PathSegment::Branch(1),
+                PathSegment::Branch(3),
+                PathSegment::Extension(0x24.into()),
+            ],
+            vec![
+                PathSegment::Branch(1),
+                PathSegment::Branch(3),
+                PathSegment::Extension(0x24.into()),
+                PathSegment::Branch(0),
+                PathSegment::Leaf(Nibbles::from_str("0x0005").unwrap()),
+            ],
+            vec![
+                PathSegment::Branch(2),
+                PathSegment::Extension(Nibbles::from_str("0x00").unwrap()),
+                PathSegment::Branch(0x1),
+                PathSegment::Leaf(Nibbles::default()),
+            ],
+            vec![
+                PathSegment::Branch(2),
+                PathSegment::Extension(Nibbles::from_str("0x00").unwrap()),
+                PathSegment::Branch(0x2),
+                PathSegment::Leaf(Nibbles::default()),
+            ],
+        ];
+
+        for (q, expected) in ks.into_iter().zip(res.into_iter()) {
+            let res: Vec<_> = get_path_for_query(&trie.node, q).collect();
+            assert_eq!(res, expected)
+        }
+    }
+}

--- a/mpt_trie/src/special_query.rs
+++ b/mpt_trie/src/special_query.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 #[derive(Debug)]
-struct PathSegmentIterator<N: PartialTrie> {
+pub struct TriePathIter<N: PartialTrie> {
     /// The next node in the trie to query with the remaining key.
     curr_node: WrappedNode<N>,
 
@@ -20,7 +20,7 @@ struct PathSegmentIterator<N: PartialTrie> {
     terminated: bool,
 }
 
-impl<T: PartialTrie> Iterator for PathSegmentIterator<T> {
+impl<T: PartialTrie> Iterator for TriePathIter<T> {
     type Item = PathSegment;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -94,14 +94,11 @@ fn pop_nibbles_clamped(nibbles: &mut Nibbles, n: usize) -> Nibbles {
 /// Note that if the key does not match the entire key of a node (eg. the
 /// remaining key is `0x34` but the next key is a leaf with the key `0x3456`),
 /// then the leaf will not appear in the query output.
-pub fn get_path_for_query<K, T: PartialTrie>(
-    trie: &Node<T>,
-    k: K,
-) -> impl Iterator<Item = PathSegment>
+pub fn path_for_query<K, T: PartialTrie>(trie: &Node<T>, k: K) -> impl Iterator<Item = PathSegment>
 where
     K: Into<Nibbles>,
 {
-    PathSegmentIterator {
+    TriePathIter {
         curr_node: trie.clone().into(),
         curr_key: k.into(),
         terminated: false,
@@ -112,7 +109,7 @@ where
 mod test {
     use std::str::FromStr;
 
-    use super::get_path_for_query;
+    use super::path_for_query;
     use crate::{nibbles::Nibbles, testing_utils::handmade_trie_1, utils::PathSegment};
 
     #[test]
@@ -153,7 +150,7 @@ mod test {
         ];
 
         for (q, expected) in ks.into_iter().zip(res.into_iter()) {
-            let res: Vec<_> = get_path_for_query(&trie.node, q).collect();
+            let res: Vec<_> = path_for_query(&trie.node, q).collect();
             assert_eq!(res, expected)
         }
     }

--- a/mpt_trie/src/special_query.rs
+++ b/mpt_trie/src/special_query.rs
@@ -81,8 +81,8 @@ impl<T: PartialTrie> Iterator for TriePathIter<T> {
     }
 }
 
-/// Attempt to pop `n` nibbles from the given [`Nibbles`] and "clamp" the
-/// nibbles popped by not popping more nibbles than exist.
+/// Attempts to pop `n` nibbles from the given [`Nibbles`] and "clamp" the
+/// nibbles popped by not popping more nibbles than there are.
 fn pop_nibbles_clamped(nibbles: &mut Nibbles, n: usize) -> Nibbles {
     let n_nibs_to_pop = nibbles.count.min(n);
     nibbles.pop_nibbles_front(n_nibs_to_pop)

--- a/mpt_trie/src/special_query.rs
+++ b/mpt_trie/src/special_query.rs
@@ -7,6 +7,7 @@ use crate::{
     utils::PathSegment,
 };
 
+/// An iterator for a trie query. Note that this iterator is lazy.
 #[derive(Debug)]
 pub struct TriePathIter<N: PartialTrie> {
     /// The next node in the trie to query with the remaining key.
@@ -94,7 +95,7 @@ fn pop_nibbles_clamped(nibbles: &mut Nibbles, n: usize) -> Nibbles {
 /// Note that if the key does not match the entire key of a node (eg. the
 /// remaining key is `0x34` but the next key is a leaf with the key `0x3456`),
 /// then the leaf will not appear in the query output.
-pub fn path_for_query<K, T: PartialTrie>(trie: &Node<T>, k: K) -> impl Iterator<Item = PathSegment>
+pub fn path_for_query<K, T: PartialTrie>(trie: &Node<T>, k: K) -> TriePathIter<T>
 where
     K: Into<Nibbles>,
 {

--- a/mpt_trie/src/trie_subsets.rs
+++ b/mpt_trie/src/trie_subsets.rs
@@ -662,9 +662,9 @@ mod tests {
     ) {
         let nodes = get_all_nodes_in_trie(trie);
         let keys_to_node_types: HashMap<_, _> =
-            HashMap::from_iter(nodes.into_iter().map(|n| (n.nibbles, n.n_type)));
+            HashMap::from_iter(nodes.into_iter().map(|n| (n.nibbles.reverse(), n.n_type)));
 
-        for (k, expected_n_type) in keys.map(|(k, t)| (k, t)) {
+        for (k, expected_n_type) in keys {
             let actual_n_type_opt = keys_to_node_types.get(&k);
 
             match actual_n_type_opt {
@@ -714,7 +714,8 @@ mod tests {
         let trie = create_trie_with_large_entry_nodes(&[0x1234, 0x1234589, 0x12346]);
         let partial_trie = create_trie_subset(&trie, [0x1234567]).unwrap();
 
-        assert_nodes_are_hash_nodes(&partial_trie, [0x1234589, 0x12346]);
+        // Note that `0x1234589` gets hashed at the branch slot at `0x12345`.
+        assert_nodes_are_hash_nodes(&partial_trie, [0x12345, 0x12346]);
     }
 
     #[test]

--- a/mpt_trie/src/trie_subsets.rs
+++ b/mpt_trie/src/trie_subsets.rs
@@ -390,8 +390,8 @@ mod tests {
         nibbles::Nibbles,
         partial_trie::{Node, PartialTrie},
         testing_utils::{
-            create_trie_with_large_entry_nodes, generate_n_random_fixed_trie_value_entries,
-            handmade_trie_1, TrieType,
+            common_setup, create_trie_with_large_entry_nodes,
+            generate_n_random_fixed_trie_value_entries, handmade_trie_1, TrieType,
         },
         trie_ops::ValOrHash,
         utils::TrieNodeType,
@@ -497,6 +497,8 @@ mod tests {
 
     #[test]
     fn empty_trie_does_not_return_err_on_query() {
+        common_setup();
+
         let trie = TrieType::default();
         let nibbles: Nibbles = 0x1234.into();
         let res = create_trie_subset(&trie, once(nibbles));
@@ -506,6 +508,8 @@ mod tests {
 
     #[test]
     fn non_existent_key_does_not_return_err() {
+        common_setup();
+
         let mut trie = TrieType::default();
         trie.insert(0x1234, vec![0, 1, 2]);
         let res = create_trie_subset(&trie, once(0x5678));
@@ -515,6 +519,8 @@ mod tests {
 
     #[test]
     fn encountering_a_hash_node_returns_err() {
+        common_setup();
+
         let trie = TrieType::new(Node::Hash(H256::zero()));
         let res = create_trie_subset(&trie, once(0x1234));
 
@@ -523,6 +529,8 @@ mod tests {
 
     #[test]
     fn single_node_trie_is_queryable() {
+        common_setup();
+
         let mut trie = TrieType::default();
         trie.insert(0x1234, vec![0, 1, 2]);
         let trie_subset = create_trie_subset(&trie, once(0x1234)).unwrap();
@@ -532,6 +540,8 @@ mod tests {
 
     #[test]
     fn multi_node_trie_returns_proper_subset() {
+        common_setup();
+
         let trie = create_trie_with_large_entry_nodes(&[0x1234, 0x56, 0x12345_u64]);
 
         let trie_subset = create_trie_subset(&trie, vec![0x1234, 0x56]).unwrap();
@@ -544,6 +554,8 @@ mod tests {
 
     #[test]
     fn intermediate_nodes_are_included_in_subset() {
+        common_setup();
+
         let (trie, ks_nibbles) = handmade_trie_1();
         let trie_subset_all = create_trie_subset(&trie, ks_nibbles.iter().cloned()).unwrap();
 
@@ -687,6 +699,8 @@ mod tests {
 
     #[test]
     fn all_leafs_of_keys_to_create_subset_are_included_in_subset_for_giant_trie() {
+        common_setup();
+
         let (_, trie_subsets, keys_of_subsets) = create_massive_trie_and_subsets(9009);
 
         for (sub_trie, ks_used) in trie_subsets.into_iter().zip(keys_of_subsets.into_iter()) {
@@ -707,6 +721,8 @@ mod tests {
 
     #[test]
     fn sub_trie_that_includes_branch_but_not_children_hashes_out_children() {
+        common_setup();
+
         let trie = create_trie_with_large_entry_nodes(&[0x1234, 0x12345, 0x12346, 0x1234f]);
         let partial_trie = create_trie_subset(&trie, [0x1234f]).unwrap();
 
@@ -715,6 +731,8 @@ mod tests {
 
     #[test]
     fn sub_trie_for_non_existent_key_that_hits_branch_leaf_hashes_out_leaf() {
+        common_setup();
+
         let trie = create_trie_with_large_entry_nodes(&[0x1234, 0x1234589, 0x12346]);
         let partial_trie = create_trie_subset(&trie, [0x1234567]).unwrap();
 
@@ -724,6 +742,7 @@ mod tests {
 
     #[test]
     fn hash_of_branch_partial_tries_matches_original_trie() {
+        common_setup();
         let trie = create_trie_with_large_entry_nodes(&[0x1234, 0x56, 0x12345]);
 
         let base_hash: H256 = trie.hash();
@@ -741,6 +760,8 @@ mod tests {
 
     #[test]
     fn hash_of_giant_random_partial_tries_matches_original_trie() {
+        common_setup();
+
         let (base_trie, trie_subsets, _) = create_massive_trie_and_subsets(9010);
         let base_hash = base_trie.hash();
 
@@ -751,6 +772,8 @@ mod tests {
 
     #[test]
     fn giant_random_partial_tries_hashes_leaves_correctly() {
+        common_setup();
+
         let (base_trie, trie_subsets, leaf_keys_per_trie) = create_massive_trie_and_subsets(9011);
         let all_keys: Vec<Nibbles> = base_trie.keys().collect();
 

--- a/mpt_trie/src/trie_subsets.rs
+++ b/mpt_trie/src/trie_subsets.rs
@@ -384,7 +384,7 @@ mod tests {
     use super::{create_trie_subset, create_trie_subsets};
     use crate::{
         nibbles::Nibbles,
-        partial_trie::{HashedPartialTrie, Node, PartialTrie},
+        partial_trie::{Node, PartialTrie},
         testing_utils::{
             create_trie_with_large_entry_nodes, generate_n_random_fixed_trie_value_entries,
             handmade_trie_1, TrieType,

--- a/mpt_trie/src/trie_subsets.rs
+++ b/mpt_trie/src/trie_subsets.rs
@@ -420,17 +420,6 @@ mod tests {
                 nibbles: nibbles.into(),
             }
         }
-
-        fn with_key(&self, k: &Nibbles) -> bool {
-            self.nibbles.reverse() == *k
-        }
-    }
-
-    fn get_node_full_nibbles_from_list<'a>(
-        nodes: &'a [NodeFullNibbles],
-        k: &'a Nibbles,
-    ) -> Option<&'a NodeFullNibbles> {
-        nodes.iter().find(|x| x.with_key(k))
     }
 
     fn get_all_nodes_in_trie(trie: &TrieType) -> Vec<NodeFullNibbles> {

--- a/mpt_trie/src/utils.rs
+++ b/mpt_trie/src/utils.rs
@@ -142,12 +142,24 @@ impl TriePath {
 
 /// A trie path that is constructed lazily.
 #[derive(Debug)]
-pub struct TriePathLazy<T: PartialTrie>(TriePathIter<T>);
+pub struct TriePathLazy<T: PartialTrie>(pub TriePathIter<T>);
 
 impl<T: PartialTrie> TriePathLazy<T> {
     /// Extract the key from the trie path.
     pub fn into_key(self) -> Nibbles {
-        todo!()
+        let mut key = Nibbles::default();
+
+        for seg in self.0 {
+            match seg {
+                PathSegment::Empty | PathSegment::Hash => (),
+                PathSegment::Branch(nib) => key.push_nibble_front(nib),
+                PathSegment::Extension(nibs) | PathSegment::Leaf(nibs) => {
+                    key.push_nibbles_front(&nibs)
+                }
+            }
+        }
+
+        key
     }
 }
 

--- a/mpt_trie/src/utils.rs
+++ b/mpt_trie/src/utils.rs
@@ -1,17 +1,35 @@
-use std::{fmt::Display, ops::BitAnd, sync::Arc};
+//! Various types and logic that don't fit well into any other module.
+
+use std::{
+    fmt::{self, Display},
+    ops::BitAnd,
+    sync::Arc,
+};
 
 use ethereum_types::{H256, U512};
 use num_traits::PrimInt;
 
-use crate::partial_trie::{Node, PartialTrie};
+use crate::{
+    nibbles::{Nibble, Nibbles},
+    partial_trie::{Node, PartialTrie},
+};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 /// Simplified trie node type to make logging cleaner.
-pub(crate) enum TrieNodeType {
+pub enum TrieNodeType {
+    /// Empty node.
     Empty,
+
+    /// Hash node.
     Hash,
+
+    /// Branch node.
     Branch,
+
+    /// Extension node.
     Extension,
+
+    /// Leaf node.
     Leaf,
 }
 
@@ -57,4 +75,118 @@ pub(crate) fn create_mask_of_1s(amt: usize) -> U512 {
 
 pub(crate) fn bytes_to_h256(b: &[u8; 32]) -> H256 {
     keccak_hash::H256::from_slice(b)
+}
+
+/// Minimal key information of "segments" (nodes) used to construct trie
+/// "traces" of a trie query. Unlike [`TrieNodeType`], this type also contains
+/// the key piece of the node if applicable (eg. [`Node::Empty`] &
+/// [`Node::Hash`] do not have associated key pieces).
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum PathSegment {
+    /// Empty node.
+    Empty,
+
+    /// Hash node.
+    Hash,
+
+    /// Branch node along with the nibble of the child taken.
+    Branch(Nibble),
+
+    /// Extension node along with the key piece of the node.
+    Extension(Nibbles),
+
+    /// Leaf node along wth the key piece of the node.
+    Leaf(Nibbles),
+}
+
+/// A vector of path segments representing a path in the trie.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub struct NodePath(pub Vec<PathSegment>);
+
+impl NodePath {
+    pub(crate) fn dup_and_append(&self, seg: PathSegment) -> Self {
+        let mut duped_vec = self.0.clone();
+        duped_vec.push(seg);
+
+        Self(duped_vec)
+    }
+
+    pub(crate) fn append(&mut self, seg: PathSegment) {
+        self.0.push(seg);
+    }
+
+    fn write_elem(f: &mut fmt::Formatter<'_>, seg: &PathSegment) -> fmt::Result {
+        write!(f, "{}", seg)
+    }
+}
+
+impl Display for NodePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let num_elems = self.0.len();
+
+        // For everything but the last elem.
+        for seg in self.0.iter().take(num_elems.saturating_sub(1)) {
+            Self::write_elem(f, seg)?;
+            write!(f, " --> ")?;
+        }
+
+        // Avoid the extra `-->` for the last elem.
+        if let Some(seg) = self.0.last() {
+            Self::write_elem(f, seg)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Display for PathSegment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PathSegment::Empty => write!(f, "Empty"),
+            PathSegment::Hash => write!(f, "Hash"),
+            PathSegment::Branch(nib) => write!(f, "Branch({})", nib),
+            PathSegment::Extension(nibs) => write!(f, "Extension({})", nibs),
+            PathSegment::Leaf(nibs) => write!(f, "Leaf({})", nibs),
+        }
+    }
+}
+
+impl PathSegment {
+    /// Get the node type of the [`PathSegment`].
+    pub fn node_type(&self) -> TrieNodeType {
+        match self {
+            PathSegment::Empty => TrieNodeType::Empty,
+            PathSegment::Hash => TrieNodeType::Hash,
+            PathSegment::Branch(_) => TrieNodeType::Branch,
+            PathSegment::Extension(_) => TrieNodeType::Extension,
+            PathSegment::Leaf(_) => TrieNodeType::Leaf,
+        }
+    }
+
+    /// Extracts the key piece used by the segment (if applicable).
+    pub fn get_key_piece_from_seg_if_present(&self) -> Option<Nibbles> {
+        match self {
+            PathSegment::Empty | PathSegment::Hash => None,
+            PathSegment::Branch(nib) => Some(Nibbles::from_nibble(*nib)),
+            PathSegment::Extension(nibs) | PathSegment::Leaf(nibs) => Some(*nibs),
+        }
+    }
+}
+
+/// Creates a [`PathSegment`] given a node and a key we are querying.
+///
+/// This function is intended to be used during a trie query as we are
+/// traversing down a trie. Depending on the current node, we pop off nibbles
+/// and use these to create `PathSegment`s.
+pub fn get_segment_from_node_and_key_piece<T: PartialTrie>(
+    n: &Node<T>,
+    k_piece: &Nibbles,
+) -> PathSegment {
+    match TrieNodeType::from(n) {
+        TrieNodeType::Empty => PathSegment::Empty,
+        TrieNodeType::Hash => PathSegment::Hash,
+        TrieNodeType::Branch => PathSegment::Branch(k_piece.get_nibble(0)),
+        TrieNodeType::Extension => PathSegment::Extension(*k_piece),
+        TrieNodeType::Leaf => PathSegment::Leaf(*k_piece),
+    }
 }


### PR DESCRIPTION
This PR adds the tooling needed to prune as aggressively as we were before while allowing us to detect the edge cases that were causing us to sometimes "over-prune".

Unfortunately I noticed as I was working on this PR that some public functions (`Nibbles::push_nibbles_back`) and other tests were missing that I needed. I decided to take care of that as well in this PR, so apologies for the additional noise.

The two new public functions that are needed upstream are:
- `path_for_query` (potentially rename?)
- `IntoTrieKey::into_key`

`path_for_query` returns minimal information (eg. key piece if available) on the nodes traversed by a query against a trie. `IntoTrieKey::into_key` is a trait that is used by `TriePath` & `TriePathIter` to extract the key of the query result. Note that the logic here is fairly similar to what already exists in `debug_query.rs`. However, this new query implementation is a lot more lightweight and unlike `debug_query.rs`, these calls are intended to actually be used in production.

### Other notes
- Fixed `create_trie_subsets` (not `create_trie_subset`) giving incorrect results if more than one trie was passed in. This was not yet used in production, and the existing test did not trigger the bug.
- I don't know if `TrieSegment` is the best name. In reality it's just the node type along with the key piece, but I couldn't come up with a better name.
- I'm not sure if a lot of this new logic really should go into `utils.rs` or be moved into a new module.