### PR TITLE
Pacify clippy

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/parser.rs
+++ b/evm_arithmetization/src/cpu/kernel/parser.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::empty_docs)]
+
 use std::str::FromStr;
 
 use ethereum_types::U256;


### PR DESCRIPTION
Yet another commit to pacify clippy.
This one seems like a false positive, but it's kinda harmless so no big deal to disable it for the file where the lint is triggered.