### PR TITLE
Add clock to GenerationStateCheckpoint and fix interpreter rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix post-txn trie debugging output for multi-logs receipts ([#86](https://github.com/0xPolygonZero/zk_evm/pull/86))
 - Fixed *most* failing blocks caused by the merged in aggressive pruning changes ([#97](https://github.com/0xPolygonZero/zk_evm/pull/97))
 - Fixed trie hash collision issue when constructing storage tries [#75](https://github.com/0xPolygonZero/zk_evm/pull/75)
+- Fix interpreter rollback by adding the clock to generation state checkpoints ([#109] https://github.com/0xPolygonZero/zk_evm/pull/109)
 
 ## [0.1.1] - 2024-03-01
 

--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -748,6 +748,7 @@ impl<F: Field> State<F> for Interpreter<F> {
         GenerationStateCheckpoint {
             registers: self.generation_state.registers,
             traces: self.generation_state.traces.checkpoint(),
+            clock: self.get_clock(),
         }
     }
 
@@ -814,6 +815,7 @@ impl<F: Field> State<F> for Interpreter<F> {
     fn push_keccak_sponge(&mut self, _op: KeccakSpongeOp) {}
 
     fn rollback(&mut self, checkpoint: GenerationStateCheckpoint) {
+        self.clock = checkpoint.clock;
         self.generation_state.rollback(checkpoint)
     }
 

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -424,6 +424,7 @@ impl<F: Field> State<F> for GenerationState<F> {
         GenerationStateCheckpoint {
             registers: self.registers,
             traces: self.traces.checkpoint(),
+            clock: self.get_clock(),
         }
     }
 
@@ -591,6 +592,7 @@ impl<F: Field> Transition<F> for GenerationState<F> {
 pub(crate) struct GenerationStateCheckpoint {
     pub(crate) registers: RegistersState,
     pub(crate) traces: TraceCheckpoint,
+    pub(crate) clock: usize,
 }
 
 /// Withdrawals prover input array is of the form `[addr0, amount0, ..., addrN,


### PR DESCRIPTION
Small PR to add the `clock` to `GenerationStateCheckpoint`, so we can fix the interpreter rollback by setting the clock correctly.