### PR TITLE
Update mpt_trie API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refactor accessed lists as sorted linked lists ([#30](https://github.com/0xPolygonZero/zk_evm/pull/30))
+- Change visibility of `compact` mod ([#57](https://github.com/0xPolygonZero/zk_evm/pull/57))
+- Remove compilation flag for `debug_tools` mod ([#57](https://github.com/0xPolygonZero/zk_evm/pull/57))
 
 ## [0.1.0] - 2024-02-21
 * Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactor accessed lists as sorted linked lists ([#30](https://github.com/0xPolygonZero/zk_evm/pull/30))
 - Change visibility of `compact` mod ([#57](https://github.com/0xPolygonZero/zk_evm/pull/57))
-- Remove compilation flag for `debug_tools` mod ([#57](https://github.com/0xPolygonZero/zk_evm/pull/57))
 
 ## [0.1.0] - 2024-02-21
 * Initial release.

--- a/mpt_trie/src/lib.rs
+++ b/mpt_trie/src/lib.rs
@@ -16,6 +16,7 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 
+pub mod debug_tools;
 pub mod nibbles;
 pub mod partial_trie;
 pub mod special_query;
@@ -23,9 +24,6 @@ mod trie_hashing;
 pub mod trie_ops;
 pub mod trie_subsets;
 pub mod utils;
-
-#[cfg(feature = "trie_debug")]
-pub mod debug_tools;
 
 #[cfg(test)]
 pub(crate) mod testing_utils;

--- a/mpt_trie/src/lib.rs
+++ b/mpt_trie/src/lib.rs
@@ -16,7 +16,6 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 
-pub mod debug_tools;
 pub mod nibbles;
 pub mod partial_trie;
 pub mod special_query;
@@ -24,6 +23,9 @@ mod trie_hashing;
 pub mod trie_ops;
 pub mod trie_subsets;
 pub mod utils;
+
+#[cfg(feature = "trie_debug")]
+pub mod debug_tools;
 
 #[cfg(test)]
 pub(crate) mod testing_utils;

--- a/trace_decoder/src/lib.rs
+++ b/trace_decoder/src/lib.rs
@@ -5,7 +5,7 @@
 #![allow(unused)]
 #![allow(private_interfaces)]
 
-mod compact;
+pub mod compact;
 pub mod decoding;
 mod deserializers;
 pub mod processed_block_trace;


### PR DESCRIPTION
Some changes required for the `eth-trie-tools` dependencies.