### PR TITLE
Fixed trie hash collision issue when constructing storage tries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Clean up logging output upon Kernel failure ([#74](https://github.com/0xPolygonZero/zk_evm/pull/74))
+- Fixed trie hash collision issue when constructing storage tries [#75](https://github.com/0xPolygonZero/zk_evm/pull/75)
 
 ## [0.1.1] - 2024-03-01
 

--- a/trace_decoder/src/compact/compact_prestate_processing.rs
+++ b/trace_decoder/src/compact/compact_prestate_processing.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 
 use super::compact_to_partial_trie::{
     create_partial_trie_from_remaining_witness_elem, create_storage_partial_trie_from_compact_node,
-    CompactToPartialTrieExtractionOutput, StateTrieExtractionOutput, UnexpectedCompactNodeType,
+    StateTrieExtractionOutput, UnexpectedCompactNodeType,
 };
 use crate::{
     decoding::TrieType,
@@ -85,7 +85,7 @@ pub enum CompactParsingError {
     )]
     MissingExpectedNodesPrecedingBranch(usize, usize, BranchMask, Vec<WitnessEntry>),
 
-    #[error("Found an unexpected compact node type ({0}) during processing compact into a `mpt_trie` {1} partial trie.")]
+    #[error("Found an unexpected compact node type ({0:?}) during processing compact into a `mpt_trie` {1} partial trie.")]
     UnexpectedNodeForTrieType(UnexpectedCompactNodeType, TrieType),
 
     #[error("Expected the entry preceding {0} positions behind a {1} entry to be a node but instead found a {2}. (nodes: {3:?})")]

--- a/trace_decoder/src/compact/compact_to_partial_trie.rs
+++ b/trace_decoder/src/compact/compact_to_partial_trie.rs
@@ -1,4 +1,7 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    fmt::{self, Display},
+};
 
 use evm_arithmetization::generation::mpt::AccountRlp;
 use log::trace;
@@ -8,25 +11,187 @@ use mpt_trie::{
 };
 
 use super::compact_prestate_processing::{
-    AccountNodeCode, AccountNodeData, CompactParsingResult, LeafNodeData, NodeEntry, WitnessEntry,
+    AccountNodeCode, AccountNodeData, CompactParsingError, CompactParsingResult, LeafNodeData,
+    NodeEntry, WitnessEntry,
 };
 use crate::{
-    types::{CodeHash, HashedAccountAddr, TrieRootHash, EMPTY_CODE_HASH, EMPTY_TRIE_HASH},
+    decoding::TrieType,
+    types::{
+        CodeHash, HashedAccountAddr, HashedAccountAddrNibbles, TrieRootHash, EMPTY_CODE_HASH,
+        EMPTY_TRIE_HASH,
+    },
     utils::{h_addr_nibs_to_h256, hash},
 };
 
-#[derive(Debug, Default)]
-pub(super) struct CompactToPartialTrieExtractionOutput {
-    pub(super) trie: HashedPartialTrie,
+pub trait CompactToPartialTrieExtractionOutput {
+    fn process_branch(
+        &mut self,
+        curr_key: Nibbles,
+        children: &[Option<Box<NodeEntry>>],
+    ) -> CompactParsingResult<()> {
+        for (i, slot) in children.iter().enumerate().take(16) {
+            if let Some(child) = slot {
+                // TODO: Seriously update `mpt_trie` to have a better API...
+                let mut new_k = curr_key;
+                new_k.push_nibble_back(i as Nibble);
+                create_partial_trie_from_compact_node_rec(new_k, child, self)?;
+            }
+        }
 
-    // TODO: `code` is ever only available for storage tries, so we should come up with a better
-    // API that represents this...
+        Ok(())
+    }
+
+    fn process_code(&mut self, c_bytes: Vec<u8>) -> CompactParsingResult<()>;
+
+    fn process_empty(&self) -> CompactParsingResult<()> {
+        // Nothing to do.
+        Ok(())
+    }
+
+    fn process_hash(&mut self, curr_key: Nibbles, hash: TrieRootHash) -> CompactParsingResult<()> {
+        self.get_trie().insert(curr_key, hash);
+
+        Ok(())
+    }
+
+    fn process_leaf(
+        &mut self,
+        curr_key: Nibbles,
+        leaf_key: &Nibbles,
+        leaf_node_data: &LeafNodeData,
+    ) -> CompactParsingResult<()>;
+
+    fn process_extension(
+        &mut self,
+        curr_key: Nibbles,
+        ext_node_key: &Nibbles,
+        ext_child: &NodeEntry,
+    ) -> CompactParsingResult<()> {
+        let new_k = curr_key.merge_nibbles(ext_node_key);
+        create_partial_trie_from_compact_node_rec(new_k, ext_child, self)?;
+
+        Ok(())
+    }
+
+    fn get_trie(&mut self) -> &mut HashedPartialTrie;
+}
+
+#[derive(Debug)]
+pub(super) enum UnexpectedCompactNodeType {
+    AccountLeaf,
+    Code,
+}
+
+impl Display for UnexpectedCompactNodeType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UnexpectedCompactNodeType::AccountLeaf => write!(f, "AccountLeaf"),
+            UnexpectedCompactNodeType::Code => write!(f, "Code"),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct StateTrieExtractionOutput {
+    pub(super) trie: HashedPartialTrie,
     pub(super) code: HashMap<CodeHash, Vec<u8>>,
+    pub(super) storage_tries: HashMap<HashedAccountAddr, HashedPartialTrie>,
+}
+
+impl CompactToPartialTrieExtractionOutput for StateTrieExtractionOutput {
+    fn process_code(&mut self, c_bytes: Vec<u8>) -> CompactParsingResult<()> {
+        let c_hash = hash(&c_bytes);
+        self.code.insert(c_hash, c_bytes);
+
+        Ok(())
+    }
+
+    fn process_leaf(
+        &mut self,
+        curr_key: Nibbles,
+        leaf_key: &Nibbles,
+        leaf_node_data: &LeafNodeData,
+    ) -> CompactParsingResult<()> {
+        process_leaf_common(
+            &mut self.trie,
+            curr_key,
+            leaf_key,
+            leaf_node_data,
+            |acc_data, full_k| {
+                Ok(
+                    convert_account_node_data_to_rlp_bytes_and_add_any_code_to_lookup(
+                        acc_data,
+                        full_k,
+                        &mut self.code,
+                        &mut self.storage_tries,
+                    ),
+                )
+            },
+        )
+    }
+    fn get_trie(&mut self) -> &mut HashedPartialTrie {
+        &mut self.trie
+    }
+}
+#[derive(Debug, Default)]
+pub(super) struct StorageTrieExtractionOutput {
+    pub(super) trie: HashedPartialTrie,
+}
+
+impl CompactToPartialTrieExtractionOutput for StorageTrieExtractionOutput {
+    fn process_code(&mut self, c_bytes: Vec<u8>) -> CompactParsingResult<()> {
+        Err(CompactParsingError::UnexpectedNodeForTrieType(
+            UnexpectedCompactNodeType::Code,
+            TrieType::Storage,
+        ))
+    }
+
+    fn process_leaf(
+        &mut self,
+        curr_key: Nibbles,
+        leaf_key: &Nibbles,
+        leaf_node_data: &LeafNodeData,
+    ) -> CompactParsingResult<()> {
+        process_leaf_common(
+            &mut self.trie,
+            curr_key,
+            leaf_key,
+            leaf_node_data,
+            |_, _| {
+                Err(CompactParsingError::UnexpectedNodeForTrieType(
+                    UnexpectedCompactNodeType::AccountLeaf,
+                    TrieType::Storage,
+                ))
+            },
+        )
+    }
+
+    fn get_trie(&mut self) -> &mut HashedPartialTrie {
+        &mut self.trie
+    }
+}
+
+fn process_leaf_common<F: FnMut(&AccountNodeData, &Nibbles) -> CompactParsingResult<Vec<u8>>>(
+    trie: &mut HashedPartialTrie,
+    curr_key: Nibbles,
+    leaf_key: &Nibbles,
+    leaf_node_data: &LeafNodeData,
+    mut account_leaf_proc_f: F,
+) -> CompactParsingResult<()> {
+    let full_k = curr_key.merge_nibbles(leaf_key);
+
+    let l_val = match leaf_node_data {
+        LeafNodeData::Value(v_bytes) => rlp::encode(&v_bytes.0).to_vec(),
+        LeafNodeData::Account(acc_data) => account_leaf_proc_f(acc_data, &full_k)?,
+    };
+
+    trie.insert(full_k, l_val);
+    Ok(())
 }
 
 pub(super) fn create_partial_trie_from_remaining_witness_elem(
     remaining_entry: WitnessEntry,
-) -> CompactParsingResult<CompactToPartialTrieExtractionOutput> {
+) -> CompactParsingResult<StateTrieExtractionOutput> {
     let remaining_node = remaining_entry
         .into_node()
         .expect("Final node in compact entries was not a node! This is a bug!");
@@ -34,11 +199,16 @@ pub(super) fn create_partial_trie_from_remaining_witness_elem(
     create_partial_trie_from_compact_node(remaining_node)
 }
 
-pub(super) fn create_partial_trie_from_compact_node(
+pub(super) fn create_storage_partial_trie_from_compact_node(
     node: NodeEntry,
-) -> CompactParsingResult<CompactToPartialTrieExtractionOutput> {
-    let mut output = CompactToPartialTrieExtractionOutput::default();
+) -> CompactParsingResult<StorageTrieExtractionOutput> {
+    create_partial_trie_from_compact_node(node)
+}
 
+fn create_partial_trie_from_compact_node<T: CompactToPartialTrieExtractionOutput + Default>(
+    node: NodeEntry,
+) -> CompactParsingResult<T> {
+    let mut output = T::default();
     create_partial_trie_from_compact_node_rec(Nibbles::default(), &node, &mut output)?;
 
     Ok(output)
@@ -46,106 +216,35 @@ pub(super) fn create_partial_trie_from_compact_node(
 
 // TODO: Consider putting in some asserts that invalid nodes are not appearing
 // in the wrong trie type (eg. account )
-pub(super) fn create_partial_trie_from_compact_node_rec(
+pub(super) fn create_partial_trie_from_compact_node_rec<
+    T: CompactToPartialTrieExtractionOutput + ?Sized,
+>(
     curr_key: Nibbles,
     curr_node: &NodeEntry,
-    output: &mut CompactToPartialTrieExtractionOutput,
+    output: &mut T,
 ) -> CompactParsingResult<()> {
     trace!("Processing node {} into `PartialTrie` node...", curr_node);
 
     match curr_node {
-        NodeEntry::Branch(n) => process_branch(curr_key, n, output),
-        NodeEntry::Code(c_bytes) => process_code(c_bytes.clone(), output),
-        NodeEntry::Empty => process_empty(),
-        NodeEntry::Hash(h) => process_hash(curr_key, *h, &mut output.trie),
-        NodeEntry::Leaf(k, v) => process_leaf(curr_key, k, v, output),
-        NodeEntry::Extension(k, c) => process_extension(curr_key, k, c, output),
+        NodeEntry::Branch(n) => output.process_branch(curr_key, n),
+        NodeEntry::Code(c_bytes) => output.process_code(c_bytes.clone()),
+        NodeEntry::Empty => output.process_empty(),
+        NodeEntry::Hash(h) => output.process_hash(curr_key, *h),
+        NodeEntry::Leaf(k, v) => output.process_leaf(curr_key, k, v),
+        NodeEntry::Extension(k, c) => output.process_extension(curr_key, k, c),
     }
-}
-
-fn process_branch(
-    curr_key: Nibbles,
-    branch: &[Option<Box<NodeEntry>>],
-    output: &mut CompactToPartialTrieExtractionOutput,
-) -> CompactParsingResult<()> {
-    for (i, slot) in branch.iter().enumerate().take(16) {
-        if let Some(child) = slot {
-            // TODO: Seriously update `mpt_trie` to have a better API...
-            let mut new_k = curr_key;
-            new_k.push_nibble_back(i as Nibble);
-            create_partial_trie_from_compact_node_rec(new_k, child, output)?;
-        }
-    }
-
-    Ok(())
-}
-
-fn process_code(
-    c_bytes: Vec<u8>,
-    output: &mut CompactToPartialTrieExtractionOutput,
-) -> CompactParsingResult<()> {
-    let c_hash = hash(&c_bytes);
-    output.code.insert(c_hash, c_bytes);
-
-    Ok(())
-}
-
-fn process_empty() -> CompactParsingResult<()> {
-    // Nothing to do.
-    Ok(())
-}
-
-fn process_hash(
-    curr_key: Nibbles,
-    hash: TrieRootHash,
-    p_trie: &mut HashedPartialTrie,
-) -> CompactParsingResult<()> {
-    // If we see a hash node at this stage, it must be a hashed out node in the
-    // trie.
-    p_trie.insert(curr_key, hash);
-
-    Ok(())
-}
-
-fn process_leaf(
-    curr_key: Nibbles,
-    leaf_key: &Nibbles,
-    leaf_node_data: &LeafNodeData,
-    output: &mut CompactToPartialTrieExtractionOutput,
-) -> CompactParsingResult<()> {
-    let full_k = curr_key.merge_nibbles(leaf_key);
-
-    let l_val = match leaf_node_data {
-        LeafNodeData::Value(v_bytes) => rlp::encode(&v_bytes.0).to_vec(),
-        LeafNodeData::Account(acc_data) => {
-            convert_account_node_data_to_rlp_bytes_and_add_any_code_to_lookup(acc_data, output)
-        }
-    };
-
-    output.trie.insert(full_k, l_val);
-    Ok(())
-}
-
-fn process_extension(
-    curr_key: Nibbles,
-    ext_node_key: &Nibbles,
-    ext_child: &NodeEntry,
-    output: &mut CompactToPartialTrieExtractionOutput,
-) -> CompactParsingResult<()> {
-    let new_k = curr_key.merge_nibbles(ext_node_key);
-    create_partial_trie_from_compact_node_rec(new_k, ext_child, output)?;
-
-    Ok(())
 }
 
 fn convert_account_node_data_to_rlp_bytes_and_add_any_code_to_lookup(
     acc_data: &AccountNodeData,
-    output: &mut CompactToPartialTrieExtractionOutput,
+    h_addr_nibs: &HashedAccountAddrNibbles,
+    c_hash_to_code: &mut HashMap<CodeHash, Vec<u8>>,
+    h_addr_to_storage_trie: &mut HashMap<HashedAccountAddr, HashedPartialTrie>,
 ) -> Vec<u8> {
     let code_hash = match &acc_data.account_node_code {
         Some(AccountNodeCode::CodeNode(c_bytes)) => {
             let c_hash = hash(c_bytes);
-            output.code.insert(c_hash, c_bytes.clone());
+            c_hash_to_code.insert(c_hash, c_bytes.clone());
 
             c_hash
         }
@@ -153,38 +252,20 @@ fn convert_account_node_data_to_rlp_bytes_and_add_any_code_to_lookup(
         None => EMPTY_CODE_HASH,
     };
 
+    let s_trie = acc_data.storage_trie.clone().unwrap_or_default().clone();
+    let h_addr = HashedAccountAddr::from_slice(&h_addr_nibs.bytes_be());
+
+    let storage_root = s_trie.hash();
+
+    h_addr_to_storage_trie.insert(h_addr, s_trie);
+
     let account = AccountRlp {
         nonce: acc_data.nonce,
         balance: acc_data.balance,
-        storage_root: acc_data.storage_root.unwrap_or(EMPTY_TRIE_HASH),
+        storage_root,
         code_hash,
     };
 
     // TODO: Avoid the unnecessary allocation...
     rlp::encode(&account).into()
-}
-
-pub(crate) fn convert_storage_trie_root_keyed_hashmap_to_account_addr_keyed(
-    state_trie: &HashedPartialTrie,
-    storage_root_trie: HashMap<TrieRootHash, HashedPartialTrie>,
-) -> HashMap<HashedAccountAddr, HashedPartialTrie> {
-    let mut acc_addr_to_storage_trie_map = HashMap::new();
-
-    let account_addr_and_storage_root_iter = state_trie.items()
-        .filter_map(|(h_addr_nibs, acc_bytes)| {
-            acc_bytes.as_val().map(|acc_bytes| {
-                (h_addr_nibs_to_h256(&h_addr_nibs), rlp::decode::<AccountRlp>(acc_bytes).expect("Encoder lib managed to improperly encode an account node in the state trie! This is a major bug in the encoder.").storage_root)
-        })
-    });
-
-    // TODO: Replace with a map...
-    for (acc_addr, storage_root) in account_addr_and_storage_root_iter {
-        if let Some(s_trie) = storage_root_trie.get(&storage_root) {
-            // Possibility of identical tries between accounts, so we need to do a clone
-            // here.
-            acc_addr_to_storage_trie_map.insert(acc_addr, s_trie.clone());
-        }
-    }
-
-    acc_addr_to_storage_trie_map
 }

--- a/trace_decoder/src/compact/compact_to_partial_trie.rs
+++ b/trace_decoder/src/compact/compact_to_partial_trie.rs
@@ -129,6 +129,7 @@ impl CompactToPartialTrieExtractionOutput for StateTrieExtractionOutput {
             },
         )
     }
+
     fn get_trie(&mut self) -> &mut HashedPartialTrie {
         &mut self.trie
     }

--- a/trace_decoder/src/types.rs
+++ b/trace_decoder/src/types.rs
@@ -7,31 +7,31 @@ use mpt_trie::nibbles::Nibbles;
 use serde::{Deserialize, Serialize};
 
 // TODO: Make these types in the doc comments point to the actual types...
-/// A type alias around `u64` for a block height.
+/// A type alias for `u64` of a block height.
 pub type BlockHeight = u64;
-/// A type alias around `[U256; 8]` for a bloom filter.
+/// A type alias for `[U256; 8]` of a bloom filter.
 pub type Bloom = [U256; 8];
-/// A type alias around `H256` for a code hash.
+/// A type alias for `H256` of a code hash.
 pub type CodeHash = H256;
-/// A type alias around `H256` for an account address's hash.
+/// A type alias for `H256` of an account address's hash.
 pub type HashedAccountAddr = H256;
-/// A type alias around `Nibbles` for an account address's hash.
+/// A type alias for `Nibbles` of an account address's hash.
 pub type HashedAccountAddrNibbles = Nibbles;
-/// A type alias around `H256` for a node address's hash.
+/// A type alias for `H256` of a node address's hash.
 pub type HashedNodeAddr = H256;
-/// A type alias around `H256` for a storage address's hash.
+/// A type alias for `H256` of a storage address's hash.
 pub type HashedStorageAddr = H256;
-/// A type alias around `Nibbles` for a hashed storage address's nibbles.
+/// A type alias for `Nibbles` of a hashed storage address's nibbles.
 pub type HashedStorageAddrNibbles = Nibbles;
-/// A type alias around `H256` for a storage address.
+/// A type alias for `H256` of a storage address.
 pub type StorageAddr = H256;
-/// A type alias around `H256` for a storage address's nibbles.
+/// A type alias for `H256` of a storage address's nibbles.
 pub type StorageAddrNibbles = H256;
-/// A type alias around `U256` for a storage value.
+/// A type alias for `U256` of a storage value.
 pub type StorageVal = U256;
-/// A type alias around `H256` for a trie root hash.
+/// A type alias for `H256` of a trie root hash.
 pub type TrieRootHash = H256;
-/// A type alias around `usize` for a transaction's index within a block.
+/// A type alias for `usize` of a transaction's index within a block.
 pub type TxnIdx = usize;
 
 /// A function which turns a code hash into bytes.

--- a/trace_decoder/src/types.rs
+++ b/trace_decoder/src/types.rs
@@ -6,14 +6,17 @@ use evm_arithmetization::{
 use mpt_trie::nibbles::Nibbles;
 use serde::{Deserialize, Serialize};
 
+// TODO: Make these types in the doc comments point to the actual types...
 /// A type alias around `u64` for a block height.
 pub type BlockHeight = u64;
 /// A type alias around `[U256; 8]` for a bloom filter.
 pub type Bloom = [U256; 8];
 /// A type alias around `H256` for a code hash.
 pub type CodeHash = H256;
-/// A type alias for `H256` for an account address's hash.
+/// A type alias around `H256` for an account address's hash.
 pub type HashedAccountAddr = H256;
+/// A type alias around `Nibbles` for an account address's hash.
+pub type HashedAccountAddrNibbles = Nibbles;
 /// A type alias around `H256` for a node address's hash.
 pub type HashedNodeAddr = H256;
 /// A type alias around `H256` for a storage address's hash.


### PR DESCRIPTION
Fixes the issue with hitting a hash node on block `17735424`.

Essentially the issue was we were making the assumption that a trie's root would always uniquely identify it, which is not the case when you have two otherwise identical tries except different nodes are hashed/unhashed. The previous impl did not have access to the account key when parsing the embedded storage trie within the account trie and relied on creating a temporary map between `trie_hash` --> `trie`. This map would at the end of the decoding process be used to connect accounts with their storage tries.

However, with the above issue, this meant that sometimes (apparently extremely rarely) an account's storage trie would get swapped out with another "identical" trie that had different nodes hashed out. In the case of `17735424`, an account was getting a trie that was entirely hashed out due to another storage trie overwriting it in the map.

A lot of the work in this PR is removing this old map of `trie_hash` --> `trie` and instead embedding the trie directly in `AccountNodeData` itself. Also needed to change `compact_to_partial_trie.rs` (which is used to parse both compact state and storage tries) to use a bit of specific logic for each.