### PR TITLE
Add trimmed inputs to `ExtraSegmentData`

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -16,12 +16,12 @@ use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::cpu::kernel::constants::txn_fields::NormalizedTxnField;
-use crate::generation::debug_inputs;
 use crate::generation::mpt::{load_all_mpts, TrieRootPtrs};
 use crate::generation::rlp::all_rlp_prover_inputs_reversed;
 use crate::generation::state::{
     all_withdrawals_prover_inputs_reversed, GenerationState, GenerationStateCheckpoint,
 };
+use crate::generation::{debug_inputs, TrimmedGenerationInputs};
 use crate::generation::{state::State, GenerationInputs};
 use crate::keccak_sponge::columns::KECCAK_WIDTH_BYTES;
 use crate::keccak_sponge::keccak_sponge_stark::KeccakSpongeOp;
@@ -148,6 +148,7 @@ pub(crate) fn simulate_cpu_and_get_user_jumps<F: Field>(
 /// State data required to initialize the state passed to the prover.
 #[derive(Default, Debug, Clone)]
 pub(crate) struct ExtraSegmentData {
+    pub(crate) trimmed_inputs: TrimmedGenerationInputs,
     pub(crate) bignum_modmul_result_limbs: Vec<U256>,
     pub(crate) rlp_prover_inputs: Vec<U256>,
     pub(crate) withdrawal_prover_inputs: Vec<U256>,
@@ -192,6 +193,7 @@ pub(crate) fn generate_segment<F: Field>(
     for i in 0..=index {
         if i == index {
             extra_data = ExtraSegmentData {
+                trimmed_inputs: interpreter.generation_state.inputs.clone(),
                 bignum_modmul_result_limbs: interpreter
                     .generation_state
                     .bignum_modmul_result_limbs

--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -68,6 +68,7 @@ where
         };
 
         let ExtraSegmentData {
+            trimmed_inputs,
             bignum_modmul_result_limbs,
             rlp_prover_inputs,
             withdrawal_prover_inputs,
@@ -75,6 +76,7 @@ where
             jumpdest_table,
         } = extra_segment_data.clone();
 
+        state.inputs = trimmed_inputs;
         state.bignum_modmul_result_limbs = bignum_modmul_result_limbs;
         state.rlp_prover_inputs = rlp_prover_inputs;
         state.withdrawal_prover_inputs = withdrawal_prover_inputs;


### PR DESCRIPTION
Some elements of the inputs of `generation_state` weren't properly propagated from `generate_segment` to `generate_traces`. The issue was about `contract_code`, making e.g. `extCodeHashDeletedAccountCancun_d0g0v0_Shanghai` fail, but we propagate the whole `TrimmedGenerationInputs` struct to avoid future problems.