### PR TITLE
fix(evm_arithmetization): remove duplicate constraint in keccak_stark

### DIFF
--- a/evm_arithmetization/src/keccak/keccak_stark.rs
+++ b/evm_arithmetization/src/keccak/keccak_stark.rs
@@ -276,9 +276,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakStark<F
         let next_values = vars.get_next_values();
 
         // If this is not the final step, the filter must be off.
-        let final_step = local_values[reg_step(NUM_ROUNDS - 1)];
-        let not_final_step = P::ONES - final_step;
-        yield_constr.constraint(not_final_step * final_step);
+        let not_final_step = P::ONES - local_values[reg_step(NUM_ROUNDS - 1)];
 
         // If this is not the final step or a padding row,
         // the local and next timestamps must match.
@@ -443,10 +441,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakStark<F
         let next_values = vars.get_next_values();
 
         // If this is not the final step, the filter must be off.
-        let final_step = local_values[reg_step(NUM_ROUNDS - 1)];
-        let not_final_step = builder.sub_extension(one_ext, final_step);
-        let constraint = builder.mul_extension(not_final_step, final_step);
-        yield_constr.constraint(builder, constraint);
+        let not_final_step = builder.sub_extension(one_ext, local_values[reg_step(NUM_ROUNDS - 1)]);
 
         // If this is not the final step or a padding row,
         // the local and next timestamps must match.

--- a/evm_arithmetization/src/keccak/keccak_stark.rs
+++ b/evm_arithmetization/src/keccak/keccak_stark.rs
@@ -275,14 +275,10 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakStark<F
         let local_values = vars.get_local_values();
         let next_values = vars.get_next_values();
 
-        // The filter must be 0 or 1.
-        let filter = local_values[reg_step(NUM_ROUNDS - 1)];
-        yield_constr.constraint(filter * (filter - P::ONES));
-
         // If this is not the final step, the filter must be off.
         let final_step = local_values[reg_step(NUM_ROUNDS - 1)];
         let not_final_step = P::ONES - final_step;
-        yield_constr.constraint(not_final_step * filter);
+        yield_constr.constraint(not_final_step * final_step);
 
         // If this is not the final step or a padding row,
         // the local and next timestamps must match.
@@ -446,15 +442,10 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakStark<F
         let local_values = vars.get_local_values();
         let next_values = vars.get_next_values();
 
-        // The filter must be 0 or 1.
-        let filter = local_values[reg_step(NUM_ROUNDS - 1)];
-        let constraint = builder.mul_sub_extension(filter, filter, filter);
-        yield_constr.constraint(builder, constraint);
-
         // If this is not the final step, the filter must be off.
         let final_step = local_values[reg_step(NUM_ROUNDS - 1)];
         let not_final_step = builder.sub_extension(one_ext, final_step);
-        let constraint = builder.mul_extension(not_final_step, filter);
+        let constraint = builder.mul_extension(not_final_step, final_step);
         yield_constr.constraint(builder, constraint);
 
         // If this is not the final step or a padding row,

