### PR TITLE
Add utility method for testing CPU execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix block padding without withdrawals ([#63](https://github.com/0xPolygonZero/zk_evm/pull/63))
 - Change position of empty node encoding in RLP segment ([#62](https://github.com/0xPolygonZero/zk_evm/pull/62))
 - Unify interpreter and prover witness generation ([#56](https://github.com/0xPolygonZero/zk_evm/pull/56))
+- Add utility method for testing CPU execution ([#71](https://github.com/0xPolygonZero/zk_evm/pull/71))
 
 ## [0.1.0] - 2024-02-21
 * Initial release.

--- a/evm_arithmetization/src/cpu/kernel/tests/add11.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/add11.rs
@@ -139,7 +139,7 @@ fn test_add11_yml() {
         block_bloom: [0.into(); 8],
     };
 
-    let tries_inputs = GenerationInputs {
+    let inputs = GenerationInputs {
         signed_txn: Some(txn.to_vec()),
         withdrawals: vec![],
         tries: tries_before,
@@ -157,13 +157,10 @@ fn test_add11_yml() {
     };
 
     let initial_stack = vec![];
+    let initial_offset = KERNEL.global_labels["main"];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new_with_generation_inputs(0, initial_stack, tries_inputs);
+        Interpreter::new_with_generation_inputs(initial_offset, initial_stack, inputs);
 
-    let route_txn_label = KERNEL.global_labels["main"];
-    // Switch context and initialize memory with the data we need for the tests.
-    interpreter.generation_state.registers.program_counter = route_txn_label;
-    interpreter.set_context_metadata_field(0, ContextMetadata::GasLimit, 1_000_000.into());
     interpreter.set_is_kernel(true);
     interpreter.run().expect("Proving add11 failed.");
 }
@@ -283,7 +280,7 @@ fn test_add11_yml_with_exception() {
         block_bloom: [0.into(); 8],
     };
 
-    let tries_inputs = GenerationInputs {
+    let inputs = GenerationInputs {
         signed_txn: Some(txn.to_vec()),
         withdrawals: vec![],
         tries: tries_before,
@@ -301,13 +298,10 @@ fn test_add11_yml_with_exception() {
     };
 
     let initial_stack = vec![];
+    let initial_offset = KERNEL.global_labels["main"];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new_with_generation_inputs(0, initial_stack, tries_inputs);
+        Interpreter::new_with_generation_inputs(initial_offset, initial_stack, inputs);
 
-    let route_txn_label = KERNEL.global_labels["main"];
-    // Switch context and initialize memory with the data we need for the tests.
-    interpreter.generation_state.registers.program_counter = route_txn_label;
-    interpreter.set_context_metadata_field(0, ContextMetadata::GasLimit, 1_000_000.into());
     interpreter.set_is_kernel(true);
     interpreter
         .run()

--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -364,3 +364,19 @@ pub fn check_abort_signal(abort_signal: Option<Arc<AtomicBool>>) -> Result<()> {
 
     Ok(())
 }
+
+/// A utility module designed to test witness generation externally.
+pub mod testing {
+    use super::*;
+    use crate::cpu::kernel::interpreter::Interpreter;
+
+    /// Simulates the zkEVM CPU execution.
+    /// It does not generate any trace or proof of correct state transition.
+    pub fn simulate_execution<F: RichField>(inputs: GenerationInputs) -> Result<()> {
+        let initial_stack = vec![];
+        let initial_offset = KERNEL.global_labels["main"];
+        let mut interpreter: Interpreter<F> =
+            Interpreter::new_with_generation_inputs(initial_offset, initial_stack, inputs);
+        interpreter.run()
+    }
+}


### PR DESCRIPTION
We need stronger testing through both the runner, the test chain, and L1 blocks, to prevent regressions and to support debugging efficiently.

Since #56 has been merged, we can leverage it to support full CPU execution without generating the traces, effectively just going through the kernel, thus allowing faster and cheaper testing without lower memory requirements.

This PR introduces such method for testing purposes.
