### PR TITLE
Bump all crates to v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2024-03-01
+
 ### Changed
 - Add verification for invalid jumps. [#36](https://github.com/0xPolygonZero/zk_evm/pull/36)
 - Refactor accessed lists as sorted linked lists ([#30](https://github.com/0xPolygonZero/zk_evm/pull/30))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0.49"
 plonky2 = "0.2.0"
 plonky2_maybe_rayon = "0.2.0"
 plonky2_util = "0.2.0"
-starky = "0.2.0"
+starky = "0.2.1"
 
 
 [workspace.package]

--- a/evm_arithmetization/Cargo.toml
+++ b/evm_arithmetization/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "evm_arithmetization"
 description = "Implementation of STARKs for the Ethereum Virtual Machine"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Daniel Lubarov <daniel@lubarov.com>", "William Borgeaud <williamborgeaud@gmail.com>"]
 readme = "README.md"
 categories = ["cryptography"]
@@ -41,7 +41,7 @@ tiny-keccak = "2.0.2"
 serde_json = { workspace = true }
 
 # Local dependencies
-mpt_trie = { version = "0.1.0", path = "../mpt_trie" }
+mpt_trie = { version = "0.1.1", path = "../mpt_trie" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.5.0"

--- a/mpt_trie/Cargo.toml
+++ b/mpt_trie/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mpt_trie"
 description = "Types and utility functions for building/working with partial Ethereum tries."
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Polygon Zero <bgluth@polygon.technology>"]
 readme = "README.md"
 edition.workspace = true

--- a/proof_gen/Cargo.toml
+++ b/proof_gen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proof_gen"
 description = "Generates block proofs from zero proof IR."
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Polygon Zero <bgluth@polygon.technology>"]
 edition.workspace = true
 license.workspace = true
@@ -17,5 +17,5 @@ plonky2 = { workspace = true }
 serde = { workspace = true }
 
 # Local dependencies
-trace_decoder = { version = "0.1.0", path = "../trace_decoder" }
-evm_arithmetization = { version = "0.1.0", path = "../evm_arithmetization" }
+trace_decoder = { version = "0.1.1", path = "../trace_decoder" }
+evm_arithmetization = { version = "0.1.1", path = "../evm_arithmetization" }

--- a/trace_decoder/Cargo.toml
+++ b/trace_decoder/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trace_decoder"
 description = "Processes trace payloads into Intermediate Representation (IR) format."
 authors = ["Polygon Zero <bgluth@polygon.technology>"]
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -27,8 +27,8 @@ serde_with = "3.4.0"
 thiserror = { workspace = true }
 
 # Local dependencies
-mpt_trie = { version = "0.1.0", path = "../mpt_trie" }
-evm_arithmetization = { version = "0.1.0", path = "../evm_arithmetization" }
+mpt_trie = { version = "0.1.1", path = "../mpt_trie" }
+evm_arithmetization = { version = "0.1.1", path = "../evm_arithmetization" }
 
 [dev-dependencies]
 pretty_env_logger = "0.5.0"


### PR DESCRIPTION
Also includes bumping `starky` to `v0.2.1` to fix `doctest` running in release mode: https://github.com/0xPolygonZero/plonky2/pull/1549

new releases to be published **AFTER** #73 is merged