### PR TITLE
Fix generation inputs logging pre-transaction execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clean up logging output upon Kernel failure ([#74](https://github.com/0xPolygonZero/zk_evm/pull/74))
 - Fix CPU Cycle display in logs during simulations ([#77](https://github.com/0xPolygonZero/zk_evm/pull/77))
 - Fix blake2 precompile ([#78](https://github.com/0xPolygonZero/zk_evm/pull/78))
+- Fix generation inputs logging pre-transaction execution ([#89](https://github.com/0xPolygonZero/zk_evm/pull/89))
 
 ## [0.1.1] - 2024-03-01
 

--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -15,6 +15,7 @@ use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::cpu::kernel::constants::txn_fields::NormalizedTxnField;
+use crate::generation::debug_inputs;
 use crate::generation::mpt::load_all_mpts;
 use crate::generation::rlp::all_rlp_prover_inputs_reversed;
 use crate::generation::state::{
@@ -146,6 +147,8 @@ impl<F: Field> Interpreter<F> {
         initial_stack: Vec<U256>,
         inputs: GenerationInputs,
     ) -> Self {
+        debug_inputs(&inputs);
+
         let mut result = Self::new(initial_offset, initial_stack);
         result.initialize_interpreter_state(inputs);
         result

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -203,12 +203,25 @@ fn apply_metadata_and_tries_memops<F: RichField + Extendable<D>, const D: usize>
     state.traces.memory_ops.extend(ops);
 }
 
+pub(crate) fn debug_inputs(inputs: &GenerationInputs) {
+    log::debug!("Input signed_txn: {:?}", &inputs.signed_txn);
+    log::debug!("Input state_trie: {:?}", &inputs.tries.state_trie);
+    log::debug!(
+        "Input transactions_trie: {:?}",
+        &inputs.tries.transactions_trie
+    );
+    log::debug!("Input receipts_trie: {:?}", &inputs.tries.receipts_trie);
+    log::debug!("Input storage_tries: {:?}", &inputs.tries.storage_tries);
+    log::debug!("Input contract_code: {:?}", &inputs.contract_code);
+}
+
 pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
     all_stark: &AllStark<F, D>,
     inputs: GenerationInputs,
     config: &StarkConfig,
     timing: &mut TimingTree,
 ) -> anyhow::Result<([Vec<PolynomialValues<F>>; NUM_TABLES], PublicValues)> {
+    debug_inputs(&inputs);
     let mut state = GenerationState::<F>::new(inputs.clone(), &KERNEL.code)
         .map_err(|err| anyhow!("Failed to parse all the initial prover inputs: {:?}", err))?;
 

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -310,16 +310,6 @@ impl<F: Field> GenerationState<F> {
         trie_roots_ptrs
     }
     pub(crate) fn new(inputs: GenerationInputs, kernel_code: &[u8]) -> Result<Self, ProgramError> {
-        log::debug!("Input signed_txn: {:?}", &inputs.signed_txn);
-        log::debug!("Input state_trie: {:?}", &inputs.tries.state_trie);
-        log::debug!(
-            "Input transactions_trie: {:?}",
-            &inputs.tries.transactions_trie
-        );
-        log::debug!("Input receipts_trie: {:?}", &inputs.tries.receipts_trie);
-        log::debug!("Input storage_tries: {:?}", &inputs.tries.storage_tries);
-        log::debug!("Input contract_code: {:?}", &inputs.contract_code);
-
         let rlp_prover_inputs =
             all_rlp_prover_inputs_reversed(inputs.clone().signed_txn.as_ref().unwrap_or(&vec![]));
         let withdrawal_prover_inputs = all_withdrawals_prover_inputs_reversed(&inputs.withdrawals);


### PR DESCRIPTION
Yet another tiny bug fix post #56.
CPU simulation displays default values in `Debug` mode, because we initialize the interpreter with empty inputs, before setting them during preinitialization.

```logtalk
DEBUG evm_arithmetization::generation::state: Input signed_txn: None    
DEBUG evm_arithmetization::generation::state: Input state_trie: HashedPartialTrie { node: Empty, hash: RwLock { data: None } }    
DEBUG evm_arithmetization::generation::state: Input transactions_trie: HashedPartialTrie { node: Empty, hash: RwLock { data: None } }    
DEBUG evm_arithmetization::generation::state: Input receipts_trie: HashedPartialTrie { node: Empty, hash: RwLock { data: None } }    
DEBUG evm_arithmetization::generation::state: Input storage_tries: []    
DEBUG evm_arithmetization::generation::state: Input contract_code: {}    
```

This PR fixes it.