### PR TITLE
Creating sub-tries now never hashes leaves

### DIFF
--- a/mpt_trie/src/trie_subsets.rs
+++ b/mpt_trie/src/trie_subsets.rs
@@ -288,7 +288,7 @@ fn mark_nodes_that_are_needed<N: PartialTrie>(
                 return Err(SubsetTrieError::UnexpectedKey(
                     *curr_nibbles,
                     format!("{:?}", trie),
-                ))
+                ));
             }
             true => {
                 trie.info.touched = true;
@@ -716,14 +716,14 @@ mod tests {
     }
 
     #[test]
-    fn sub_trie_for_non_existent_key_that_hits_branch_leaf_hashes_out_leaf() {
+    fn sub_trie_for_non_existent_key_that_hits_branch_leaf_does_not_hash_out_leaf() {
         common_setup();
 
         let trie = create_trie_with_large_entry_nodes(&[0x1234, 0x1234589, 0x12346]);
         let partial_trie = create_trie_subset(&trie, [0x1234567]).unwrap();
 
         // Note that `0x1234589` gets hashed at the branch slot at `0x12345`.
-        assert_nodes_are_hash_nodes(&partial_trie, [0x12345, 0x12346]);
+        assert_nodes_are_hash_nodes(&partial_trie, Vec::<Nibbles>::default());
     }
 
     #[test]

--- a/mpt_trie/src/trie_subsets.rs
+++ b/mpt_trie/src/trie_subsets.rs
@@ -316,10 +316,7 @@ fn mark_nodes_that_are_needed<N: PartialTrie>(
             }
         }
         TrackedNodeIntern::Leaf => {
-            let (k, _) = trie.info.get_leaf_nibbles_and_value_expected();
-            if k == curr_nibbles {
-                trie.info.touched = true;
-            }
+            trie.info.touched = true;
         }
     }
 


### PR DESCRIPTION
Very straightforward change.

`plonky2` seems to always expect that leaf nodes are never hashed out directly. By "directly" I mean if you have a leaf that is never read/written to but is the direct child of a parent that is also not hashed, then if we hash the leaf it may be traversed over and panic. It's not clear to me if this always happens, but I have observed a leaf that had no reads/writes (and was hashed out) be hit by plonky2.

Let me know if this shouldn't be the case in `plonky2`.