### PR TITLE
Document trace-decoder.

### DIFF
--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -25,48 +25,45 @@ use crate::{
     utils::{hash, update_val_if_some},
 };
 
-/// Stores the result of parsing tries. Returns a `TraceParsingError` in case of
-/// an error.
+/// Stores the result of parsing tries. Returns a [TraceParsingError] upon
+/// failure.
 pub type TraceParsingResult<T> = Result<T, TraceParsingError>;
 
 /// An error type for trie parsing.
 #[derive(Debug, Error)]
 pub enum TraceParsingError {
-    /// Error reslting from a failure to decode an Ethereum account.
+    /// Failure to decode an Ethereum [Account].
     #[error("Failed to decode RLP bytes ({0}) as an Ethereum account due to the error: {1}")]
     AccountDecode(String, String),
 
-    /// Error resulting from trying to access or delete a storage trie missing
+    /// Failure due to trying to access or delete a storage trie missing
     /// from the base trie.
     #[error("Missing account storage trie in base trie when constructing subset partial trie for txn (account: {0})")]
     MissingAccountStorageTrie(HashedAccountAddr),
 
-    /// Error resulting from trying to access a non-existent key in the trie.
+    /// Failure due to trying to access a non-existent key in the trie.
     #[error("Tried accessing a non-existent key ({1}) in the {0} trie (root hash: {2:x})")]
     NonExistentTrieEntry(TrieType, Nibbles, TrieRootHash),
 
-    // TODO: Figure out how to make this error useful/meaningful... For now this is just a
-    // placeholder.
-    /// Error resulting from missing keys when creating a subpartial trie.
+    /// Failure due to missing keys when creating a subpartial trie.
     #[error("Missing keys when creating sub-partial tries (Trie type: {0})")]
     MissingKeysCreatingSubPartialTrie(TrieType),
 
-    /// Error resulting from trying to withdraw from a missing withdrawal
-    /// account.
+    /// Failure due to trying to withdraw from a missing account
     #[error("No account present at {0:x} (hashed: {1:x}) to withdraw {2} Gwei from!")]
     MissingWithdrawalAccount(Address, HashedAccountAddr, U256),
 }
 
-/// Enumerates the types of tries.
+/// An enum to cover all Ethereum trie types (see https://ethereum.github.io/yellowpaper/paper.pdf for details).
 #[derive(Debug)]
 pub enum TrieType {
-    /// State trie type.
+    /// State trie.
     State,
-    /// Storage trie type.
+    /// Storage trie.
     Storage,
-    /// Receipt trie type.
+    /// Receipt trie.
     Receipt,
-    /// Transaction trie type.
+    /// Transaction trie.
     Txn,
 }
 

--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -25,33 +25,48 @@ use crate::{
     utils::{hash, update_val_if_some},
 };
 
+/// Stores the result of parsing tries. Returns a `TraceParsingError` in case of
+/// an error.
 pub type TraceParsingResult<T> = Result<T, TraceParsingError>;
 
+/// An error type for trie parsing.
 #[derive(Debug, Error)]
 pub enum TraceParsingError {
+    /// Error reslting from a failure to decode an Ethereum account.
     #[error("Failed to decode RLP bytes ({0}) as an Ethereum account due to the error: {1}")]
     AccountDecode(String, String),
 
+    /// Error resulting from trying to access or delete a storage trie missing
+    /// from the base trie.
     #[error("Missing account storage trie in base trie when constructing subset partial trie for txn (account: {0})")]
     MissingAccountStorageTrie(HashedAccountAddr),
 
+    /// Error resulting from trying to access a non-existent key in the trie.
     #[error("Tried accessing a non-existent key ({1}) in the {0} trie (root hash: {2:x})")]
     NonExistentTrieEntry(TrieType, Nibbles, TrieRootHash),
 
     // TODO: Figure out how to make this error useful/meaningful... For now this is just a
     // placeholder.
+    /// Error resulting from missing keys when creating a subpartial trie.
     #[error("Missing keys when creating sub-partial tries (Trie type: {0})")]
     MissingKeysCreatingSubPartialTrie(TrieType),
 
+    /// Error resulting from trying to withdraw from a missing withdrawal
+    /// account.
     #[error("No account present at {0:x} (hashed: {1:x}) to withdraw {2} Gwei from!")]
     MissingWithdrawalAccount(Address, HashedAccountAddr, U256),
 }
 
+/// Enumerates the types of tries.
 #[derive(Debug)]
 pub enum TrieType {
+    /// State trie type.
     State,
+    /// Storage trie type.
     Storage,
+    /// Receipt trie type.
     Receipt,
+    /// Transaction trie type.
     Txn,
 }
 

