### PR TITLE
Shave off a clone

### DIFF
--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -63,9 +63,11 @@ where
     C: GenericConfig<D, F = F>,
 {
     timed!(timing, "build kernel", Lazy::force(&KERNEL));
+    let inputs2 = inputs.clone();
+    let inputs3 = inputs.clone();
     let (registers_before, registers_after, mut memory_before) =
-        generate_segment::<F>(max_cpu_len, segment_index, &inputs)?;
-    let mut state = GenerationState::<F>::new(inputs.clone(), &KERNEL.code)
+        generate_segment::<F>(max_cpu_len, segment_index, inputs)?;
+    let mut state = GenerationState::<F>::new(inputs2, &KERNEL.code)
         .map_err(|err| anyhow!("Failed to parse all the initial prover inputs: {:?}", err))?;
     state.registers = RegistersState {
         program_counter: state.registers.program_counter,
@@ -132,7 +134,7 @@ where
     let (traces, mut public_values, final_values) = timed!(
         timing,
         "generate all traces",
-        generate_traces(all_stark, inputs.clone(), config, segment_data, timing)?
+        generate_traces(all_stark, inputs3, config, segment_data, timing)?
     );
 
     check_abort_signal(abort_signal.clone())?;


### PR DESCRIPTION
Suggestion. Reading through generate_segment I noticed that we can save one clone of `inputs` and clean up the code a bit.
