### PR TITLE
suggestion: store max_cpu_len in Interpreter

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/assembler.rs
+++ b/evm_arithmetization/src/cpu/kernel/assembler.rs
@@ -30,7 +30,7 @@ pub struct Kernel {
     /// Computed using `hash_kernel`.
     pub(crate) code_hash: H256,
 
-    pub global_labels: HashMap<String, usize>,
+    pub(crate) global_labels: HashMap<String, usize>,
     pub(crate) ordered_labels: Vec<String>,
 
     /// Map from `PROVER_INPUT` offsets to their corresponding `ProverInputFn`.

--- a/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
@@ -119,7 +119,7 @@ fn prepare_interpreter<F: Field>(
         .push(k.try_into_u256().unwrap())
         .expect("The stack should not overflow"); // key
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(
         interpreter.stack().len(),
         0,
@@ -135,7 +135,7 @@ fn prepare_interpreter<F: Field>(
     interpreter
         .push(1.into()) // Initial length of the trie data segment, unused.
         .expect("The stack should not overflow");
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     assert_eq!(
         interpreter.stack().len(),
@@ -157,7 +157,7 @@ fn test_extcodesize() -> Result<()> {
     let code = random_code();
     let account = test_account(&code);
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![]);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], 0);
     let address: Address = thread_rng().gen();
     // Prepare the interpreter by inserting the account in the state trie.
     prepare_interpreter(&mut interpreter, address, &account)?;
@@ -177,7 +177,7 @@ fn test_extcodesize() -> Result<()> {
         .expect("The stack should not overflow");
     interpreter.generation_state.inputs.contract_code =
         HashMap::from([(keccak(&code), code.clone())]);
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     assert_eq!(interpreter.stack(), vec![code.len().into()]);
 
@@ -189,7 +189,7 @@ fn test_extcodecopy() -> Result<()> {
     let code = random_code();
     let account = test_account(&code);
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![]);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], 0);
     let address: Address = thread_rng().gen();
     // Prepare the interpreter by inserting the account in the state trie.
     prepare_interpreter(&mut interpreter, address, &account)?;
@@ -203,7 +203,7 @@ fn test_extcodecopy() -> Result<()> {
     let init_accessed_addresses = KERNEL.global_labels["init_access_lists"];
     interpreter.generation_state.registers.program_counter = init_accessed_addresses;
     interpreter.push(0xdeadbeefu32.into());
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     let extcodecopy = KERNEL.global_labels["sys_extcodecopy"];
 
@@ -246,7 +246,7 @@ fn test_extcodecopy() -> Result<()> {
         .expect("The stack should not overflow"); // kexit_info
     interpreter.generation_state.inputs.contract_code =
         HashMap::from([(keccak(&code), code.clone())]);
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     assert!(interpreter.stack().is_empty());
     // Check that the code was correctly copied to memory.
@@ -332,18 +332,18 @@ fn sstore() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, 0);
 
     // Pre-initialize the accessed addresses list.
     let init_accessed_addresses = KERNEL.global_labels["init_access_lists"];
     interpreter.generation_state.registers.program_counter = init_accessed_addresses;
     interpreter.push(0xdeadbeefu32.into());
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     // Prepare the interpreter by inserting the account in the state trie.
     prepare_interpreter_all_accounts(&mut interpreter, trie_inputs, addr, &code)?;
 
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     // The first two elements in the stack are `success` and `leftover_gas`,
     // returned by the `sys_stop` opcode.
@@ -373,7 +373,7 @@ fn sstore() -> Result<()> {
     interpreter
         .push(1.into()) // Initial length of the trie data segment, unused.
         .expect("The stack should not overflow");
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     assert_eq!(
         interpreter.stack().len(),
@@ -428,17 +428,17 @@ fn sload() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, 0);
 
     // Pre-initialize the accessed addresses list.
     let init_accessed_addresses = KERNEL.global_labels["init_access_lists"];
     interpreter.generation_state.registers.program_counter = init_accessed_addresses;
     interpreter.push(0xdeadbeefu32.into());
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     // Prepare the interpreter by inserting the account in the state trie.
     prepare_interpreter_all_accounts(&mut interpreter, trie_inputs, addr, &code)?;
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     // The first two elements in the stack are `success` and `leftover_gas`,
     // returned by the `sys_stop` opcode.
@@ -471,7 +471,7 @@ fn sload() -> Result<()> {
     interpreter
         .push(1.into()) // Initial length of the trie data segment, unused.
         .expect("The stack should not overflow.");
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     assert_eq!(
         interpreter.stack().len(),

--- a/evm_arithmetization/src/cpu/kernel/tests/add11.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/add11.rs
@@ -167,14 +167,14 @@ fn test_add11_yml() {
 
     let initial_stack = vec![];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new_with_generation_inputs(0, initial_stack, tries_inputs);
+        Interpreter::new_with_generation_inputs(0, initial_stack, tries_inputs, 0);
 
     let route_txn_label = KERNEL.global_labels["init"];
     // Switch context and initialize memory with the data we need for the tests.
     interpreter.generation_state.registers.program_counter = route_txn_label;
     interpreter.set_context_metadata_field(0, ContextMetadata::GasLimit, 1_000_000.into());
     interpreter.set_is_kernel(true);
-    interpreter.run(None).expect("Proving add11 failed.");
+    interpreter.run().expect("Proving add11 failed.");
 }
 
 #[test]
@@ -311,7 +311,7 @@ fn test_add11_yml_with_exception() {
 
     let initial_stack = vec![];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new_with_generation_inputs(0, initial_stack, tries_inputs);
+        Interpreter::new_with_generation_inputs(0, initial_stack, tries_inputs, 0);
 
     let route_txn_label = KERNEL.global_labels["init"];
     // Switch context and initialize memory with the data we need for the tests.
@@ -319,6 +319,6 @@ fn test_add11_yml_with_exception() {
     interpreter.set_context_metadata_field(0, ContextMetadata::GasLimit, 1_000_000.into());
     interpreter.set_is_kernel(true);
     interpreter
-        .run(None)
+        .run()
         .expect("Proving add11 with exception failed.");
 }

--- a/evm_arithmetization/src/cpu/kernel/tests/balance.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/balance.rs
@@ -70,7 +70,7 @@ fn prepare_interpreter<F: Field>(
         .push(k.try_into_u256().unwrap())
         .expect("The stack should not overflow"); // key
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(
         interpreter.stack().len(),
         0,
@@ -86,7 +86,7 @@ fn prepare_interpreter<F: Field>(
     interpreter
         .push(1.into()) // Initial trie data segment size, unused.
         .expect("The stack should not overflow");
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     assert_eq!(
         interpreter.stack().len(),
@@ -109,7 +109,7 @@ fn test_balance() -> Result<()> {
     let balance = U256(rng.gen());
     let account = test_account(balance);
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![]);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], 0);
     let address: Address = rng.gen();
     // Prepare the interpreter by inserting the account in the state trie.
     prepare_interpreter(&mut interpreter, address, &account)?;
@@ -125,7 +125,7 @@ fn test_balance() -> Result<()> {
     interpreter
         .push(U256::from_big_endian(address.as_bytes()))
         .expect("The stack should not overflow");
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     assert_eq!(interpreter.stack(), vec![balance]);
 

--- a/evm_arithmetization/src/cpu/kernel/tests/bignum/mod.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/bignum/mod.rs
@@ -101,9 +101,9 @@ fn run_test(fn_label: &str, memory: Vec<U256>, stack: Vec<U256>) -> Result<(Vec<
     initial_stack.push(retdest);
     initial_stack.reverse();
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(fn_label, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(fn_label, initial_stack, 0);
     interpreter.set_current_general_memory(memory);
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     let new_memory = interpreter.get_current_general_memory();
 

--- a/evm_arithmetization/src/cpu/kernel/tests/block_hash.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/block_hash.rs
@@ -20,11 +20,11 @@ fn test_correct_block_hash() -> Result<()> {
 
     let hashes: Vec<U256> = vec![U256::from_big_endian(&thread_rng().gen::<H256>().0); 257];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(blockhash_label, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(blockhash_label, initial_stack, 0);
     interpreter.set_memory_segment(Segment::BlockHashes, hashes[0..256].to_vec());
     interpreter.set_global_metadata_field(GlobalMetadata::BlockCurrentHash, hashes[256]);
     interpreter.set_global_metadata_field(GlobalMetadata::BlockNumber, 256.into());
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     let result = interpreter.stack();
     assert_eq!(
@@ -49,11 +49,11 @@ fn test_big_index_block_hash() -> Result<()> {
 
     let hashes: Vec<U256> = vec![U256::from_big_endian(&thread_rng().gen::<H256>().0); 257];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(blockhash_label, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(blockhash_label, initial_stack, 0);
     interpreter.set_memory_segment(Segment::BlockHashes, hashes[0..256].to_vec());
     interpreter.set_global_metadata_field(GlobalMetadata::BlockCurrentHash, hashes[256]);
     interpreter.set_global_metadata_field(GlobalMetadata::BlockNumber, cur_block_number.into());
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     let result = interpreter.stack();
     assert_eq!(
@@ -79,11 +79,11 @@ fn test_small_index_block_hash() -> Result<()> {
 
     let hashes: Vec<U256> = vec![U256::from_big_endian(&thread_rng().gen::<H256>().0); 257];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(blockhash_label, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(blockhash_label, initial_stack, 0);
     interpreter.set_memory_segment(Segment::BlockHashes, hashes[0..256].to_vec());
     interpreter.set_global_metadata_field(GlobalMetadata::BlockCurrentHash, hashes[256]);
     interpreter.set_global_metadata_field(GlobalMetadata::BlockNumber, cur_block_number.into());
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     let result = interpreter.stack();
     assert_eq!(
@@ -107,11 +107,11 @@ fn test_block_hash_with_overflow() -> Result<()> {
 
     let hashes: Vec<U256> = vec![U256::from_big_endian(&thread_rng().gen::<H256>().0); 257];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(blockhash_label, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(blockhash_label, initial_stack, 0);
     interpreter.set_memory_segment(Segment::BlockHashes, hashes[0..256].to_vec());
     interpreter.set_global_metadata_field(GlobalMetadata::BlockCurrentHash, hashes[256]);
     interpreter.set_global_metadata_field(GlobalMetadata::BlockNumber, cur_block_number.into());
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     let result = interpreter.stack();
     assert_eq!(

--- a/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
@@ -21,8 +21,8 @@ fn test_init_access_lists() -> Result<()> {
 
     // Check the initial state of the access list in the kernel.
     let initial_stack = vec![0xdeadbeefu32.into()];
-    let mut interpreter = Interpreter::<F>::new(init_label, initial_stack);
-    interpreter.run(None)?;
+    let mut interpreter = Interpreter::<F>::new(init_label, initial_stack, 0);
+    interpreter.run()?;
 
     assert!(interpreter.stack().is_empty());
 
@@ -66,8 +66,8 @@ fn test_list_iterator() -> Result<()> {
     let init_label = KERNEL.global_labels["init_access_lists"];
 
     let initial_stack = vec![0xdeadbeefu32.into()];
-    let mut interpreter = Interpreter::<F>::new(init_label, initial_stack);
-    interpreter.run(None)?;
+    let mut interpreter = Interpreter::<F>::new(init_label, initial_stack, 0);
+    interpreter.run()?;
 
     // test the list iterator
     let mut list = interpreter
@@ -93,8 +93,8 @@ fn test_insert_address() -> Result<()> {
 
     // Test for address already in list.
     let initial_stack = vec![0xdeadbeefu32.into()];
-    let mut interpreter = Interpreter::<F>::new(init_label, initial_stack);
-    interpreter.run(None)?;
+    let mut interpreter = Interpreter::<F>::new(init_label, initial_stack, 0);
+    interpreter.run()?;
 
     let insert_accessed_addresses = KERNEL.global_labels["insert_accessed_addresses"];
 
@@ -108,7 +108,7 @@ fn test_insert_address() -> Result<()> {
     interpreter.push(U256::from(address.0.as_slice()));
     interpreter.generation_state.registers.program_counter = insert_accessed_addresses;
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(interpreter.stack(), &[U256::one()]);
     assert_eq!(
         interpreter.generation_state.memory.get_with_init(
@@ -126,8 +126,8 @@ fn test_insert_accessed_addresses() -> Result<()> {
 
     // Test for address already in list.
     let initial_stack = vec![0xdeadbeefu32.into()];
-    let mut interpreter = Interpreter::<F>::new(init_access_lists, initial_stack);
-    interpreter.run(None)?;
+    let mut interpreter = Interpreter::<F>::new(init_access_lists, initial_stack, 0);
+    interpreter.run()?;
 
     let insert_accessed_addresses = KERNEL.global_labels["insert_accessed_addresses"];
 
@@ -151,7 +151,7 @@ fn test_insert_accessed_addresses() -> Result<()> {
         interpreter.push(0xdeadbeefu32.into());
         interpreter.push(addr);
         interpreter.generation_state.registers.program_counter = insert_accessed_addresses;
-        interpreter.run(None)?;
+        interpreter.run()?;
         assert_eq!(interpreter.pop().unwrap(), U256::one());
     }
 
@@ -161,7 +161,7 @@ fn test_insert_accessed_addresses() -> Result<()> {
         interpreter.push(retaddr);
         interpreter.push(U256::from(addr_in_list.0.as_slice()));
         interpreter.generation_state.registers.program_counter = insert_accessed_addresses;
-        interpreter.run(None)?;
+        interpreter.run()?;
         assert_eq!(interpreter.pop().unwrap(), U256::zero());
         assert_eq!(
             interpreter.generation_state.memory.get_with_init(
@@ -176,7 +176,7 @@ fn test_insert_accessed_addresses() -> Result<()> {
     interpreter.push(U256::from(addr_not_in_list.0.as_slice()));
     interpreter.generation_state.registers.program_counter = insert_accessed_addresses;
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(interpreter.stack(), &[U256::one()]);
     assert_eq!(
         interpreter.generation_state.memory.get_with_init(
@@ -201,8 +201,8 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
 
     // Test for address already in list.
     let initial_stack = vec![0xdeadbeefu32.into()];
-    let mut interpreter = Interpreter::<F>::new(init_access_lists, initial_stack);
-    interpreter.run(None)?;
+    let mut interpreter = Interpreter::<F>::new(init_access_lists, initial_stack, 0);
+    interpreter.run()?;
 
     let insert_accessed_storage_keys = KERNEL.global_labels["insert_accessed_storage_keys"];
 
@@ -231,7 +231,7 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
         interpreter.push(key);
         interpreter.push(addr);
         interpreter.generation_state.registers.program_counter = insert_accessed_storage_keys;
-        interpreter.run(None)?;
+        interpreter.run()?;
         assert_eq!(interpreter.pop().unwrap(), U256::one());
         assert_eq!(interpreter.pop().unwrap(), value);
     }
@@ -244,7 +244,7 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
         interpreter.push(key);
         interpreter.push(U256::from(addr.0.as_slice()));
         interpreter.generation_state.registers.program_counter = insert_accessed_storage_keys;
-        interpreter.run(None)?;
+        interpreter.run()?;
         assert_eq!(interpreter.pop().unwrap(), U256::zero());
         assert_eq!(interpreter.pop().unwrap(), value);
         assert_eq!(
@@ -262,7 +262,7 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
     interpreter.push(U256::from(storage_key_not_in_list.0 .0.as_slice()));
     interpreter.generation_state.registers.program_counter = insert_accessed_storage_keys;
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(
         interpreter.stack(),
         &[storage_key_not_in_list.2, U256::one()]

--- a/evm_arithmetization/src/cpu/kernel/tests/core/create_addresses.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/create_addresses.rs
@@ -20,8 +20,8 @@ fn test_get_create_address() -> Result<()> {
     let expected_addr = U256::from_big_endian(&hex!("3f09c73a5ed19289fb9bdc72f1742566df146f56"));
 
     let initial_stack = vec![retaddr, nonce, sender];
-    let mut interpreter: Interpreter<F> = Interpreter::new(get_create_address, initial_stack);
-    interpreter.run(None)?;
+    let mut interpreter: Interpreter<F> = Interpreter::new(get_create_address, initial_stack, 0);
+    interpreter.run()?;
 
     assert_eq!(interpreter.stack(), &[expected_addr]);
 
@@ -106,8 +106,9 @@ fn test_get_create2_address() -> Result<()> {
     } in create2_test_cases()
     {
         let initial_stack = vec![retaddr, salt, U256::from(code_hash.0), sender];
-        let mut interpreter: Interpreter<F> = Interpreter::new(get_create2_address, initial_stack);
-        interpreter.run(None)?;
+        let mut interpreter: Interpreter<F> =
+            Interpreter::new(get_create2_address, initial_stack, 0);
+        interpreter.run()?;
 
         assert_eq!(interpreter.stack(), &[expected_addr]);
     }

--- a/evm_arithmetization/src/cpu/kernel/tests/core/intrinsic_gas.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/intrinsic_gas.rs
@@ -16,15 +16,15 @@ fn test_intrinsic_gas() -> Result<()> {
 
     // Contract creation transaction.
     let initial_stack = vec![0xdeadbeefu32.into()];
-    let mut interpreter: Interpreter<F> = Interpreter::new(intrinsic_gas, initial_stack.clone());
+    let mut interpreter: Interpreter<F> = Interpreter::new(intrinsic_gas, initial_stack.clone(), 0);
     interpreter.set_global_metadata_field(GlobalMetadata::ContractCreation, U256::one());
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![(GAS_TX + GAS_TXCREATE).into()]);
 
     // Message transaction.
-    let mut interpreter: Interpreter<F> = Interpreter::new(intrinsic_gas, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(intrinsic_gas, initial_stack, 0);
     interpreter.set_txn_field(NormalizedTxnField::To, 123.into());
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![GAS_TX.into()]);
 
     Ok(())

--- a/evm_arithmetization/src/cpu/kernel/tests/core/jumpdest_analysis.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/jumpdest_analysis.rs
@@ -48,7 +48,7 @@ fn test_jumpdest_analysis() -> Result<()> {
             .chain(std::iter::once(true)),
     );
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(jumpdest_analysis, vec![]);
+    let mut interpreter: Interpreter<F> = Interpreter::new(jumpdest_analysis, vec![], 0);
     let code_len = code.len();
 
     interpreter.set_code(CONTEXT, code);
@@ -89,7 +89,7 @@ fn test_jumpdest_analysis() -> Result<()> {
         .pop();
     interpreter.push(41.into());
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![]);
 
     assert_eq!(jumpdest_bits, interpreter.get_jumpdest_bits(CONTEXT));
@@ -127,11 +127,11 @@ fn test_packed_verification() -> Result<()> {
         U256::one(),
     ];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new(write_table_if_jumpdest, initial_stack.clone());
+        Interpreter::new(write_table_if_jumpdest, initial_stack.clone(), 0);
     interpreter.set_code(CONTEXT, code.clone());
     interpreter.generation_state.jumpdest_table = Some(HashMap::from([(3, vec![1, 33])]));
 
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     assert_eq!(jumpdest_bits, interpreter.get_jumpdest_bits(CONTEXT));
 
@@ -140,11 +140,11 @@ fn test_packed_verification() -> Result<()> {
     for i in 1..=32 {
         code[i] += 1;
         let mut interpreter: Interpreter<F> =
-            Interpreter::new(write_table_if_jumpdest, initial_stack.clone());
+            Interpreter::new(write_table_if_jumpdest, initial_stack.clone(), 0);
         interpreter.set_code(CONTEXT, code.clone());
         interpreter.generation_state.jumpdest_table = Some(HashMap::from([(3, vec![1, 33])]));
 
-        assert!(interpreter.run(None).is_err());
+        assert!(interpreter.run().is_err());
 
         assert!(interpreter.get_jumpdest_bits(CONTEXT).is_empty());
 
@@ -189,7 +189,7 @@ fn test_verify_non_jumpdest() -> Result<()> {
     // jumpdest
     for i in 8..code_len - 1 {
         code[i] += 1;
-        let mut interpreter: Interpreter<F> = Interpreter::new(verify_non_jumpdest, vec![]);
+        let mut interpreter: Interpreter<F> = Interpreter::new(verify_non_jumpdest, vec![], 0);
         interpreter.generation_state.registers.context = CONTEXT;
 
         interpreter.set_code(CONTEXT, code.clone());
@@ -204,7 +204,7 @@ fn test_verify_non_jumpdest() -> Result<()> {
             interpreter.generation_state.registers.program_counter = verify_non_jumpdest;
             interpreter.push(0xDEADBEEFu32.into());
             interpreter.push(j.into());
-            interpreter.run(None)?;
+            interpreter.run()?;
             assert!(interpreter.stack().is_empty());
             assert_eq!(interpreter.get_jumpdest_bit(j), U256::zero());
         }

--- a/evm_arithmetization/src/cpu/kernel/tests/ecc/curve_ops.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/ecc/curve_ops.rs
@@ -185,8 +185,8 @@ mod bn {
 
             let mut initial_stack = u256ify(["0xdeadbeef"])?;
             initial_stack.push(k);
-            let mut int: Interpreter<F> = Interpreter::new(glv, initial_stack);
-            int.run(None)?;
+            let mut int: Interpreter<F> = Interpreter::new(glv, initial_stack, 0);
+            int.run()?;
 
             assert_eq!(line, int.stack());
         }
@@ -203,8 +203,8 @@ mod bn {
             "0x10d7cf0621b6e42c1dbb421f5ef5e1936ca6a87b38198d1935be31e28821d171",
             "0x11b7d55f16aaac07de9a0ed8ac2e8023570dbaa78571fc95e553c4b3ba627689",
         ])?;
-        let mut int: Interpreter<F> = Interpreter::new(precompute, initial_stack);
-        int.run(None)?;
+        let mut int: Interpreter<F> = Interpreter::new(precompute, initial_stack, 0);
+        int.run()?;
 
         let mut computed_table = Vec::new();
         for i in 0..32 {
@@ -354,8 +354,8 @@ mod secp {
 
             let mut initial_stack = u256ify(["0xdeadbeef"])?;
             initial_stack.push(k);
-            let mut int: Interpreter<F> = Interpreter::new(glv, initial_stack);
-            int.run(None)?;
+            let mut int: Interpreter<F> = Interpreter::new(glv, initial_stack, 0);
+            int.run()?;
 
             assert_eq!(line, int.stack());
         }

--- a/evm_arithmetization/src/cpu/kernel/tests/exp.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/exp.rs
@@ -16,7 +16,7 @@ fn test_exp() -> Result<()> {
 
     // Random input
     let initial_stack = vec![0xDEADBEEFu32.into(), b, a];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack.clone());
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack.clone(), 0);
 
     let stack_with_kernel = run_interpreter::<F>(exp, initial_stack)?.stack();
 

--- a/evm_arithmetization/src/cpu/kernel/tests/log.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/log.rs
@@ -26,11 +26,11 @@ fn test_log_0() -> Result<()> {
         U256::from_big_endian(&address.to_fixed_bytes()),
     ];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack, 0);
     interpreter.set_global_metadata_field(GlobalMetadata::LogsLen, 0.into());
     interpreter.set_global_metadata_field(GlobalMetadata::LogsDataLen, 0.into());
 
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     // The address is encoded in 1+20 bytes. There are no topics or data, so each is
     // encoded in 1 byte. This leads to a payload of 23.
@@ -70,13 +70,13 @@ fn test_log_2() -> Result<()> {
         U256::from_big_endian(&address.to_fixed_bytes()),
     ];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack, 0);
     interpreter.set_global_metadata_field(GlobalMetadata::LogsLen, 2.into());
     interpreter.set_global_metadata_field(GlobalMetadata::LogsDataLen, 5.into());
 
     interpreter.set_memory_segment(Segment::MainMemory, memory);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(
         interpreter.get_memory_segment(Segment::Logs),
         [0.into(), 0.into(), 5.into(),]
@@ -134,13 +134,13 @@ fn test_log_4() -> Result<()> {
         U256::from_big_endian(&address.to_fixed_bytes()),
     ];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack, 0);
     interpreter.set_global_metadata_field(GlobalMetadata::LogsLen, 2.into());
     interpreter.set_global_metadata_field(GlobalMetadata::LogsDataLen, 5.into());
 
     interpreter.set_memory_segment(Segment::MainMemory, memory);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(
         interpreter.get_memory_segment(Segment::Logs),
         [0.into(), 0.into(), 5.into(),]
@@ -197,10 +197,10 @@ fn test_log_5() -> Result<()> {
         U256::from_big_endian(&address.to_fixed_bytes()),
     ];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack, 0);
     interpreter.set_global_metadata_field(GlobalMetadata::LogsLen, 0.into());
     interpreter.set_global_metadata_field(GlobalMetadata::LogsDataLen, 0.into());
 
-    assert!(interpreter.run(None).is_err());
+    assert!(interpreter.run().is_err());
     Ok(())
 }

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/delete.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/delete.rs
@@ -100,7 +100,7 @@ fn test_state_trie(
     let mpt_hash_state_trie = KERNEL.global_labels["mpt_hash_state_trie"];
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, 0);
 
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
@@ -132,7 +132,7 @@ fn test_state_trie(
     interpreter
         .push(k.try_into_u256().unwrap())
         .expect("The stack should not overflow"); // key
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(
         interpreter.stack().len(),
         0,
@@ -155,7 +155,7 @@ fn test_state_trie(
     interpreter
         .push(state_trie_ptr)
         .expect("The stack should not overflow");
-    interpreter.run(None)?;
+    interpreter.run()?;
     let state_trie_ptr = interpreter.pop().expect("The stack should not be empty");
     interpreter.set_global_metadata_field(GlobalMetadata::StateTrieRoot, state_trie_ptr);
 
@@ -167,7 +167,7 @@ fn test_state_trie(
     interpreter
         .push(1.into()) // Initial length of the trie data segment, unused.
         .expect("The stack should not overflow");
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     let state_trie_hash =
         H256::from_uint(&interpreter.pop().expect("The stack should not be empty"));

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/hash.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/hash.rs
@@ -112,7 +112,7 @@ fn test_state_trie(trie_inputs: TrieInputs) -> Result<()> {
     let mpt_hash_state_trie = KERNEL.global_labels["mpt_hash_state_trie"];
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, 0);
 
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
@@ -125,7 +125,7 @@ fn test_state_trie(trie_inputs: TrieInputs) -> Result<()> {
     interpreter
         .push(1.into()) // Initial length of the trie data segment, unused.
         .expect("The stack should not overflow");
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     assert_eq!(
         interpreter.stack().len(),

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/hex_prefix.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/hex_prefix.rs
@@ -16,8 +16,8 @@ fn hex_prefix_even_nonterminated() -> Result<()> {
     let num_nibbles = 6.into();
     let rlp_pos = U256::from(Segment::RlpRaw as usize);
     let initial_stack = vec![retdest, terminated, packed_nibbles, num_nibbles, rlp_pos];
-    let mut interpreter: Interpreter<F> = Interpreter::new(hex_prefix, initial_stack);
-    interpreter.run(None)?;
+    let mut interpreter: Interpreter<F> = Interpreter::new(hex_prefix, initial_stack, 0);
+    interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![rlp_pos + U256::from(5)]);
 
     assert_eq!(
@@ -44,8 +44,8 @@ fn hex_prefix_odd_terminated() -> Result<()> {
     let num_nibbles = 5.into();
     let rlp_pos = U256::from(Segment::RlpRaw as usize);
     let initial_stack = vec![retdest, terminated, packed_nibbles, num_nibbles, rlp_pos];
-    let mut interpreter: Interpreter<F> = Interpreter::new(hex_prefix, initial_stack);
-    interpreter.run(None)?;
+    let mut interpreter: Interpreter<F> = Interpreter::new(hex_prefix, initial_stack, 0);
+    interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![rlp_pos + U256::from(4)]);
 
     assert_eq!(
@@ -71,8 +71,8 @@ fn hex_prefix_odd_terminated_tiny() -> Result<()> {
     let num_nibbles = 1.into();
     let rlp_pos = U256::from(Segment::RlpRaw as usize + 2);
     let initial_stack = vec![retdest, terminated, packed_nibbles, num_nibbles, rlp_pos];
-    let mut interpreter: Interpreter<F> = Interpreter::new(hex_prefix, initial_stack);
-    interpreter.run(None)?;
+    let mut interpreter: Interpreter<F> = Interpreter::new(hex_prefix, initial_stack, 0);
+    interpreter.run()?;
     assert_eq!(
         interpreter.stack(),
         vec![U256::from(Segment::RlpRaw as usize + 3)]

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/insert.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/insert.rs
@@ -175,7 +175,7 @@ fn test_state_trie(
     let mpt_hash_state_trie = KERNEL.global_labels["mpt_hash_state_trie"];
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, 0);
 
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
@@ -208,7 +208,7 @@ fn test_state_trie(
         .push(k.try_into_u256().unwrap())
         .expect("The stack should not overflow"); // key
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(
         interpreter.stack().len(),
         0,
@@ -224,7 +224,7 @@ fn test_state_trie(
     interpreter
         .push(1.into()) // Initial length of the trie data segment, unused.
         .expect("The stack should not overflow");
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     assert_eq!(
         interpreter.stack().len(),

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/load.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/load.rs
@@ -25,7 +25,7 @@ fn load_all_mpts_empty() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, 0);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
@@ -62,7 +62,7 @@ fn load_all_mpts_leaf() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, 0);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
@@ -108,7 +108,7 @@ fn load_all_mpts_hash() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, 0);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
@@ -146,7 +146,7 @@ fn load_all_mpts_empty_branch() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, 0);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
@@ -198,7 +198,7 @@ fn load_all_mpts_ext_to_leaf() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, 0);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
@@ -244,7 +244,7 @@ fn load_mpt_txn_trie() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, 0);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/read.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/read.rs
@@ -21,7 +21,7 @@ fn mpt_read() -> Result<()> {
     let mpt_read = KERNEL.global_labels["mpt_read"];
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, 0);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
@@ -39,7 +39,7 @@ fn mpt_read() -> Result<()> {
     interpreter
         .push(interpreter.get_global_metadata_field(GlobalMetadata::StateTrieRoot))
         .expect("The stack should not overflow");
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     assert_eq!(interpreter.stack().len(), 1);
     let result_ptr = interpreter.stack()[0].as_usize();

--- a/evm_arithmetization/src/cpu/kernel/tests/packing.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/packing.rs
@@ -16,9 +16,9 @@ fn test_mstore_unpacking() -> Result<()> {
     let addr = (Segment::TxnData as u64).into();
     let initial_stack = vec![retdest, len, value, addr];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(mstore_unpacking, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(mstore_unpacking, initial_stack, 0);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![addr + U256::from(4)]);
     assert_eq!(
         &interpreter.get_txn_data(),

--- a/evm_arithmetization/src/cpu/kernel/tests/receipt.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/receipt.rs
@@ -48,7 +48,7 @@ fn test_process_receipt() -> Result<()> {
         leftover_gas,
         success,
     ];
-    let mut interpreter: Interpreter<F> = Interpreter::new(process_receipt, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(process_receipt, initial_stack, 0);
     interpreter.set_memory_segment(
         Segment::LogsData,
         vec![
@@ -65,7 +65,7 @@ fn test_process_receipt() -> Result<()> {
     interpreter.set_global_metadata_field(GlobalMetadata::LogsPayloadLen, 58.into());
     interpreter.set_global_metadata_field(GlobalMetadata::LogsLen, U256::from(1));
     interpreter.set_global_metadata_field(GlobalMetadata::ReceiptTrieRoot, 500.into());
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     let segment_read = interpreter.get_memory_segment(Segment::TrieData);
 
@@ -130,7 +130,7 @@ fn test_receipt_encoding() -> Result<()> {
     let expected_rlp = rlp::encode(&rlp::encode(&receipt_1));
 
     let initial_stack: Vec<U256> = vec![retdest, 0.into(), 0.into(), 0.into()];
-    let mut interpreter: Interpreter<F> = Interpreter::new(encode_receipt, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(encode_receipt, initial_stack, 0);
 
     // Write data to memory.
     let expected_bloom_bytes = vec![
@@ -195,7 +195,7 @@ fn test_receipt_encoding() -> Result<()> {
     interpreter.set_global_metadata_field(GlobalMetadata::LogsPayloadLen, 157.into());
     interpreter.set_memory_segment(Segment::TrieData, receipt);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     let rlp_pos = interpreter.pop().expect("The stack should not be empty");
 
     let rlp_read: &[u8] = &interpreter.get_rlp_memory()[1..]; // skip empty_node
@@ -250,7 +250,7 @@ fn test_receipt_bloom_filter() -> Result<()> {
     // Set logs memory and initialize TxnBloom and BlockBloom segments.
     let initial_stack: Vec<U256> = vec![retdest];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(logs_bloom, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(logs_bloom, initial_stack, 0);
     let mut logs = vec![
         0.into(), // unused
         addr,
@@ -272,7 +272,7 @@ fn test_receipt_bloom_filter() -> Result<()> {
     interpreter.set_memory_segment(Segment::LogsData, logs);
     interpreter.set_memory_segment(Segment::Logs, vec![0.into()]);
     interpreter.set_global_metadata_field(GlobalMetadata::LogsLen, U256::from(1));
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     // Second transaction.
     let loaded_bloom_u256 = interpreter.get_memory_segment(Segment::TxnBloom);
@@ -307,7 +307,7 @@ fn test_receipt_bloom_filter() -> Result<()> {
     interpreter.set_memory_segment(Segment::LogsData, logs2);
     interpreter.set_memory_segment(Segment::Logs, vec![0.into()]);
     interpreter.set_global_metadata_field(GlobalMetadata::LogsLen, U256::from(1));
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     let second_bloom_bytes = vec![
         00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00,
@@ -412,7 +412,7 @@ fn test_mpt_insert_receipt() -> Result<()> {
     receipt.push(num_logs.into()); // num_logs
     receipt.extend(logs_0.clone());
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![]);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], 0);
     initialize_mpts(&mut interpreter, &trie_inputs);
 
     // If TrieData is empty, we need to push 0 because the first value is always 0.
@@ -442,7 +442,7 @@ fn test_mpt_insert_receipt() -> Result<()> {
     interpreter.set_memory_segment(Segment::TrieData, cur_trie_data.clone());
     interpreter.set_global_metadata_field(GlobalMetadata::TrieDataSize, cur_trie_data.len().into());
     // First insertion.
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     // receipt_1:
     let status_1 = 1;
@@ -513,7 +513,7 @@ fn test_mpt_insert_receipt() -> Result<()> {
     interpreter.set_memory_segment(Segment::TrieData, cur_trie_data.clone());
     let trie_data_len = cur_trie_data.len().into();
     interpreter.set_global_metadata_field(GlobalMetadata::TrieDataSize, trie_data_len);
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     // Finally, check that the hashes correspond.
     let mpt_hash_receipt = KERNEL.global_labels["mpt_hash_receipt_trie"];
@@ -525,7 +525,7 @@ fn test_mpt_insert_receipt() -> Result<()> {
         .push(1.into()) // Initial length of the trie data segment, unused.; // Initial length of the trie data
         // segment, unused.
         .expect("The stack should not overflow");
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(
         interpreter.stack()[1],
         U256::from(hex!(
@@ -568,12 +568,12 @@ fn test_bloom_two_logs() -> Result<()> {
         ]
         .into(),
     ];
-    let mut interpreter: Interpreter<F> = Interpreter::new(logs_bloom, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(logs_bloom, initial_stack, 0);
     interpreter.set_memory_segment(Segment::TxnBloom, vec![0.into(); 256]); // Initialize transaction Bloom filter.
     interpreter.set_memory_segment(Segment::LogsData, logs);
     interpreter.set_memory_segment(Segment::Logs, vec![0.into(), 4.into()]);
     interpreter.set_global_metadata_field(GlobalMetadata::LogsLen, U256::from(2));
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     let loaded_bloom_bytes: Vec<u8> = interpreter
         .get_memory_segment(Segment::TxnBloom)

--- a/evm_arithmetization/src/cpu/kernel/tests/rlp/decode.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/rlp/decode.rs
@@ -14,12 +14,12 @@ fn test_decode_rlp_string_len_short() -> Result<()> {
         0xDEADBEEFu32.into(),
         U256::from(Segment::RlpRaw as usize + 2),
     ];
-    let mut interpreter: Interpreter<F> = Interpreter::new(decode_rlp_string_len, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(decode_rlp_string_len, initial_stack, 0);
 
     // A couple dummy bytes, followed by "0x70" which is its own encoding.
     interpreter.set_rlp_memory(vec![123, 234, 0x70]);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     let expected_stack = vec![1.into(), U256::from(Segment::RlpRaw as usize + 2)]; // len, pos
     assert_eq!(interpreter.stack(), expected_stack);
 
@@ -34,12 +34,12 @@ fn test_decode_rlp_string_len_medium() -> Result<()> {
         0xDEADBEEFu32.into(),
         U256::from(Segment::RlpRaw as usize + 2),
     ];
-    let mut interpreter: Interpreter<F> = Interpreter::new(decode_rlp_string_len, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(decode_rlp_string_len, initial_stack, 0);
 
     // A couple dummy bytes, followed by the RLP encoding of "1 2 3 4 5".
     interpreter.set_rlp_memory(vec![123, 234, 0x85, 1, 2, 3, 4, 5]);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     let expected_stack = vec![5.into(), U256::from(Segment::RlpRaw as usize + 3)]; // len, pos
     assert_eq!(interpreter.stack(), expected_stack);
 
@@ -54,7 +54,7 @@ fn test_decode_rlp_string_len_long() -> Result<()> {
         0xDEADBEEFu32.into(),
         U256::from(Segment::RlpRaw as usize + 2),
     ];
-    let mut interpreter: Interpreter<F> = Interpreter::new(decode_rlp_string_len, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(decode_rlp_string_len, initial_stack, 0);
 
     // The RLP encoding of the string "1 2 3 ... 56".
     interpreter.set_rlp_memory(vec![
@@ -63,7 +63,7 @@ fn test_decode_rlp_string_len_long() -> Result<()> {
         44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
     ]);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     let expected_stack = vec![56.into(), U256::from(Segment::RlpRaw as usize + 4)]; // len, pos
     assert_eq!(interpreter.stack(), expected_stack);
 
@@ -75,12 +75,12 @@ fn test_decode_rlp_list_len_short() -> Result<()> {
     let decode_rlp_list_len = KERNEL.global_labels["decode_rlp_list_len"];
 
     let initial_stack = vec![0xDEADBEEFu32.into(), U256::from(Segment::RlpRaw as usize)];
-    let mut interpreter: Interpreter<F> = Interpreter::new(decode_rlp_list_len, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(decode_rlp_list_len, initial_stack, 0);
 
     // The RLP encoding of [1, 2, [3, 4]].
     interpreter.set_rlp_memory(vec![0xc5, 1, 2, 0xc2, 3, 4]);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     let expected_stack = vec![5.into(), U256::from(Segment::RlpRaw as usize + 1)]; // len, pos
     assert_eq!(interpreter.stack(), expected_stack);
 
@@ -92,7 +92,7 @@ fn test_decode_rlp_list_len_long() -> Result<()> {
     let decode_rlp_list_len = KERNEL.global_labels["decode_rlp_list_len"];
 
     let initial_stack = vec![0xDEADBEEFu32.into(), U256::from(Segment::RlpRaw as usize)];
-    let mut interpreter: Interpreter<F> = Interpreter::new(decode_rlp_list_len, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(decode_rlp_list_len, initial_stack, 0);
 
     // The RLP encoding of [1, ..., 56].
     interpreter.set_rlp_memory(vec![
@@ -101,7 +101,7 @@ fn test_decode_rlp_list_len_long() -> Result<()> {
         46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
     ]);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     let expected_stack = vec![56.into(), U256::from(Segment::RlpRaw as usize + 2)]; // len, pos
     assert_eq!(interpreter.stack(), expected_stack);
 
@@ -113,12 +113,12 @@ fn test_decode_rlp_scalar() -> Result<()> {
     let decode_rlp_scalar = KERNEL.global_labels["decode_rlp_scalar"];
 
     let initial_stack = vec![0xDEADBEEFu32.into(), U256::from(Segment::RlpRaw as usize)];
-    let mut interpreter: Interpreter<F> = Interpreter::new(decode_rlp_scalar, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(decode_rlp_scalar, initial_stack, 0);
 
     // The RLP encoding of "12 34 56".
     interpreter.set_rlp_memory(vec![0x83, 0x12, 0x34, 0x56]);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     let expected_stack = vec![0x123456.into(), U256::from(Segment::RlpRaw as usize + 4)]; // scalar, pos
     assert_eq!(interpreter.stack(), expected_stack);
 

--- a/evm_arithmetization/src/cpu/kernel/tests/rlp/encode.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/rlp/encode.rs
@@ -14,9 +14,9 @@ fn test_encode_rlp_scalar_small() -> Result<()> {
     let scalar = 42.into();
     let pos = U256::from(Segment::RlpRaw as usize + 2);
     let initial_stack = vec![retdest, scalar, pos];
-    let mut interpreter: Interpreter<F> = Interpreter::new(encode_rlp_scalar, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(encode_rlp_scalar, initial_stack, 0);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     let expected_stack = vec![pos + U256::from(1)]; // pos' = pos + rlp_len = 2 + 1
 
     // The two first values of the RLP segment are the hardcoded 0x80 for an empty
@@ -37,9 +37,9 @@ fn test_encode_rlp_scalar_medium() -> Result<()> {
     let scalar = 0x12345.into();
     let pos = U256::from(Segment::RlpRaw as usize + 2);
     let initial_stack = vec![retdest, scalar, pos];
-    let mut interpreter: Interpreter<F> = Interpreter::new(encode_rlp_scalar, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(encode_rlp_scalar, initial_stack, 0);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     let expected_stack = vec![pos + U256::from(4)]; // pos' = pos + rlp_len = 2 + 4
 
     // The two first values of the RLP segment are the hardcoded 0x80 for an empty
@@ -60,9 +60,9 @@ fn test_encode_rlp_160() -> Result<()> {
     let string = 0x12345.into();
     let pos = U256::from(Segment::RlpRaw as usize);
     let initial_stack = vec![retdest, string, pos, U256::from(20)];
-    let mut interpreter: Interpreter<F> = Interpreter::new(encode_rlp_fixed, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(encode_rlp_fixed, initial_stack, 0);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     let expected_stack = vec![pos + U256::from(1 + 20)]; // pos'
     #[rustfmt::skip]
     let expected_rlp = vec![0x80 + 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01, 0x23, 0x45];
@@ -80,9 +80,9 @@ fn test_encode_rlp_256() -> Result<()> {
     let string = 0x12345.into();
     let pos = U256::from(Segment::RlpRaw as usize);
     let initial_stack = vec![retdest, string, pos, U256::from(32)];
-    let mut interpreter: Interpreter<F> = Interpreter::new(encode_rlp_fixed, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(encode_rlp_fixed, initial_stack, 0);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     let expected_stack = vec![pos + U256::from(1 + 32)]; // pos'
     #[rustfmt::skip]
     let expected_rlp = vec![0x80 + 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01, 0x23, 0x45];
@@ -100,7 +100,8 @@ fn test_prepend_rlp_list_prefix_small() -> Result<()> {
     let start_pos = U256::from(Segment::RlpRaw as usize + 9);
     let end_pos = U256::from(Segment::RlpRaw as usize + 9 + 5);
     let initial_stack = vec![retdest, start_pos, end_pos];
-    let mut interpreter: Interpreter<F> = Interpreter::new(prepend_rlp_list_prefix, initial_stack);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(prepend_rlp_list_prefix, initial_stack, 0);
     interpreter.set_rlp_memory(vec![
         // Nine 0s to leave room for the longest possible RLP list prefix.
         0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -108,7 +109,7 @@ fn test_prepend_rlp_list_prefix_small() -> Result<()> {
         1, 2, 3, 4, 5,
     ]);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     let expected_rlp_len = 6.into();
     let expected_start_pos = U256::from(Segment::RlpRaw as usize + 8);
@@ -129,7 +130,8 @@ fn test_prepend_rlp_list_prefix_large() -> Result<()> {
     let start_pos = U256::from(Segment::RlpRaw as usize + 9);
     let end_pos = U256::from(Segment::RlpRaw as usize + 9 + 60);
     let initial_stack = vec![retdest, start_pos, end_pos];
-    let mut interpreter: Interpreter<F> = Interpreter::new(prepend_rlp_list_prefix, initial_stack);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(prepend_rlp_list_prefix, initial_stack, 0);
 
     #[rustfmt::skip]
     interpreter.set_rlp_memory(vec![
@@ -144,7 +146,7 @@ fn test_prepend_rlp_list_prefix_large() -> Result<()> {
         50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
     ]);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     let expected_rlp_len = 62.into();
     let expected_start_pos = U256::from(Segment::RlpRaw as usize + 7);

--- a/evm_arithmetization/src/cpu/kernel/tests/rlp/num_bytes.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/rlp/num_bytes.rs
@@ -11,9 +11,9 @@ fn test_num_bytes_0() -> Result<()> {
     let retdest = 0xDEADBEEFu32.into();
     let x = 0.into();
     let initial_stack = vec![retdest, x];
-    let mut interpreter: Interpreter<F> = Interpreter::new(num_bytes, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(num_bytes, initial_stack, 0);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![1.into()]);
     Ok(())
 }
@@ -25,9 +25,9 @@ fn test_num_bytes_small() -> Result<()> {
     let retdest = 0xDEADBEEFu32.into();
     let x = 42.into();
     let initial_stack = vec![retdest, x];
-    let mut interpreter: Interpreter<F> = Interpreter::new(num_bytes, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(num_bytes, initial_stack, 0);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![1.into()]);
     Ok(())
 }
@@ -39,9 +39,9 @@ fn test_num_bytes_medium() -> Result<()> {
     let retdest = 0xDEADBEEFu32.into();
     let x = 0xAABBCCDDu32.into();
     let initial_stack = vec![retdest, x];
-    let mut interpreter: Interpreter<F> = Interpreter::new(num_bytes, initial_stack);
+    let mut interpreter: Interpreter<F> = Interpreter::new(num_bytes, initial_stack, 0);
 
-    interpreter.run(None)?;
+    interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![4.into()]);
     Ok(())
 }

--- a/evm_arithmetization/src/cpu/kernel/tests/signed_syscalls.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/signed_syscalls.rs
@@ -118,8 +118,8 @@ fn run_test(fn_label: &str, expected_fn: fn(U256, U256) -> U256, opname: &str) {
     for &x in &inputs {
         for &y in &inputs {
             let stack = vec![retdest, y, x];
-            let mut interpreter: Interpreter<F> = Interpreter::new(fn_label, stack);
-            interpreter.run(None).unwrap();
+            let mut interpreter: Interpreter<F> = Interpreter::new(fn_label, stack, 0);
+            interpreter.run().unwrap();
             assert_eq!(interpreter.stack_len(), 1usize, "unexpected stack size");
             let output = interpreter
                 .stack_top()

--- a/evm_arithmetization/src/cpu/kernel/tests/transaction_parsing/parse_type_0_txn.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/transaction_parsing/parse_type_0_txn.rs
@@ -15,7 +15,7 @@ fn process_type_0_txn() -> Result<()> {
     let process_normalized_txn = KERNEL.global_labels["process_normalized_txn"];
 
     let retaddr = 0xDEADBEEFu32.into();
-    let mut interpreter: Interpreter<F> = Interpreter::new(process_type_0_txn, vec![retaddr]);
+    let mut interpreter: Interpreter<F> = Interpreter::new(process_type_0_txn, vec![retaddr], 0);
 
     // When we reach process_normalized_txn, we're done with parsing and
     // normalizing. Processing normalized transactions is outside the scope of
@@ -40,7 +40,7 @@ fn process_type_0_txn() -> Result<()> {
     // rlp.encode(signed_txn).hex()
     interpreter.extend_memory_segment_bytes(Segment::RlpRaw, hex!("f861050a8255f0940000000000000000000000000000000000000000648242421ca07c5c61ed975ebd286f6b027b8c504842e50a47d318e1e801719dd744fe93e6c6a01e7b5119b57dd54e175ff2f055c91f3ab1b53eba0b2c184f347cdff0e745aca2").to_vec());
 
-    interpreter.run(None)?;
+    interpreter.run()?;
 
     assert_eq!(interpreter.get_txn_field(ChainIdPresent), 0.into());
     assert_eq!(interpreter.get_txn_field(ChainId), 0.into());


### PR DESCRIPTION
As a followup to an earlier comment, I tried removing the argument to `run()` and instead store the `max_cpu_len` inside the `Interpreter`. Seems to work alright?