--- a/evm_arithmetization/src/keccak/round_flags.rs
+++ b/evm_arithmetization/src/keccak/round_flags.rs
@@ -30,12 +30,13 @@ pub(crate) fn eval_round_flags<F: Field, P: PackedField<Scalar = F>>(
         .sum::<P>();
     let next_any_flag = (0..NUM_ROUNDS).map(|i| next_values[reg_step(i)]).sum::<P>();
     let last_round_flag = local_values[reg_step(NUM_ROUNDS - 1)];
+    let padding_constraint =
+        (next_any_flag - F::ONE) * current_any_flag * (last_round_flag - F::ONE);
     for i in 0..NUM_ROUNDS {
         let current_round_flag = local_values[reg_step(i)];
         let next_round_flag = next_values[reg_step((i + 1) % NUM_ROUNDS)];
         yield_constr.constraint_transition(
-            next_any_flag * (next_round_flag - current_round_flag)
-                + (next_any_flag - F::ONE) * current_any_flag * (last_round_flag - F::ONE),
+            next_any_flag * (next_round_flag - current_round_flag) + padding_constraint,
         );
     }
 
@@ -65,16 +66,15 @@ pub(crate) fn eval_round_flags_recursively<F: RichField + Extendable<D>, const D
     let next_any_flag =
         builder.add_many_extension((0..NUM_ROUNDS).map(|i| next_values[reg_step(i)]));
     let last_round_flag = local_values[reg_step(NUM_ROUNDS - 1)];
+    let padding_constraint = {
+        let tmp = builder.mul_sub_extension(current_any_flag, next_any_flag, current_any_flag);
+        builder.mul_sub_extension(tmp, last_round_flag, tmp)
+    };
     for i in 0..NUM_ROUNDS {
         let current_round_flag = local_values[reg_step(i)];
         let next_round_flag = next_values[reg_step((i + 1) % NUM_ROUNDS)];
         let flag_diff = builder.sub_extension(next_round_flag, current_round_flag);
-        let constraint1 = builder.mul_extension(next_any_flag, flag_diff);
-        let constraint2 = {
-            let tmp = builder.mul_sub_extension(current_any_flag, next_any_flag, current_any_flag);
-            builder.mul_sub_extension(tmp, last_round_flag, tmp)
-        };
-        let constraint = builder.add_extension(constraint1, constraint2);
+        let constraint = builder.mul_add_extension(next_any_flag, flag_diff, padding_constraint);
         yield_constr.constraint_transition(builder, constraint);
     }
 

--- a/evm_arithmetization/src/keccak/round_flags.rs
+++ b/evm_arithmetization/src/keccak/round_flags.rs
@@ -29,13 +29,13 @@ pub(crate) fn eval_round_flags<F: Field, P: PackedField<Scalar = F>>(
         .map(|i| local_values[reg_step(i)])
         .sum::<P>();
     let next_any_flag = (0..NUM_ROUNDS).map(|i| next_values[reg_step(i)]).sum::<P>();
-    let last_row_flag = local_values[reg_step(NUM_ROUNDS - 1)];
+    let last_round_flag = local_values[reg_step(NUM_ROUNDS - 1)];
     for i in 0..NUM_ROUNDS {
         let current_round_flag = local_values[reg_step(i)];
         let next_round_flag = next_values[reg_step((i + 1) % NUM_ROUNDS)];
         yield_constr.constraint_transition(
             next_any_flag * (next_round_flag - current_round_flag)
-                + (next_any_flag - F::ONE) * current_any_flag * (last_row_flag - F::ONE),
+                + (next_any_flag - F::ONE) * current_any_flag * (last_round_flag - F::ONE),
         );
     }
 
@@ -64,16 +64,16 @@ pub(crate) fn eval_round_flags_recursively<F: RichField + Extendable<D>, const D
         builder.add_many_extension((0..NUM_ROUNDS).map(|i| local_values[reg_step(i)]));
     let next_any_flag =
         builder.add_many_extension((0..NUM_ROUNDS).map(|i| next_values[reg_step(i)]));
-    let last_row_flag = local_values[reg_step(NUM_ROUNDS - 1)];
+    let last_round_flag = local_values[reg_step(NUM_ROUNDS - 1)];
     for i in 0..NUM_ROUNDS {
         let current_round_flag = local_values[reg_step(i)];
         let next_round_flag = next_values[reg_step((i + 1) % NUM_ROUNDS)];
-        let diff1 = builder.sub_extension(next_round_flag, current_round_flag);
-        let constraint1 = builder.mul_extension(next_any_flag, diff1);
-        let diff2 = builder.sub_extension(next_any_flag, one);
-        let diff3 = builder.sub_extension(last_row_flag, one);
-        let prod = builder.mul_extension(diff2, diff3);
-        let constraint2 = builder.mul_extension(current_any_flag, prod);
+        let flag_diff = builder.sub_extension(next_round_flag, current_round_flag);
+        let constraint1 = builder.mul_extension(next_any_flag, flag_diff);
+        let constraint2 = {
+            let tmp = builder.mul_sub_extension(current_any_flag, next_any_flag, current_any_flag);
+            builder.mul_sub_extension(tmp, last_round_flag, tmp)
+        };
         let constraint = builder.add_extension(constraint1, constraint2);
         yield_constr.constraint_transition(builder, constraint);
     }

--- a/evm_arithmetization/src/keccak/round_flags.rs
+++ b/evm_arithmetization/src/keccak/round_flags.rs
@@ -29,6 +29,7 @@ pub(crate) fn eval_round_flags<F: Field, P: PackedField<Scalar = F>>(
         .map(|i| local_values[reg_step(i)])
         .sum::<P>();
     let next_any_flag = (0..NUM_ROUNDS).map(|i| next_values[reg_step(i)]).sum::<P>();
+    // Padding row should only start after the last round row.
     let not_final_step = P::ONES - local_values[reg_step(NUM_ROUNDS - 1)];
     let padding_constraint = (next_any_flag - F::ONE) * current_any_flag * not_final_step;
     for i in 0..NUM_ROUNDS {
@@ -64,6 +65,7 @@ pub(crate) fn eval_round_flags_recursively<F: RichField + Extendable<D>, const D
         builder.add_many_extension((0..NUM_ROUNDS).map(|i| local_values[reg_step(i)]));
     let next_any_flag =
         builder.add_many_extension((0..NUM_ROUNDS).map(|i| next_values[reg_step(i)]));
+    // Padding row should only start after the last round row.
     let not_final_step = builder.sub_extension(one, local_values[reg_step(NUM_ROUNDS - 1)]);
     let padding_constraint = {
         let tmp = builder.mul_sub_extension(current_any_flag, next_any_flag, current_any_flag);


### PR DESCRIPTION
Both the following constraints evaluate to the same constraint:
https://github.com/0xPolygonZero/zk_evm/blob/d0bc5ecef656eeb7fc0e335419c7b0e8f5b96282/evm_arithmetization/src/keccak/keccak_stark.rs#L278-L285

If $f = \text{local\\_values[reg\\_step(NUM\\_ROUNDS - 1)]}$ then
```rust
 let filter = local_values[reg_step(NUM_ROUNDS - 1)]; 
 yield_constr.constraint(filter * (filter - P::ONES)); 
 ```
corresponds to $f * (f - 1)$ and
```rust
 let final_step = local_values[reg_step(NUM_ROUNDS - 1)]; 
 let not_final_step = P::ONES - final_step; 
 yield_constr.constraint(not_final_step * filter); 
 ```
corresponds to $(1-f)*f$