### PR TITLE
Remove `blobbasefee` from block header

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/memory/metadata.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/metadata.asm
@@ -268,10 +268,6 @@ global sys_chainid:
     %mload_global_metadata(@GLOBAL_METADATA_BLOCK_BASE_FEE)
 %endmacro
 
-%macro blobbasefee
-    %mload_global_metadata(@GLOBAL_METADATA_BLOCK_BLOB_BASE_FEE)
-%endmacro
-
 global sys_basefee:
     // stack: kexit_info
     %charge_gas_const(@GAS_BASE)
@@ -318,7 +314,7 @@ global sys_blobbasefee:
     // stack: kexit_info
     %charge_gas_const(@GAS_BASE)
     // stack: kexit_info
-    %blobbasefee
+    PROVER_INPUT(blobbasefee)
     // stack: blobbasefee, kexit_info
     SWAP1
     EXIT_KERNEL

--- a/evm_arithmetization/src/cpu/kernel/constants/global_metadata.rs
+++ b/evm_arithmetization/src/cpu/kernel/constants/global_metadata.rs
@@ -49,7 +49,6 @@ pub(crate) enum GlobalMetadata {
     BlockGasLimit,
     BlockChainId,
     BlockBaseFee,
-    BlockBlobBaseFee,
     BlockBlobGasUsed,
     BlockExcessBlobGas,
     BlockGasUsed,
@@ -115,7 +114,7 @@ pub(crate) enum GlobalMetadata {
 }
 
 impl GlobalMetadata {
-    pub(crate) const COUNT: usize = 56;
+    pub(crate) const COUNT: usize = 55;
 
     /// Unscales this virtual offset by their respective `Segment` value.
     pub(crate) const fn unscale(&self) -> usize {
@@ -146,7 +145,6 @@ impl GlobalMetadata {
             Self::BlockChainId,
             Self::BlockBaseFee,
             Self::BlockGasUsed,
-            Self::BlockBlobBaseFee,
             Self::BlockBlobGasUsed,
             Self::BlockExcessBlobGas,
             Self::BlockGasUsedBefore,
@@ -207,7 +205,6 @@ impl GlobalMetadata {
             Self::BlockGasLimit => "GLOBAL_METADATA_BLOCK_GAS_LIMIT",
             Self::BlockChainId => "GLOBAL_METADATA_BLOCK_CHAIN_ID",
             Self::BlockBaseFee => "GLOBAL_METADATA_BLOCK_BASE_FEE",
-            Self::BlockBlobBaseFee => "GLOBAL_METADATA_BLOCK_BLOB_BASE_FEE",
             Self::BlockBlobGasUsed => "GLOBAL_METADATA_BLOCK_BLOB_GAS_USED",
             Self::BlockExcessBlobGas => "GLOBAL_METADATA_BLOCK_EXCESS_BLOB_GAS",
             Self::BlockGasUsed => "GLOBAL_METADATA_BLOCK_GAS_USED",

--- a/evm_arithmetization/src/cpu/kernel/constants/mod.rs
+++ b/evm_arithmetization/src/cpu/kernel/constants/mod.rs
@@ -316,9 +316,14 @@ const MAX_NONCE: (&str, u64) = ("MAX_NONCE", 0xffffffffffffffff);
 const CALL_STACK_LIMIT: (&str, u64) = ("CALL_STACK_LIMIT", 1024);
 
 /// Cancun-related constants
-/// See <https://eips.ethereum.org/EIPS/eip-4788#deployment>.
+/// See <https://eips.ethereum.org/EIPS/eip-4788> and
+/// <https://eips.ethereum.org/EIPS/eip-4844>.
 pub mod cancun_constants {
     use super::*;
+
+    pub const BLOB_BASE_FEE_UPDATE_FRACTION: U256 = U256([0x32f0ed, 0, 0, 0]);
+
+    pub const MIN_BLOB_BASE_FEE: U256 = U256::one();
 
     pub const BEACON_ROOTS_ADDRESS: (&str, [u8; 20]) = (
         "BEACON_ROOTS_ADDRESS",

--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -244,10 +244,6 @@ impl<F: Field> Interpreter<F> {
             (GlobalMetadata::BlockChainId, metadata.block_chain_id),
             (GlobalMetadata::BlockBaseFee, metadata.block_base_fee),
             (
-                GlobalMetadata::BlockBlobBaseFee,
-                metadata.block_blob_base_fee,
-            ),
-            (
                 GlobalMetadata::BlockCurrentHash,
                 h2u(inputs.block_hashes.cur_hash),
             ),

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -131,10 +131,6 @@ fn apply_metadata_and_tries_memops<F: RichField + Extendable<D>, const D: usize>
         ),
         (GlobalMetadata::BlockGasUsed, metadata.block_gas_used),
         (
-            GlobalMetadata::BlockBlobBaseFee,
-            metadata.block_blob_base_fee,
-        ),
-        (
             GlobalMetadata::BlockBlobGasUsed,
             metadata.block_blob_gas_used,
         ),

--- a/evm_arithmetization/src/recursive_verifier.rs
+++ b/evm_arithmetization/src/recursive_verifier.rs
@@ -379,7 +379,7 @@ pub(crate) fn get_memory_extra_looking_sum_circuit<F: RichField + Extendable<D>,
     // This contains the `block_beneficiary`, `block_random`, `block_base_fee`,
     // `block_blob_base_fee`, `block_blob_gas_used`, `block_excess_blob_gas`,
     // `parent_beacon_block_root` as well as `cur_hash`.
-    let block_fields_arrays: [(GlobalMetadata, &[Target]); 8] = [
+    let block_fields_arrays: [(GlobalMetadata, &[Target]); 7] = [
         (
             GlobalMetadata::BlockBeneficiary,
             &public_values.block_metadata.block_beneficiary,
@@ -391,10 +391,6 @@ pub(crate) fn get_memory_extra_looking_sum_circuit<F: RichField + Extendable<D>,
         (
             GlobalMetadata::BlockBaseFee,
             &public_values.block_metadata.block_base_fee,
-        ),
-        (
-            GlobalMetadata::BlockBlobBaseFee,
-            &public_values.block_metadata.block_blob_base_fee,
         ),
         (
             GlobalMetadata::BlockBlobGasUsed,
@@ -800,10 +796,6 @@ where
         block_metadata_target.block_gas_used,
         u256_to_u32(block_metadata.block_gas_used)?,
     );
-    // BlobBaseFee fits in 2 limbs
-    let blob_basefee = u256_to_u64(block_metadata.block_blob_base_fee)?;
-    witness.set_target(block_metadata_target.block_blob_base_fee[0], blob_basefee.0);
-    witness.set_target(block_metadata_target.block_blob_base_fee[1], blob_basefee.1);
     // BlobGasUsed fits in 2 limbs
     let blob_gas_used = u256_to_u64(block_metadata.block_blob_gas_used)?;
     witness.set_target(

--- a/evm_arithmetization/src/verifier.rs
+++ b/evm_arithmetization/src/verifier.rs
@@ -195,10 +195,6 @@ where
             public_values.block_metadata.block_gas_used,
         ),
         (
-            GlobalMetadata::BlockBlobBaseFee,
-            public_values.block_metadata.block_blob_base_fee,
-        ),
-        (
             GlobalMetadata::BlockBlobGasUsed,
             public_values.block_metadata.block_blob_gas_used,
         ),
@@ -350,10 +346,6 @@ pub(crate) mod debug_utils {
             (
                 GlobalMetadata::BlockGasUsed,
                 public_values.block_metadata.block_gas_used,
-            ),
-            (
-                GlobalMetadata::BlockBlobBaseFee,
-                public_values.block_metadata.block_blob_base_fee,
             ),
             (
                 GlobalMetadata::BlockBlobGasUsed,


### PR DESCRIPTION
As per [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516), `blobbasefee` should be retrieved from the `excess_blob_gas` stored in the block header, but is not a header field on its own.
The details on how this is computed are in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844#helpers).

For simplicity with higher layers of the stack, it's probably better to remove it from the plonky2 header to keep it as consistent as possible with an actual chain header. It's still taken as a prover input though, as blob fee market mechanism isn't implemented.