### PR TITLE
Fix Cycle count in logs for interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Clean up logging output upon Kernel failure ([#74](https://github.com/0xPolygonZero/zk_evm/pull/74))
+- Fix CPU Cycle display in logs during simulations ([#77](https://github.com/0xPolygonZero/zk_evm/pull/77))
 
 ## [0.1.1] - 2024-03-01
 

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -53,6 +53,9 @@ pub(crate) trait State<F: Field> {
     /// Returns a `RegistersState`.
     fn get_registers(&self) -> RegistersState;
 
+    /// Returns a reference to this `State`s `GenerationState`.
+    fn get_generation_state(&self) -> &GenerationState<F>;
+
     /// Returns a mutable reference to the `State`'s registers.
     fn get_mut_registers(&mut self) -> &mut RegistersState;
 
@@ -448,47 +451,42 @@ impl<F: Field> State<F> for GenerationState<F> {
         false
     }
 
-    /// Increments the `gas_used` register by a value `n`.
     fn incr_gas(&mut self, n: u64) {
         self.registers.gas_used += n;
     }
 
-    /// Increments the `program_counter` register by a value `n`.
     fn incr_pc(&mut self, n: usize) {
         self.registers.program_counter += n;
     }
 
-    /// Returns a `State`'s registers.
     fn get_registers(&self) -> RegistersState {
         self.registers
     }
 
-    /// Returns a `State`'s mutable registers.
     fn get_mut_registers(&mut self) -> &mut RegistersState {
         &mut self.registers
     }
 
-    /// Returns the value stored at address `address` in a `State`.
     fn get_from_memory(&mut self, address: MemoryAddress) -> U256 {
         self.memory.get_with_init(address)
     }
 
-    /// Returns a mutable `GenerationState` from a `State`.
+    fn get_generation_state(&self) -> &GenerationState<F> {
+        self
+    }
+
     fn get_mut_generation_state(&mut self) -> &mut GenerationState<F> {
         self
     }
 
-    /// Returns the value of a `State`'s clock.
     fn get_clock(&self) -> usize {
         self.traces.clock()
     }
 
-    /// Rolls back a `State`.
     fn rollback(&mut self, checkpoint: GenerationStateCheckpoint) {
         self.rollback(checkpoint)
     }
 
-    /// Returns a `State`'s stack.
     fn get_stack(&self) -> Vec<U256> {
         self.stack()
     }
@@ -497,14 +495,12 @@ impl<F: Field> State<F> for GenerationState<F> {
         self.registers.context
     }
 
-    /// Returns the content of a the `KernelGeneral` segment of a `State`.
     fn mem_get_kernel_content(&self) -> Vec<Option<U256>> {
         self.memory.contexts[0].segments[Segment::KernelGeneral.unscale()]
             .content
             .clone()
     }
 
-    /// Applies a `State`'s operations since a checkpoint.
     fn apply_ops(&mut self, checkpoint: GenerationStateCheckpoint) {
         self.memory
             .apply_ops(self.traces.mem_ops_since(checkpoint.traces))

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -171,6 +171,7 @@ pub(crate) trait State<F: Field> {
                         return Ok(());
                     }
                 } else {
+                    #[cfg(not(test))]
                     log::info!("CPU halted after {} cycles", self.get_clock());
                     return Ok(());
                 }

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::mem::size_of;
 
-use anyhow::bail;
+use anyhow::{anyhow, bail};
 use ethereum_types::{Address, BigEndianHash, H160, H256, U256};
 use itertools::Itertools;
 use keccak_hash::keccak;
@@ -200,7 +200,8 @@ pub(crate) trait State<F: Field> {
         let checkpoint = self.checkpoint();
 
         let (row, _) = self.base_row();
-        generate_exception(exc_code, self, row);
+        generate_exception(exc_code, self, row)
+            .map_err(|e| anyhow!("Exception handling failed with error: {:?}", e))?;
 
         self.apply_ops(checkpoint);
 

--- a/evm_arithmetization/src/witness/transition.rs
+++ b/evm_arithmetization/src/witness/transition.rs
@@ -268,13 +268,13 @@ pub(crate) const fn might_overflow_op(op: Operation) -> bool {
     }
 }
 
-pub(crate) fn log_kernel_instruction<F: Field>(state: &mut GenerationState<F>, op: Operation) {
+pub(crate) fn log_kernel_instruction<F: Field, S: State<F>>(state: &mut S, op: Operation) {
     // The logic below is a bit costly, so skip it if debug logs aren't enabled.
     if !log_enabled!(log::Level::Debug) {
         return;
     }
 
-    let pc = state.registers.program_counter;
+    let pc = state.get_registers().program_counter;
     let is_interesting_offset = KERNEL
         .offset_label(pc)
         .filter(|label| !label.starts_with("halt"))
@@ -287,11 +287,11 @@ pub(crate) fn log_kernel_instruction<F: Field>(state: &mut GenerationState<F>, o
     log::log!(
         level,
         "Cycle {}, ctx={}, pc={}, instruction={:?}, stack={:?}",
-        state.traces.clock(),
-        state.registers.context,
+        state.get_clock(),
+        state.get_context(),
         KERNEL.offset_name(pc),
         op,
-        state.stack(),
+        state.get_generation_state().stack(),
     );
 
     assert!(pc < KERNEL.code.len(), "Kernel PC is out of range: {}", pc);


### PR DESCRIPTION
Tiny other fix from #56.
Running CPU simulation outputs the correct total CPU cycles count at the end, but using `Debug` or `Trace` levels would display always `Cycle 0` with current `main` when going through the execution.
The issue was that we were still using `GenerationState` for `log_kernel_instruction` instead of the new `State` trait.

It also hides the final unpadded length print behind a `#[cfg(not(test))]` flag, as to not get the CI logs too verbose (it's getting spammed currently).