### PR TITLE
Don't let doctest quirks stop testing in release mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactor accessed lists as sorted linked lists ([#30](https://github.com/0xPolygonZero/zk_evm/pull/30))
 - Change visibility of `compact` mod ([#57](https://github.com/0xPolygonZero/zk_evm/pull/57))
+- Fix running doctests in release mode ([#60](https://github.com/0xPolygonZero/zk_evm/pull/60))
 
 ## [0.1.0] - 2024-02-21
 * Initial release.

--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -14,8 +14,6 @@ use plonky2::plonk::config::GenericConfig;
 use plonky2::timed;
 use plonky2::util::timing::TimingTree;
 use starky::config::StarkConfig;
-#[cfg(debug_assertions)]
-use starky::cross_table_lookup::debug_utils::check_ctls;
 use starky::cross_table_lookup::{get_ctl_data, CtlData};
 use starky::lookup::GrandProductChallengeSet;
 use starky::proof::{MultiProof, StarkProofWithMetadata};
@@ -27,8 +25,6 @@ use crate::cpu::kernel::aggregator::KERNEL;
 use crate::generation::{generate_traces, GenerationInputs};
 use crate::get_challenges::observe_public_values;
 use crate::proof::{AllProof, PublicValues};
-#[cfg(debug_assertions)]
-use crate::verifier::debug_utils::get_memory_extra_looking_values;
 
 /// Generate traces, then create all STARK proofs.
 pub fn prove<F, C, const D: usize>(
@@ -149,6 +145,10 @@ where
     // enabled.
     #[cfg(debug_assertions)]
     {
+        use starky::cross_table_lookup::debug_utils::check_ctls;
+
+        use crate::verifier::debug_utils::get_memory_extra_looking_values;
+
         let mut extra_values = HashMap::new();
         extra_values.insert(
             *Table::Memory,

--- a/evm_arithmetization/src/verifier.rs
+++ b/evm_arithmetization/src/verifier.rs
@@ -282,7 +282,6 @@ where
     running_sum + challenge.combine(row.iter()).inverse()
 }
 
-#[cfg(debug_assertions)]
 pub(crate) mod debug_utils {
     use super::*;
 


### PR DESCRIPTION
On `main` we can't run tests with a simple `cargo t --release` because of a quirk in the way doctests are compiled in Rust. Doctests do not "see" compilation attributes like e.g. `test`, `doctest` or, as is the case here, `debug_assertions` because they are treated as separate compilation units. 

To work around this, this PR moves the relevant `use` clauses to the one spot in the code where the `debug_utils` modules are actually used and removes the conditional compilation from the modules themselves. The same has to be done in `starky` and that must be merged and published before this PR can be merged. 

Depends on https://github.com/0xPolygonZero/plonky2/pull/1540 being merged and published.