--- a/trace_decoder/src/lib.rs
+++ b/trace_decoder/src/lib.rs
@@ -1,14 +1,141 @@
+//! This library is intended to genrate an Intermediary Representation (IR) of a
+//! block's transactions, given a [BlockTrace] and some additional
+//! data [OtherBlockData].
+//!
+//! A [BlockTrace] is defined as follows:
+//! ```ignore
+//! pub struct BlockTrace {
+//!     /// The trie pre-images (state and storage) in multiple possible formats.
+//!     pub trie_pre_images: BlockTraceTriePreImages,
+//!     /// Traces and other info per transaction. The index of the transaction
+//!     /// within the block corresponds to the slot in this vec.
+//!     pub txn_info: Vec<TxnInfo>,
+//! }
+//! ```
+//! The trie preimages are the [HashedPartialTrie]s at the
+//! start of the block. A [TxnInfo] contains all the transaction data
+//! necessary to generate an IR.
+//!
+//! # Usage
+//!
+//! [The zero-bin prover](https://github.com/topos-protocol/zero-bin/blob/main/prover/src/lib.rs)
+//! provides a use case for this library:
+//! ```ignore
+//!  pub async fn prove(
+//!      // In this example, [self] is a [ProverInput] storing a [BlockTrace] and
+//!      // [OtherBlockData].
+//!      self,
+//!      runtime: &Runtime,
+//!      previous: Option<PlonkyProofIntern>,
+//!  ) -> Result<GeneratedBlockProof> {
+//!      let block_number = self.get_block_number();
+//!      info!("Proving block {block_number}");
+//!
+//!      let other_data = self.other_data;
+//!      // The method calls [into_txn_proof_gen_ir] (see below) to
+//!      // generate an IR for eaach block transaction.
+//!      let txs = self.block_trace.into_txn_proof_gen_ir(
+//!          &ProcessingMeta::new(resolve_code_hash_fn),
+//!          other_data.clone(),
+//!      )?;
+//!
+//!      // The block IRs are provided to the prover to generate an
+//!      // aggregation proof.
+//!      let agg_proof = IndexedStream::from(txs)
+//!          .map(&TxProof)
+//!          .fold(&AggProof)
+//!          .run(runtime)
+//!          .await?;
+//!
+//!      
+//!      if let AggregatableProof::Agg(proof) = agg_proof {
+//!          let prev = previous.map(|p| GeneratedBlockProof {
+//!              b_height: block_number.as_u64() - 1,
+//!              intern: p,
+//!          });
+//!
+//!          // The final aggregation proof is then used to prove the
+//!          // current block.
+//!          let block_proof = Literal(proof)
+//!              .map(&BlockProof { prev })
+//!              .run(runtime)
+//!              .await?;
+//!
+//!          info!("Successfully proved block {block_number}");
+//!          Ok(block_proof.0)
+//!      } else {
+//!          bail!("AggProof is is not GeneratedAggProof")
+//!      }
+//!  }
+//! ```
+//!
+//! As we see in the example, to turn a [BlockTrace] into a
+//! vector of IRs, one must call the method
+//! [into_txn_proof_gen_ir](BlockTrace::into_txn_proof_gen_ir):
+//! ```ignore
+//! pub fn into_txn_proof_gen_ir<F>(
+//!     self,
+//!     // Specifies the way code hashes should be dealt with.
+//!     p_meta: &ProcessingMeta<F>,
+//!     // Extra data needed for proof generation.
+//!     other_data: OtherBlockData,
+//! ) -> TraceParsingResult<Vec<TxnProofGenIR>>
+//! ```
+//!
+//! It first preprocesses the [BlockTrace] to provide transaction,
+//! withdrawals and tries data that can be directly used to generate an IR.
+//! [into_processed_block_trace](BlockTrace::into_processed_block_trace) is the
+//! method that produces such a [ProcessedBlockTrace].
+//! For each transaction,
+//! [into_txn_proof_gen_ir](BlockTrace::into_txn_proof_gen_ir) extracts the
+//! necessary data from the [ProcessedTxnInfo] to
+//! return the IR.
+//!
+//! The IR is used to generate root proofs, then aggregation proofs and finally
+//! block proofs. But an aggregation proof requires at least two entries. We
+//! ensure this by padding the vector of IRs thanks to additional dummy
+//!representations whenever necessary.
+//!
+//! ### Withdrawals and Padding
+//!
+//! Withdrawals are all proven together in a dummy transaction. They must,
+//! however, be proven last. The padding is therefore carried out as follows:
+//! If there are no transactions in the block, we add two dummy transactions.
+//! The withdrawals -- if any -- are added to the second dummy transaction. If
+//! there is only one transaction in the block, we add one dummy transaction. If
+//! there are withdrawals, the dummy transaction is at the end. Otherwse, it is
+//! added at the start. If there are two or more transactions:
+//! - if there are no withdrawals, no dummy transactions are added
+//! - if there are withdrawals, one dummy transaction is added at the end, with
+//!   all the withdrawals in it.
+
 #![feature(linked_list_cursors)]
 #![feature(trait_alias)]
 #![feature(iter_array_chunks)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(missing_debug_implementations)]
