### PR TITLE
Reduce state trie size for dummy payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clean up logging output upon Kernel failure ([#74](https://github.com/0xPolygonZero/zk_evm/pull/74))
 - Fix CPU Cycle display in logs during simulations ([#77](https://github.com/0xPolygonZero/zk_evm/pull/77))
 - Fix blake2 precompile ([#78](https://github.com/0xPolygonZero/zk_evm/pull/78))
+- Reduce state trie size for dummy payloads ([#88](https://github.com/0xPolygonZero/zk_evm/pull/88))
 
 ## [0.1.1] - 2024-03-01
 

--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     fmt::{self, Display, Formatter},
-    iter::once,
+    iter::{empty, once},
 };
 
 use ethereum_types::{Address, H256, U256};
@@ -499,7 +499,7 @@ fn calculate_trie_input_hashes(t_inputs: &PartialTrieState) -> TrieRoots {
 // way to do it.
 fn create_fully_hashed_out_sub_partial_trie(trie: &HashedPartialTrie) -> HashedPartialTrie {
     // Impossible to actually fail with an empty iter.
-    create_trie_subset(trie, once(0_u64)).unwrap()
+    create_trie_subset(trie, empty::<Nibbles>()).unwrap()
 }
 
 fn create_dummy_txn_pair_for_empty_block(


### PR DESCRIPTION
Fairly minor, but while debugging I realized that we should (as the comment specifies) pass an empty iterator instead of `once`.
This saves a few thousand cycles on dummy payloads (tested against John's test chain).