### PR TITLE
Lighten up logging upon Kernel Panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Clean up logging output upon Kernel failure ([#74](https://github.com/0xPolygonZero/zk_evm/pull/74))
+
 ## [0.1.1] - 2024-03-01
 
 ### Changed
-- Add verification for invalid jumps. [#36](https://github.com/0xPolygonZero/zk_evm/pull/36)
+- Add verification for invalid jumps ([#36](https://github.com/0xPolygonZero/zk_evm/pull/36))
 - Refactor accessed lists as sorted linked lists ([#30](https://github.com/0xPolygonZero/zk_evm/pull/30))
 - Change visibility of `compact` mod ([#57](https://github.com/0xPolygonZero/zk_evm/pull/57))
 - Fix running doctests in release mode ([#60](https://github.com/0xPolygonZero/zk_evm/pull/60))

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -229,7 +229,10 @@ pub(crate) trait State<F: Field> {
                         e,
                         offset_name,
                         self.get_stack(),
-                        self.mem_get_kernel_content(),
+                        self.mem_get_kernel_content()
+                            .iter()
+                            .map(|c| c.unwrap_or_default())
+                            .collect_vec(),
                     );
                 }
                 self.rollback(checkpoint);


### PR DESCRIPTION
Follow-up from #56.

Upon `KernelPanic`, we print some info on where the error arised within the kernel, with the current stack and kernel memory.
With #56, we store memory elements as `Option<U256>` instead of `U256`, which makes the logs kind of heavy:

```bash
WARN [evm_arithmetization::witness::transition] Kernel panic at panic
WARN [evm_test_runner::plonky2_runner] witness generation failed with error: KernelPanic in kernel at
pc=panic, stack=[51], memory=[Some(42), Some(220), Some(37), Some(102), Some(80), Some(24), Some(170),
Some(31), Some(224), Some(230), Some(188), Some(102), Some(109), Some(172), Some(143), Some(194), Some(105), 
Some(127), Some(249), Some(186), Some(0), Some(0), Some(0), Some(0), Some(0), Some(0), Some(0), Some(0),
Some(0), Some(0), Some(0), Some(1), Some(0), Some(0), Some(0), Some(0), Some(0), Some(0), Some(0), Some(0),
Some(0), Some(0), Some(0), Some(0), Some(0), Some(0), Some(0), Some(0), Some(0), Some(0), Some(0), Some(0),
Some(0), Some(76), Some(162), Some(142), Some(182), Some(9), Some(69), Some(33), Some(226), Some(183),
Some(142), Some(18), Some(228), Some(2), Some(112), Some(23), Some(53), Some(253), Some(148), Some(76),
Some(157), Some(85), Some(253), Some(254), Some(7), Some(227), Some(247), Some(202), Some(142), Some(134),
Some(84), Some(192), Some(49)]
```

This changes it back to:
```bash 
WARN [evm_arithmetization::witness::transition] Kernel panic at panic
WARN [evm_test_runner::plonky2_runner] witness generation failed with error: KernelPanic in kernel at
pc=panic, stack=[51], memory=[42, 220, 37, 102, 80, 24, 170, 31, 224, 230, 188, 102, 109, 172, 143, 194,
105, 127, 249, 186, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
0, 0, 0, 0, 0, 76, 162, 142, 182, 9, 69, 33, 226, 183, 142, 18, 228, 2, 112, 23, 53, 253, 148, 76, 157, 85,
253, 254, 7, 227, 247, 202, 142, 134, 84, 192, 49)]
```

as it was before.