### PR TITLE
Fix trace decoder padding with dummy payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add verification for invalid jumps. [#36](https://github.com/0xPolygonZero/zk_evm/pull/36)
 - Refactor accessed lists as sorted linked lists ([#30](https://github.com/0xPolygonZero/zk_evm/pull/30))
 - Change visibility of `compact` mod ([#57](https://github.com/0xPolygonZero/zk_evm/pull/57))
+- Fix block padding without withdrawals ([#63](https://github.com/0xPolygonZero/zk_evm/pull/63))
 
 ## [0.1.0] - 2024-02-21
 * Initial release.


### PR DESCRIPTION
We were always using the final `ExtraBlockData` when padding a block. In the case of a single txn, when there are no withdrawals, we still prepend the txn with the dummy payload for efficiency, but this was leading to discrepancies when connecting the two.

This fixes it.