### PR TITLE
Fix trie output when debugging final root mismatch

### DIFF
--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -216,51 +216,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
 
     let cpu_res = timed!(timing, "simulate CPU", simulate_cpu(&mut state));
     if cpu_res.is_err() {
-        // Retrieve previous PC (before jumping to KernelPanic), to see if we reached
-        // `hash_final_tries`. We will output debugging information on the final
-        // tries only if we got a root mismatch.
-        let previous_pc = state
-            .traces
-            .cpu
-            .last()
-            .expect("We should have CPU rows")
-            .program_counter
-            .to_canonical_u64() as usize;
-
-        if KERNEL.offset_name(previous_pc).contains("hash_final_tries") {
-            let state_trie_ptr = u256_to_usize(
-                state
-                    .memory
-                    .read_global_metadata(GlobalMetadata::StateTrieRoot),
-            )
-            .map_err(|_| anyhow!("State trie pointer is too large to fit in a usize."))?;
-            log::debug!(
-                "Computed state trie: {:?}",
-                get_state_trie::<HashedPartialTrie>(&state.memory, state_trie_ptr)
-            );
-
-            let txn_trie_ptr = u256_to_usize(
-                state
-                    .memory
-                    .read_global_metadata(GlobalMetadata::TransactionTrieRoot),
-            )
-            .map_err(|_| anyhow!("Transactions trie pointer is too large to fit in a usize."))?;
-            log::debug!(
-                "Computed transactions trie: {:?}",
-                get_txn_trie::<HashedPartialTrie>(&state.memory, txn_trie_ptr)
-            );
-
-            let receipt_trie_ptr = u256_to_usize(
-                state
-                    .memory
-                    .read_global_metadata(GlobalMetadata::ReceiptTrieRoot),
-            )
-            .map_err(|_| anyhow!("Receipts trie pointer is too large to fit in a usize."))?;
-            log::debug!(
-                "Computed receipts trie: {:?}",
-                get_receipt_trie::<HashedPartialTrie>(&state.memory, receipt_trie_ptr)
-            );
-        }
+        output_debug_tries(&state);
 
         cpu_res?;
     }
@@ -332,6 +288,50 @@ fn simulate_cpu<F: Field>(state: &mut GenerationState<F>) -> anyhow::Result<()> 
     }
 
     log::info!("CPU trace padded to {} cycles", state.traces.clock());
+
+    Ok(())
+}
+
+pub(crate) fn output_debug_tries<F: RichField>(state: &GenerationState<F>) -> anyhow::Result<()> {
+    // Retrieve previous PC (before jumping to KernelPanic), to see if we reached
+    // `hash_final_tries`. We will output debugging information on the final
+    // tries only if we got a root mismatch.
+    let previous_pc = state.get_registers().program_counter;
+
+    if KERNEL.offset_name(previous_pc).contains("hash_final_tries") {
+        let state_trie_ptr = u256_to_usize(
+            state
+                .memory
+                .read_global_metadata(GlobalMetadata::StateTrieRoot),
+        )
+        .map_err(|_| anyhow!("State trie pointer is too large to fit in a usize."))?;
+        log::debug!(
+            "Computed state trie: {:?}",
+            get_state_trie::<HashedPartialTrie>(&state.memory, state_trie_ptr)
+        );
+
+        let txn_trie_ptr = u256_to_usize(
+            state
+                .memory
+                .read_global_metadata(GlobalMetadata::TransactionTrieRoot),
+        )
+        .map_err(|_| anyhow!("Transactions trie pointer is too large to fit in a usize."))?;
+        log::debug!(
+            "Computed transactions trie: {:?}",
+            get_txn_trie::<HashedPartialTrie>(&state.memory, txn_trie_ptr)
+        );
+
+        let receipt_trie_ptr = u256_to_usize(
+            state
+                .memory
+                .read_global_metadata(GlobalMetadata::ReceiptTrieRoot),
+        )
+        .map_err(|_| anyhow!("Receipts trie pointer is too large to fit in a usize."))?;
+        log::debug!(
+            "Computed receipts trie: {:?}",
+            get_receipt_trie::<HashedPartialTrie>(&state.memory, receipt_trie_ptr)
+        );
+    }
 
     Ok(())
 }

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -175,8 +175,6 @@ pub(crate) trait State<F: Field> {
 
             self.transition()?;
         }
-
-        Ok(())
     }
 
     fn handle_error(&mut self, err: ProgramError) -> anyhow::Result<()>

--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -368,7 +368,10 @@ pub fn check_abort_signal(abort_signal: Option<Arc<AtomicBool>>) -> Result<()> {
 /// A utility module designed to test witness generation externally.
 pub mod testing {
     use super::*;
-    use crate::cpu::kernel::interpreter::Interpreter;
+    use crate::{
+        cpu::kernel::interpreter::Interpreter,
+        generation::{output_debug_tries, state::State},
+    };
 
     /// Simulates the zkEVM CPU execution.
     /// It does not generate any trace or proof of correct state transition.
@@ -377,6 +380,11 @@ pub mod testing {
         let initial_offset = KERNEL.global_labels["main"];
         let mut interpreter: Interpreter<F> =
             Interpreter::new_with_generation_inputs(initial_offset, initial_stack, inputs);
-        interpreter.run()
+        let result = interpreter.run();
+        if result.is_err() {
+            output_debug_tries(interpreter.get_generation_state())?;
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Upon Kernel failure when comparing resulting tries post txn execution, we recompute the tries that plonky2 internally calculated (if `log::Level::Debug` or deeper is enabled) for debugging.
However it currently fails when the receipts contain more than 1 log because of a missing offset increment. This wasn't caught when failures were encountered among the integration tests here because none of them have actual logs.

This can be tested against the `log_opcode` tests by adding a `PANIC` say before the final `%jump(halt)`, and calling:
`RUST_LOG=debug cargo test --release --test log_opcode test_log_opcodes -- --ignored` which will result in an `Computed receipts trie: Err(IntegerTooLarge)` issue.

The PR also adapts the logic so that it can be used with the CPU simulation.