### PR TITLE
Fix blake2 precompile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Clean up logging output upon Kernel failure ([#74](https://github.com/0xPolygonZero/zk_evm/pull/74))
+- Fix blake2 precompile ([#78](https://github.com/0xPolygonZero/zk_evm/pull/78))
 
 ## [0.1.1] - 2024-03-01
 


### PR DESCRIPTION
The `blake2` precompile is currently broken. This is because gas calculation is updating the number of rounds, effectively causing tests to blow up (kernel exit info storing the gas is scaled by $2^{192}$).
Because the stack is too large, I've moved the gas calculation prior to loading all the blake inputs.

The fix can be tested on the `blake2B` test variants with the test-runner. They now pass fine (before they would just hang forever). The variants of `CALLCODEBlake2f` and `CALLBlake2f` also pass fine, though variant case `d9g0v0_Shanghai` for both takes a long time.