### PR TITLE
Now prunes tries properly (and more aggressively!) without hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix generation inputs logging pre-transaction execution ([#89](https://github.com/0xPolygonZero/zk_evm/pull/89))
 - Reduce state trie size for dummy payloads ([#88](https://github.com/0xPolygonZero/zk_evm/pull/88))
 - Fix post-txn trie debugging output for multi-logs receipts ([#86](https://github.com/0xPolygonZero/zk_evm/pull/86))
+- Fixed *most* failing blocks caused by the merged in aggressive pruning changes ([#97](https://github.com/0xPolygonZero/zk_evm/pull/97))
 
 ## [0.1.1] - 2024-03-01
 

--- a/mpt_trie/src/debug_tools/query.rs
+++ b/mpt_trie/src/debug_tools/query.rs
@@ -159,7 +159,7 @@ pub struct DebugQueryOutput {
     k: Nibbles,
 
     /// The nodes hit during the query.
-    pub node_path: TriePath,
+    node_path: TriePath,
     extra_node_info: Vec<Option<ExtraNodeSegmentInfo>>,
     node_found: bool,
     params: DebugQueryParams,

--- a/mpt_trie/src/nibbles.rs
+++ b/mpt_trie/src/nibbles.rs
@@ -26,9 +26,9 @@ pub type Nibble = u8;
 /// Used for the internal representation of a sequence of nibbles.
 pub type NibblesIntern = U512;
 
-const NIBBLES_APPEND_ASSERT_ERR_MSG: &str =
-    "Attempted to append nibbles together that produced nibbles longer than 64 nibbles!";
-const NIBBLE_APPEND_ASSERT_ERR_MSG: &str =
+const MULTIPLE_NIBBLES_APPEND_ASSERT_ERR_MSG: &str =
+    "Attempted to create a nibbles sequence longer than 64!";
+const SINGLE_NIBBLE_APPEND_ASSERT_ERR_MSG: &str =
     "Attempted to append a single nibble that was greater than 15!";
 
 /// Because there are two different ways to convert to `Nibbles`, we don't want
@@ -781,12 +781,20 @@ impl Nibbles {
     }
 
     fn nibble_append_safety_asserts(&self, n: Nibble) {
-        assert!(self.count < 64, "{}", NIBBLES_APPEND_ASSERT_ERR_MSG);
-        assert!(n < 16, "{}", NIBBLE_APPEND_ASSERT_ERR_MSG);
+        assert!(
+            self.count < 64,
+            "{}",
+            MULTIPLE_NIBBLES_APPEND_ASSERT_ERR_MSG
+        );
+        assert!(n < 16, "{}", SINGLE_NIBBLE_APPEND_ASSERT_ERR_MSG);
     }
 
     fn nibbles_append_safety_asserts(&self, new_count: usize) {
-        assert!(new_count <= 64, "{}", NIBBLES_APPEND_ASSERT_ERR_MSG);
+        assert!(
+            new_count <= 64,
+            "{}",
+            MULTIPLE_NIBBLES_APPEND_ASSERT_ERR_MSG
+        );
     }
 
     // TODO: REMOVE BEFORE NEXT CRATE VERSION! THIS IS A TEMP HACK!

--- a/mpt_trie/src/special_query.rs
+++ b/mpt_trie/src/special_query.rs
@@ -39,8 +39,8 @@ impl<T: PartialTrie> Iterator for TriePathIter<T> {
                 Some(TrieSegment::Hash)
             }
             Node::Branch { children, .. } => {
-                // Our query key has ended. Stop here.
                 if self.curr_key.is_empty() {
+                    // Our query key has ended. Stop here.
                     self.terminated = true;
                     return None;
                 }

--- a/mpt_trie/src/special_query.rs
+++ b/mpt_trie/src/special_query.rs
@@ -19,6 +19,10 @@ pub struct TriePathIter<N: PartialTrie> {
     // Although wrapping `curr_node` in an option might be more "Rust like", the logic is a lot
     // cleaner with a bool.
     terminated: bool,
+
+    /// Always include the final node we encounter even if the key does not
+    /// match.
+    always_include_final_node_if_possible: bool,
 }
 
 impl<T: PartialTrie> Iterator for TriePathIter<T> {
@@ -42,6 +46,9 @@ impl<T: PartialTrie> Iterator for TriePathIter<T> {
                 if self.curr_key.is_empty() {
                     // Our query key has ended. Stop here.
                     self.terminated = true;
+
+                    // In this case even if `always_include_final_node` is set, we have no
+                    // information on which branch to take, so we can't add in the last node.
                     return None;
                 }
 
@@ -58,7 +65,8 @@ impl<T: PartialTrie> Iterator for TriePathIter<T> {
                     false => {
                         // Only a partial match. Stop.
                         self.terminated = true;
-                        None
+                        self.always_include_final_node_if_possible
+                            .then_some(TrieSegment::Extension(*nibbles))
                     }
                     true => {
                         pop_nibbles_clamped(&mut self.curr_key, nibbles.count);
@@ -72,7 +80,7 @@ impl<T: PartialTrie> Iterator for TriePathIter<T> {
             Node::Leaf { nibbles, .. } => {
                 self.terminated = true;
 
-                match self.curr_key == *nibbles {
+                match self.curr_key == *nibbles || self.always_include_final_node_if_possible {
                     false => None,
                     true => Some(TrieSegment::Leaf(*nibbles)),
                 }
@@ -93,7 +101,11 @@ fn pop_nibbles_clamped(nibbles: &mut Nibbles, n: usize) -> Nibbles {
 /// Note that if the key does not match the entire key of a node (eg. the
 /// remaining key is `0x34` but the next key is a leaf with the key `0x3456`),
 /// then the leaf will not appear in the query output.
-pub fn path_for_query<K, T: PartialTrie>(trie: &Node<T>, k: K) -> TriePathIter<T>
+pub fn path_for_query<K, T: PartialTrie>(
+    trie: &Node<T>,
+    k: K,
+    always_include_final_node_if_possible: bool,
+) -> TriePathIter<T>
 where
     K: Into<Nibbles>,
 {
@@ -101,6 +113,7 @@ where
         curr_node: trie.clone().into(),
         curr_key: k.into(),
         terminated: false,
+        always_include_final_node_if_possible,
     }
 }
 
@@ -109,10 +122,15 @@ mod test {
     use std::str::FromStr;
 
     use super::path_for_query;
-    use crate::{nibbles::Nibbles, testing_utils::handmade_trie_1, utils::TrieSegment};
+    use crate::{
+        nibbles::Nibbles,
+        testing_utils::{common_setup, handmade_trie_1},
+        utils::TrieSegment,
+    };
 
     #[test]
-    fn query_iter_works() {
+    fn query_iter_works_no_last_node() {
+        common_setup();
         let (trie, ks) = handmade_trie_1();
 
         // ks --> vec![0x1234, 0x1324, 0x132400005_u64, 0x2001, 0x2002];
@@ -149,8 +167,50 @@ mod test {
         ];
 
         for (q, expected) in ks.into_iter().zip(res.into_iter()) {
-            let res: Vec<_> = path_for_query(&trie.node, q).collect();
+            let res: Vec<_> = path_for_query(&trie.node, q, false).collect();
             assert_eq!(res, expected)
         }
+    }
+
+    #[test]
+    fn query_iter_works_with_last_node() {
+        common_setup();
+        let (trie, _) = handmade_trie_1();
+
+        let extension_expected = vec![
+            TrieSegment::Branch(1),
+            TrieSegment::Branch(3),
+            TrieSegment::Extension(0x24.into()),
+        ];
+
+        assert_eq!(
+            path_for_query(&trie, 0x13, true).collect::<Vec<_>>(),
+            extension_expected
+        );
+        assert_eq!(
+            path_for_query(&trie, 0x132, true).collect::<Vec<_>>(),
+            extension_expected
+        );
+
+        // The last node is a branch here, but we don't include it because a TrieSegment
+        // requires us to state which nibble we took in the branch, and we don't have
+        // this information.
+        assert_eq!(
+            path_for_query(&trie, 0x1324, true).collect::<Vec<_>>(),
+            extension_expected
+        );
+
+        let mut leaf_expected = extension_expected.clone();
+        leaf_expected.push(TrieSegment::Branch(0));
+        leaf_expected.push(TrieSegment::Leaf(Nibbles::from_str("0x0005").unwrap()));
+
+        assert_eq!(
+            path_for_query(&trie, 0x13240, true).collect::<Vec<_>>(),
+            leaf_expected
+        );
+        assert_eq!(
+            path_for_query(&trie, 0x132400, true).collect::<Vec<_>>(),
+            leaf_expected
+        );
     }
 }

--- a/mpt_trie/src/trie_subsets.rs
+++ b/mpt_trie/src/trie_subsets.rs
@@ -307,11 +307,17 @@ fn mark_nodes_that_are_needed<N: PartialTrie>(
             return mark_nodes_that_are_needed(&mut children[nib as usize], curr_nibbles);
         }
         TrackedNodeIntern::Extension(child) => {
-            let nibbles = trie.info.get_nibbles_expected();
-            let r = curr_nibbles.pop_nibbles_front(nibbles.count);
+            // If we hit an extension node, we always must include it unless we exhausted
+            // our key.
+            if curr_nibbles.is_empty() {
+                return Ok(());
+            }
 
-            if r.nibbles_are_identical_up_to_smallest_count(nibbles) {
-                trie.info.touched = true;
+            trie.info.touched = true;
+
+            let nibbles: &Nibbles = trie.info.get_nibbles_expected();
+            if curr_nibbles.nibbles_are_identical_up_to_smallest_count(nibbles) {
+                curr_nibbles.pop_nibbles_front(nibbles.count);
                 return mark_nodes_that_are_needed(child, curr_nibbles);
             }
         }

--- a/mpt_trie/src/utils.rs
+++ b/mpt_trie/src/utils.rs
@@ -216,7 +216,7 @@ impl TrieSegment {
     }
 
     /// Extracts the key piece used by the segment (if applicable).
-    pub fn get_key_piece_from_seg_if_present(&self) -> Option<Nibbles> {
+    pub(crate) fn get_key_piece_from_seg_if_present(&self) -> Option<Nibbles> {
         match self {
             TrieSegment::Empty | TrieSegment::Hash => None,
             TrieSegment::Branch(nib) => Some(Nibbles::from_nibble(*nib)),
@@ -230,7 +230,7 @@ impl TrieSegment {
 /// This function is intended to be used during a trie query as we are
 /// traversing down a trie. Depending on the current node, we pop off nibbles
 /// and use these to create `TrieSegment`s.
-pub fn get_segment_from_node_and_key_piece<T: PartialTrie>(
+pub(crate) fn get_segment_from_node_and_key_piece<T: PartialTrie>(
     n: &Node<T>,
     k_piece: &Nibbles,
 ) -> TrieSegment {

--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -98,7 +98,7 @@ struct PartialTrieState {
 #[derive(Debug, Default)]
 struct TrieDeltaApplicationOutput {
     // During delta application, if a delete occurs, we may have to make sure additional nodes
-    // remain unhashed that are not accessed by the txn.
+    // that are not accessed by the txn remain unhashed.
     additional_state_trie_paths_to_not_hash: Vec<Nibbles>,
     additional_storage_trie_paths_to_not_hash: HashMap<H256, Vec<Nibbles>>,
 }

--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -369,23 +369,24 @@ impl ProcessedBlockTrace {
             return false;
         }
 
-        // Node we need to check is the second last.
-        let seg_idx = old_path.0.len() - 1;
+        // Node we need to check is the last node in the new path.
+        let seg_idx = new_path.0.len() - 1;
+        let old_seg_at_idx = &old_path.0[seg_idx];
 
-        // The second last node needs to be a branch in order for a collapse to occur.
-        if matches!(&old_path.0[seg_idx], TrieSegment::Branch(_)) {
+        // The last node needs to be a branch in order for a collapse to occur.
+        if !matches!(old_seg_at_idx, TrieSegment::Branch(_)) {
             return false;
         }
 
         let new_seg_at_idx = &new_path.0[seg_idx];
 
-        if matches!(new_seg_at_idx, TrieSegment::Branch(_)) {
+        if old_seg_at_idx.node_type() == new_seg_at_idx.node_type() {
             return false;
         }
 
         // Additional sanity check as this should be the only valid node type after a
         // collapse.
-        assert!(matches!(new_seg_at_idx, TrieSegment::Extension(_)));
+        assert!(matches!(new_seg_at_idx, TrieSegment::Leaf(_)));
 
         true
     }

--- a/trace_decoder/src/types.rs
+++ b/trace_decoder/src/types.rs
@@ -3,7 +3,7 @@ use evm_arithmetization::{
     generation::GenerationInputs,
     proof::{BlockHashes, BlockMetadata},
 };
-use mpt_trie::nibbles::Nibbles;
+use mpt_trie::{nibbles::Nibbles, partial_trie::HashedPartialTrie};
 use serde::{Deserialize, Serialize};
 
 /// A type alias around `u64` for a block height.
@@ -30,6 +30,8 @@ pub type StorageVal = U256;
 pub type TrieRootHash = H256;
 /// A type alias around `usize` for a transaction's index within a block.
 pub type TxnIdx = usize;
+
+pub(crate) type TriePathIter = mpt_trie::special_query::TriePathIter<HashedPartialTrie>;
 
 /// A function which turns a code hash into bytes.
 pub trait CodeHashResolveFunc = Fn(&CodeHash) -> Vec<u8>;


### PR DESCRIPTION
This PR is the last piece to tie together all of the pruning optimizations/fixes that have been going on over the past month. I ended up having to cherry-pick from a testing branch, so apologies if this is a bit messy (eg. `Requested PR changes for #39` somehow never got merged and was on the tip of another in progress branch that I needed, but I'm just going to leave that here for now).

The critical bits in this PR are:
- Logic in the decoder to handle the branch collapse edge case properly.
- Fix in creating trie-subsets with when to hash out extension nodes.
- The order of calls in `into_txn_proof_gen_ir` has changed in order to use `delta_out` (just contains info on collapsed nodes) when creating partial tries. I'm going to admit upfront that this section got a lot more complex and will get a nice refactor pretty soon in an upcoming PR.
- Logic to initialize empty storage tries finally got moved outside of `apply_deltas_to_trie_state`. It really had no reason to be in here.

*Almost* all blocks that I've tested are not able to generate proofs. I was hoping to say all, but `19240780` currently fails. 
