### PR TITLE
Fix trace lengths

### DIFF
--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -380,10 +380,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         (RegistersState::default(), None)
     };
 
-    log::info!(
-        "Trace lengths (before padding): {:?}",
-        state.traces.get_lengths()
-    );
+    let mut trace_lengths = state.traces.get_lengths();
 
     let read_metadata = |field| state.memory.read_global_metadata(field);
     let trie_roots_before = TrieRoots {
@@ -428,7 +425,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         "convert trace data to tables",
         state
             .traces
-            .into_tables(all_stark, &memory_before, config, timing)
+            .into_tables(all_stark, &memory_before, trace_lengths, config, timing)
     );
     Ok((tables, public_values, final_values))
 }

--- a/evm_arithmetization/src/witness/traces.rs
+++ b/evm_arithmetization/src/witness/traces.rs
@@ -124,6 +124,7 @@ impl<T: Copy> Traces<T> {
         self,
         all_stark: &AllStark<T, D>,
         mem_before_values: &MemBeforeValues,
+        mut trace_lengths: TraceCheckpoint,
         config: &StarkConfig,
         timing: &mut TimingTree,
     ) -> ([Vec<PolynomialValues<T>>; NUM_TABLES], Vec<Vec<T>>)
@@ -176,13 +177,15 @@ impl<T: Copy> Traces<T> {
                 .logic_stark
                 .generate_trace(logic_ops, cap_elements, timing)
         );
-        let (memory_trace, final_values) = timed!(
+        let (memory_trace, final_values, unpadded_memory_length) = timed!(
             timing,
             "generate memory trace",
             all_stark
                 .memory_stark
                 .generate_trace(memory_ops, mem_before_values, timing)
         );
+        trace_lengths.memory_len = unpadded_memory_length;
+
         let mem_before_trace = timed!(
             timing,
             "generate mem_before trace",
@@ -196,6 +199,13 @@ impl<T: Copy> Traces<T> {
             all_stark
                 .mem_after_stark
                 .generate_trace(final_values.clone(), timing)
+        );
+
+        log::info!(
+            "Trace lengths (before padding): {:?}, mem_before_len: {}, mem_after_len: {}",
+            trace_lengths,
+            mem_before_values.len(),
+            final_values.len()
         );
 
         (


### PR DESCRIPTION
The unpadded `Memory` length doesn't reflect the true length, since it doesn't include `MemBefore` or the filling ops.
We also now display the unpadded length of `MemBefore` and `MemAfter`.