### PR TITLE
Cleanup needless imports

### DIFF
--- a/evm_arithmetization/src/arithmetic/addcy.rs
+++ b/evm_arithmetization/src/arithmetic/addcy.rs
@@ -260,13 +260,11 @@ pub(crate) fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
 #[cfg(test)]
 mod tests {
     use plonky2::field::goldilocks_field::GoldilocksField;
-    use plonky2::field::types::{Field, Sample};
+    use plonky2::field::types::Sample;
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
-    use starky::constraint_consumer::ConstraintConsumer;
 
     use super::*;
-    use crate::arithmetic::columns::NUM_ARITH_COLUMNS;
 
     // TODO: Should be able to refactor this test to apply to all operations.
     #[test]

--- a/evm_arithmetization/src/arithmetic/arithmetic_stark.rs
+++ b/evm_arithmetization/src/arithmetic/arithmetic_stark.rs
@@ -335,15 +335,13 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for ArithmeticSta
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use ethereum_types::U256;
-    use plonky2::field::types::{Field, PrimeField64};
+    use plonky2::field::types::Field;
     use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
     use starky::stark_testing::{test_stark_circuit_constraints, test_stark_low_degree};
 
-    use super::{columns, ArithmeticStark};
-    use crate::arithmetic::columns::OUTPUT_REGISTER;
+    use super::ArithmeticStark;
     use crate::arithmetic::*;
 
     #[test]

--- a/evm_arithmetization/src/arithmetic/byte.rs
+++ b/evm_arithmetization/src/arithmetic/byte.rs
@@ -448,7 +448,6 @@ mod tests {
     use rand_chacha::ChaCha8Rng;
 
     use super::*;
-    use crate::arithmetic::columns::NUM_ARITH_COLUMNS;
 
     type F = GoldilocksField;
 

--- a/evm_arithmetization/src/arithmetic/divmod.rs
+++ b/evm_arithmetization/src/arithmetic/divmod.rs
@@ -215,10 +215,8 @@ mod tests {
     use plonky2::field::types::{Field, Sample};
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
-    use starky::constraint_consumer::ConstraintConsumer;
 
     use super::*;
-    use crate::arithmetic::columns::NUM_ARITH_COLUMNS;
 
     const N_RND_TESTS: usize = 1000;
     const MODULAR_OPS: [usize; 2] = [IS_MOD, IS_DIV];

--- a/evm_arithmetization/src/arithmetic/modular.rs
+++ b/evm_arithmetization/src/arithmetic/modular.rs
@@ -828,14 +828,11 @@ pub(crate) fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
 #[cfg(test)]
 mod tests {
     use plonky2::field::goldilocks_field::GoldilocksField;
-    use plonky2::field::types::{Field, Sample};
+    use plonky2::field::types::Sample;
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
-    use starky::constraint_consumer::ConstraintConsumer;
 
     use super::*;
-    use crate::arithmetic::columns::NUM_ARITH_COLUMNS;
-    use crate::extension_tower::BN_BASE;
 
     const N_RND_TESTS: usize = 1000;
     const MODULAR_OPS: [usize; 6] = [

--- a/evm_arithmetization/src/arithmetic/mul.rs
+++ b/evm_arithmetization/src/arithmetic/mul.rs
@@ -251,13 +251,11 @@ pub(crate) fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
 #[cfg(test)]
 mod tests {
     use plonky2::field::goldilocks_field::GoldilocksField;
-    use plonky2::field::types::{Field, Sample};
+    use plonky2::field::types::Sample;
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
-    use starky::constraint_consumer::ConstraintConsumer;
 
     use super::*;
-    use crate::arithmetic::columns::NUM_ARITH_COLUMNS;
 
     const N_RND_TESTS: usize = 1000;
 

--- a/evm_arithmetization/src/arithmetic/shift.rs
+++ b/evm_arithmetization/src/arithmetic/shift.rs
@@ -185,10 +185,8 @@ mod tests {
     use plonky2::field::types::{Field, Sample};
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
-    use starky::constraint_consumer::ConstraintConsumer;
 
     use super::*;
-    use crate::arithmetic::columns::NUM_ARITH_COLUMNS;
 
     const N_RND_TESTS: usize = 1000;
 

--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -7,7 +7,6 @@ use std::collections::{BTreeSet, HashMap};
 use anyhow::anyhow;
 use ethereum_types::{BigEndianHash, U256};
 use mpt_trie::partial_trie::PartialTrie;
-use plonky2::field::goldilocks_field::GoldilocksField;
 use plonky2::field::types::Field;
 
 use crate::byte_packing::byte_packing_stark::BytePackingOp;
@@ -1114,7 +1113,7 @@ mod tests {
     use plonky2::field::goldilocks_field::GoldilocksField as F;
 
     use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
-    use crate::cpu::kernel::interpreter::{run, Interpreter};
+    use crate::cpu::kernel::interpreter::Interpreter;
     use crate::memory::segments::Segment;
     use crate::witness::memory::MemoryAddress;
     use crate::witness::operation::CONTEXT_SCALING_FACTOR;

--- a/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use anyhow::Result;
-use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
 use ethereum_types::{Address, BigEndianHash, H256, U256};
 use hex_literal::hex;
 use keccak_hash::keccak;

--- a/evm_arithmetization/src/cpu/kernel/tests/add11.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/add11.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
 use ethereum_types::{Address, BigEndianHash, H256};
 use hex_literal::hex;
 use keccak_hash::keccak;
@@ -10,7 +9,6 @@ use mpt_trie::partial_trie::{HashedPartialTrie, Node, PartialTrie};
 use plonky2::field::goldilocks_field::GoldilocksField as F;
 
 use crate::cpu::kernel::aggregator::KERNEL;
-use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
 use crate::cpu::kernel::interpreter::Interpreter;
 use crate::generation::mpt::{AccountRlp, LegacyReceiptRlp};
 use crate::generation::TrieInputs;

--- a/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
@@ -1,8 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use anyhow::Result;
 use ethereum_types::{Address, H160, U256};
-use hashbrown::hash_map::rayon::IntoParIter;
 use plonky2::field::goldilocks_field::GoldilocksField as F;
 use rand::{thread_rng, Rng};
 
@@ -12,7 +11,6 @@ use crate::cpu::kernel::constants::global_metadata::GlobalMetadata::{
 };
 use crate::cpu::kernel::interpreter::Interpreter;
 use crate::memory::segments::Segment::{self, AccessedAddresses, AccessedStorageKeys};
-use crate::memory::segments::SEGMENT_SCALING_FACTOR;
 use crate::witness::memory::MemoryAddress;
 
 #[test]

--- a/evm_arithmetization/src/cpu/kernel/tests/core/jumpdest_analysis.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/jumpdest_analysis.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeSet, HashMap};
 
 use anyhow::Result;
 use ethereum_types::U256;
-use itertools::Itertools;
 use plonky2::field::goldilocks_field::GoldilocksField as F;
 
 use crate::cpu::kernel::aggregator::KERNEL;

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -1,6 +1,6 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 
-use anyhow::{anyhow, Error};
+use anyhow::anyhow;
 use ethereum_types::{Address, BigEndianHash, H256, U256};
 use mpt_trie::partial_trie::{HashedPartialTrie, PartialTrie};
 use plonky2::field::extension::Extendable;
@@ -20,14 +20,12 @@ use crate::all_stark::{AllStark, NUM_TABLES};
 use crate::cpu::columns::CpuColumnsView;
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
-use crate::cpu::kernel::interpreter::Interpreter;
 use crate::generation::state::GenerationState;
 use crate::generation::trie_extractor::{get_receipt_trie, get_state_trie, get_txn_trie};
 use crate::memory::segments::Segment;
 use crate::proof::{BlockHashes, BlockMetadata, ExtraBlockData, PublicValues, TrieRoots};
-use crate::util::{h2u, u256_to_u8, u256_to_usize};
-use crate::witness::memory::{MemoryAddress, MemoryChannel, MemoryOp, MemoryOpKind};
-use crate::witness::state::RegistersState;
+use crate::util::{h2u, u256_to_usize};
+use crate::witness::memory::{MemoryAddress, MemoryChannel};
 
 pub mod mpt;
 pub(crate) mod prover_input;
@@ -35,8 +33,8 @@ pub(crate) mod rlp;
 pub(crate) mod state;
 mod trie_extractor;
 
-use self::state::{GenerationStateCheckpoint, State};
-use crate::witness::util::{mem_write_log, stack_peek};
+use self::state::State;
+use crate::witness::util::mem_write_log;
 
 /// Inputs needed for trace generation.
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]

--- a/evm_arithmetization/src/generation/prover_input.rs
+++ b/evm_arithmetization/src/generation/prover_input.rs
@@ -9,7 +9,6 @@ use num_bigint::BigUint;
 use plonky2::field::types::Field;
 use serde::{Deserialize, Serialize};
 
-use super::state::State;
 use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::cpu::kernel::interpreter::simulate_cpu_and_get_user_jumps;

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -5,7 +5,6 @@ use anyhow::bail;
 use ethereum_types::{Address, BigEndianHash, H160, H256, U256};
 use itertools::Itertools;
 use keccak_hash::keccak;
-use log::log_enabled;
 use plonky2::field::types::Field;
 
 use super::mpt::{load_all_mpts, TrieRootPtrs};
@@ -13,7 +12,6 @@ use super::TrieInputs;
 use crate::byte_packing::byte_packing_stark::BytePackingOp;
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
-use crate::cpu::membus::NUM_GP_CHANNELS;
 use crate::cpu::stack::MAX_USER_STACK_SIZE;
 use crate::generation::rlp::all_rlp_prover_inputs_reversed;
 use crate::generation::CpuColumnsView;
@@ -33,9 +31,7 @@ use crate::witness::transition::{
     decode, fill_op_flag, get_op_special_length, log_kernel_instruction, might_overflow_op,
     read_code_memory, Transition,
 };
-use crate::witness::util::{
-    fill_channel_with_value, mem_read_gp_with_log_and_fill, stack_peek, stack_pop_with_log_and_fill,
-};
+use crate::witness::util::{fill_channel_with_value, stack_peek};
 use crate::{arithmetic, keccak, logic};
 
 /// A State is either an `Interpreter` (used for tests and jumpdest analysis) or

--- a/evm_arithmetization/src/memory/segments.rs
+++ b/evm_arithmetization/src/memory/segments.rs
@@ -1,5 +1,3 @@
-use ethereum_types::U256;
-
 pub(crate) const SEGMENT_SCALING_FACTOR: usize = 32;
 
 /// This contains all the existing memory segments. The values in the enum are

--- a/evm_arithmetization/src/util.rs
+++ b/evm_arithmetization/src/util.rs
@@ -5,11 +5,9 @@ use itertools::Itertools;
 use num::BigUint;
 use plonky2::field::extension::Extendable;
 use plonky2::field::packed::PackedField;
-use plonky2::field::polynomial::PolynomialValues;
 use plonky2::field::types::Field;
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::ext_target::ExtensionTarget;
-use plonky2::util::transpose;
 
 use crate::witness::errors::ProgramError;
 

--- a/evm_arithmetization/src/witness/operation.rs
+++ b/evm_arithmetization/src/witness/operation.rs
@@ -3,7 +3,6 @@ use itertools::Itertools;
 use keccak_hash::keccak;
 use plonky2::field::types::Field;
 
-use super::memory::MemorySegmentState;
 use super::transition::Transition;
 use super::util::{
     byte_packing_log, byte_unpacking_log, mem_read_with_log, mem_write_log,
@@ -14,12 +13,9 @@ use crate::cpu::columns::CpuColumnsView;
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::assembler::BYTES_PER_OFFSET;
 use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
-use crate::cpu::membus::NUM_GP_CHANNELS;
 use crate::cpu::simple_logic::eq_iszero::generate_pinv_diff;
 use crate::cpu::stack::MAX_USER_STACK_SIZE;
 use crate::extension_tower::BN_BASE;
-use crate::generation::state::GenerationState;
-use crate::generation::state::State;
 use crate::memory::segments::Segment;
 use crate::util::u256_to_usize;
 use crate::witness::errors::MemoryError::VirtTooLarge;

--- a/evm_arithmetization/src/witness/traces.rs
+++ b/evm_arithmetization/src/witness/traces.rs
@@ -1,6 +1,3 @@
-use core::mem::size_of;
-
-use itertools::Itertools;
 use plonky2::field::extension::Extendable;
 use plonky2::field::polynomial::PolynomialValues;
 use plonky2::hash::hash_types::RichField;
@@ -13,7 +10,6 @@ use crate::all_stark::{AllStark, NUM_TABLES};
 use crate::arithmetic::{BinaryOperator, Operation};
 use crate::byte_packing::byte_packing_stark::BytePackingOp;
 use crate::cpu::columns::CpuColumnsView;
-use crate::keccak_sponge::columns::KECCAK_WIDTH_BYTES;
 use crate::keccak_sponge::keccak_sponge_stark::KeccakSpongeOp;
 use crate::witness::memory::MemoryOp;
 use crate::{arithmetic, keccak, keccak_sponge, logic};

--- a/evm_arithmetization/src/witness/transition.rs
+++ b/evm_arithmetization/src/witness/transition.rs
@@ -1,28 +1,20 @@
-use anyhow::bail;
 use ethereum_types::U256;
 use log::log_enabled;
 use plonky2::field::types::Field;
 
-use super::memory::{MemoryOp, MemoryOpKind, MemorySegmentState};
-use super::util::{
-    fill_channel_with_value, mem_read_gp_with_log_and_fill, push_no_write,
-    stack_pop_with_log_and_fill,
-};
+use super::util::{mem_read_gp_with_log_and_fill, stack_pop_with_log_and_fill};
 use crate::cpu::columns::CpuColumnsView;
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
 use crate::cpu::membus::NUM_GP_CHANNELS;
 use crate::cpu::stack::{
-    EQ_STACK_BEHAVIOR, IS_ZERO_STACK_BEHAVIOR, JUMPI_OP, JUMP_OP, MAX_USER_STACK_SIZE,
-    MIGHT_OVERFLOW, STACK_BEHAVIORS,
+    EQ_STACK_BEHAVIOR, IS_ZERO_STACK_BEHAVIOR, JUMPI_OP, JUMP_OP, MIGHT_OVERFLOW, STACK_BEHAVIORS,
 };
-use crate::extension_tower::BN_BASE;
-use crate::generation::state::{GenerationState, GenerationStateCheckpoint, State};
+use crate::generation::state::{GenerationState, State};
 use crate::memory::segments::Segment;
 use crate::witness::errors::ProgramError;
 use crate::witness::gas::gas_to_charge;
 use crate::witness::memory::MemoryAddress;
-use crate::witness::memory::MemoryChannel::GeneralPurpose;
 use crate::witness::operation::*;
 use crate::witness::state::RegistersState;
 use crate::witness::util::mem_read_code_with_log_and_fill;

--- a/evm_arithmetization/src/witness/util.rs
+++ b/evm_arithmetization/src/witness/util.rs
@@ -1,7 +1,7 @@
 use ethereum_types::U256;
 use plonky2::field::types::Field;
 
-use super::memory::{MemorySegmentState, DUMMY_MEMOP};
+use super::memory::DUMMY_MEMOP;
 use super::transition::Transition;
 use crate::byte_packing::byte_packing_stark::BytePackingOp;
 use crate::cpu::columns::CpuColumnsView;


### PR DESCRIPTION
No concrete code change, just getting rid of a bunch of needless imports.
We still can't get rid of `allow(unused)` for now, there are too many warnings, but this is a first step.