### PR TITLE
Add automatic labeler for PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,24 @@
+# Add 'crate: mpt_trie' label to any changes within 'mpt_trie' folder.
+'crate: mpt_trie':
+- changed-files:
+  - any-glob-to-any-file: mpt_trie/**
+
+# Add 'crate: evm_arithmetization' label to any changes within 'evm_arithmetization' folder.
+'crate: evm_arithmetization':
+- changed-files:
+  - any-glob-to-any-file: evm_arithmetization/**
+
+# Add 'crate: trace_decoder' label to any changes within 'trace_decoder' folder.
+'crate: trace_decoder':
+- changed-files:
+  - any-glob-to-any-file: trace_decoder/**
+
+# Add 'crate: proof_gen' label to any changes within 'proof_gen' folder.
+'crate: proof_gen':
+- changed-files:
+  - any-glob-to-any-file: proof_gen/**
+
+# Add 'specs' label to any changes within 'docs' folder.
+'specs':
+- changed-files:
+  - any-glob-to-any-file: docs/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,3 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v5
+      with:
+        # Allow to remove labels that are no longer relevant when new changes are pushed.
+        sync-labels: true


### PR DESCRIPTION
Basic layout of an automatic labeler. Could be extended in the future.
For now, it will automatically label the crates touched, or add `specs` if the docs are being updated.

Note that we don't have to create any label beforehand, if it doesn't exist, the labeler will create it on the first occurence.