### PR TITLE
Fix simulation output result

### DIFF
--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -385,6 +385,6 @@ pub mod testing {
             output_debug_tries(interpreter.get_generation_state())?;
         }
 
-        Ok(())
+        result
     }
 }


### PR DESCRIPTION
Tiny overlook of #86.
We should still return the underlying result from running the interpreter. The previous PR logs tries on failure but always returns an `Ok(())`.