+#![deny(missing_docs)]
 // TODO: address these lints
 #![allow(unused)]
 #![allow(private_interfaces)]
 
+/// Provides debugging tools and a compact representation of state and storage
+/// tries, used in tests.
 pub mod compact;
+/// Defines the main functions used to generate the IR.
 pub mod decoding;
 mod deserializers;
+/// Defines functions that process a [BlockTrace](BlockTrace) and return a
+/// [ProcessedBlockTrace](ProcessedBlockTrace)so that it is easier to turn the
+/// block transactions into IRs.
 pub mod processed_block_trace;
 pub mod trace_protocol;
+/// Defines multiple types used in the other modules.
 pub mod types;
+/// Defines useful functions necessary to the other modules.
 pub mod utils;
+
+use mpt_trie::partial_trie::HashedPartialTrie;
+use processed_block_trace::{ProcessedBlockTrace, ProcessedTxnInfo};
+use trace_protocol::{BlockTrace, TxnInfo};
+use types::OtherBlockData;

--- a/trace_decoder/src/processed_block_trace.rs
+++ b/trace_decoder/src/processed_block_trace.rs
@@ -35,6 +35,8 @@ pub(crate) struct ProcessedBlockTrace {
 const COMPATIBLE_HEADER_VERSION: u8 = 1;
 
 impl BlockTrace {
+    /// Processes and returns the `GenerationInputs` for all transactions in the
+    /// block.
     pub fn into_txn_proof_gen_ir<F>(
         self,
         p_meta: &ProcessingMeta<F>,
@@ -172,6 +174,7 @@ fn process_compact_trie(trie: TrieCompact) -> ProcessedBlockTracePreImages {
     }
 }
 
+/// Structure storing a function turning a `CodeHash` into bytes.
 #[derive(Debug)]
 pub struct ProcessingMeta<F>
 where
@@ -184,6 +187,8 @@ impl<F> ProcessingMeta<F>
 where
     F: CodeHashResolveFunc,
 {
+    /// Returns a `ProcessingMeta` given the provided code hash resolving
+    /// function.
     pub fn new(resolve_code_hash_fn: F) -> Self {
         Self {
             resolve_code_hash_fn,

--- a/trace_decoder/src/processed_block_trace.rs
+++ b/trace_decoder/src/processed_block_trace.rs
@@ -35,7 +35,7 @@ pub(crate) struct ProcessedBlockTrace {
 const COMPATIBLE_HEADER_VERSION: u8 = 1;
 
 impl BlockTrace {
-    /// Processes and returns the `GenerationInputs` for all transactions in the
+    /// Processes and returns the [GenerationInputs] for all transactions in the
     /// block.
     pub fn into_txn_proof_gen_ir<F>(
         self,

--- a/trace_decoder/src/trace_protocol.rs
+++ b/trace_decoder/src/trace_protocol.rs
@@ -51,14 +51,18 @@ pub struct BlockTrace {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BlockTraceTriePreImages {
+    /// The trie pre-image with spearate state/storage tries.
     Separate(SeparateTriePreImages),
+    /// The trie pre-image with combined state/storage tries.
     Combined(CombinedPreImages),
 }
 
 /// State/Storage trie pre-images that are separate.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SeparateTriePreImages {
+    /// State trie.
     pub state: SeparateTriePreImage,
+    /// Storage trie.
     pub storage: SeparateStorageTriesPreImage,
 }
 
@@ -66,7 +70,10 @@ pub struct SeparateTriePreImages {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SeparateTriePreImage {
+    /// Storage or state trie in a bulkier format, that can be processed faster.
     Uncompressed(TrieUncompressed),
+    /// Storage or state trie format that can be processed as is, as it
+    /// corresponds to the internal format.
     Direct(TrieDirect),
 }
 
@@ -74,6 +81,7 @@ pub enum SeparateTriePreImage {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct CombinedPreImages {
+    /// Compact combined state and storage tries.
     pub compact: TrieCompact,
 }
 
@@ -94,6 +102,7 @@ pub struct TrieCompact(#[serde_as(as = "FromInto<ByteString>")] pub Vec<u8>);
 #[derive(Debug, Deserialize, Serialize)]
 pub struct TrieDirect(pub HashedPartialTrie);
 
+/// A trie pre-image where state and storage are separate.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SeparateStorageTriesPreImage {
@@ -121,6 +130,7 @@ pub struct TxnInfo {
     pub meta: TxnMeta,
 }
 
+/// Structure holding metadata for one transaction.
 #[serde_as]
 #[derive(Debug, Deserialize, Serialize)]
 pub struct TxnMeta {

--- a/trace_decoder/src/trace_protocol.rs
+++ b/trace_decoder/src/trace_protocol.rs
@@ -51,7 +51,7 @@ pub struct BlockTrace {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BlockTraceTriePreImages {
-    /// The trie pre-image with spearate state/storage tries.
+    /// The trie pre-image with separate state/storage tries.
     Separate(SeparateTriePreImages),
     /// The trie pre-image with combined state/storage tries.
     Combined(CombinedPreImages),

--- a/trace_decoder/src/types.rs
+++ b/trace_decoder/src/types.rs
@@ -6,19 +6,32 @@ use evm_arithmetization::{
 use mpt_trie::nibbles::Nibbles;
 use serde::{Deserialize, Serialize};
 
+/// A block height's type.
 pub type BlockHeight = u64;
+/// A bloom filter's type.
 pub type Bloom = [U256; 8];
+/// A code hash's type.
 pub type CodeHash = H256;
+/// The type of an account address's hash.
 pub type HashedAccountAddr = H256;
+/// The type of a node address's hash.
 pub type HashedNodeAddr = H256;
+/// The type of a storage address's hash.
 pub type HashedStorageAddr = H256;
+/// The type of a hashed storage address"s nibbles.
 pub type HashedStorageAddrNibbles = Nibbles;
+/// The type of a storage address.
 pub type StorageAddr = H256;
+/// The type of a storage address's nibbles.
 pub type StorageAddrNibbles = H256;
+/// A storage value's type.
 pub type StorageVal = U256;
+/// A trie root hash's type.
 pub type TrieRootHash = H256;
+/// Type of a transaction's index within a block.
 pub type TxnIdx = usize;
 
+/// A function which turns a code hash into bytes.
 pub trait CodeHashResolveFunc = Fn(&CodeHash) -> Vec<u8>;
 
 // 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
@@ -50,7 +63,9 @@ pub type TxnProofGenIR = GenerationInputs;
 /// Other data that is needed for proof gen.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OtherBlockData {
+    /// Data that is specific to the block.
     pub b_data: BlockLevelData,
+    /// State trie root hash at the checkpoint.
     pub checkpoint_state_trie_root: TrieRootHash,
 }
 
@@ -58,7 +73,10 @@ pub struct OtherBlockData {
 /// block.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BlockLevelData {
+    /// All block data excluding block hashes and withdrawals.
     pub b_meta: BlockMetadata,
+    /// Block hashes: the previous 256 block hashes and the current block hash.
     pub b_hashes: BlockHashes,
+    /// Block withdrawal addresses and values.
     pub withdrawals: Vec<(Address, U256)>,
 }

--- a/trace_decoder/src/types.rs
+++ b/trace_decoder/src/types.rs
@@ -6,29 +6,29 @@ use evm_arithmetization::{
 use mpt_trie::nibbles::Nibbles;
 use serde::{Deserialize, Serialize};
 
-/// A block height's type.
+/// A type alias around `u64` for a block height.
 pub type BlockHeight = u64;
-/// A bloom filter's type.
+/// A type alias around `[U256; 8]` for a bloom filter.
 pub type Bloom = [U256; 8];
-/// A code hash's type.
+/// A type alias around `H256` for a code hash.
 pub type CodeHash = H256;
-/// The type of an account address's hash.
+/// A type alias for `H256` for an account address's hash.
 pub type HashedAccountAddr = H256;
-/// The type of a node address's hash.
+/// A type alias around `H256` for a node address's hash.
 pub type HashedNodeAddr = H256;
-/// The type of a storage address's hash.
+/// A type alias around `H256` for a storage address's hash.
 pub type HashedStorageAddr = H256;
-/// The type of a hashed storage address"s nibbles.
+/// A type alias around `Nibbles` for a hashed storage address's nibbles.
 pub type HashedStorageAddrNibbles = Nibbles;
-/// The type of a storage address.
+/// A type alias around `H256` for a storage address.
 pub type StorageAddr = H256;
-/// The type of a storage address's nibbles.
+/// A type alias around `H256` for a storage address's nibbles.
 pub type StorageAddrNibbles = H256;
-/// A storage value's type.
+/// A type alias around `U256` for a storage value.
 pub type StorageVal = U256;
-/// A trie root hash's type.
+/// A type alias around `H256` for a trie root hash.
 pub type TrieRootHash = H256;
-/// Type of a transaction's index within a block.
+/// A type alias around `usize` for a transaction's index within a block.
 pub type TxnIdx = usize;
 
 /// A function which turns a code hash into bytes.


### PR DESCRIPTION
This PR aims at documenting the trace-decoding folder by adding the 
```
#![deny(rustdoc::broken_intra_doc_links)]
#![deny(missing_debug_implementations)]
#![deny(missing_docs)]
```
flags.

closes #18 