### PR TITLE
Add Will to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @muursh @Nashtare
+/evm_arithmetization/ @wborgeaud @muursh @Nashtare


### PR DESCRIPTION
The messy duplication of Robin and me is because gh won't automatically add a global owner to a PR unless it's specified if there's a rule for that dir. Don't ask me why. I have no idea. 