### PR TITLE
Add context pruning

### DIFF
--- a/evm_arithmetization/src/all_stark.rs
+++ b/evm_arithmetization/src/all_stark.rs
@@ -331,7 +331,7 @@ fn ctl_memory<F: Field>() -> CrossTableLookup<F> {
     CrossTableLookup::new(all_lookers, memory_looked)
 }
 
-/// `CrossTableLookup` for `Cpu` to propagate pruned contexts to `Memory`.
+/// `CrossTableLookup` for `Cpu` to propagate stale contexts to `Memory`.
 fn ctl_context_pruning<F: Field>() -> CrossTableLookup<F> {
     CrossTableLookup::new(
         vec![ctl_context_pruning_looking()],

--- a/evm_arithmetization/src/all_stark.rs
+++ b/evm_arithmetization/src/all_stark.rs
@@ -145,7 +145,6 @@ fn ctl_arithmetic<F: Field>() -> CrossTableLookup<F> {
         vec![
             cpu_stark::ctl_arithmetic_base_rows(),
             cpu_stark::ctl_arithmetic_context_pruning(),
-            cpu_stark::ctl_arithmetic_dummy(),
         ],
         arithmetic_stark::ctl_arithmetic_rows(),
     )

--- a/evm_arithmetization/src/cpu/columns/general.rs
+++ b/evm_arithmetization/src/cpu/columns/general.rs
@@ -11,6 +11,7 @@ pub(crate) union CpuGeneralColumnsView<T: Copy> {
     jumps: CpuJumpsView<T>,
     shift: CpuShiftView<T>,
     stack: CpuStackView<T>,
+    context_pruning: CpuContextPruningView<T>,
 }
 
 impl<T: Copy> CpuGeneralColumnsView<T> {
@@ -74,6 +75,18 @@ impl<T: Copy> CpuGeneralColumnsView<T> {
     /// SAFETY: Each view is a valid interpretation of the underlying array.
     pub(crate) fn stack_mut(&mut self) -> &mut CpuStackView<T> {
         unsafe { &mut self.stack }
+    }
+
+    /// View of the column for context pruning..
+    /// SAFETY: Each view is a valid interpretation of the underlying array.
+    pub(crate) fn context_pruning(&self) -> &CpuContextPruningView<T> {
+        unsafe { &self.context_pruning }
+    }
+
+    /// Mutable view of the column for context pruning.
+    /// SAFETY: Each view is a valid interpretation of the underlying array.
+    pub(crate) fn context_pruning_mut(&mut self) -> &mut CpuContextPruningView<T> {
+        unsafe { &mut self.context_pruning }
     }
 }
 
@@ -140,6 +153,14 @@ pub(crate) struct CpuShiftView<T: Copy> {
     /// For a shift amount of displacement: [T], this is the inverse of
     /// sum(displacement[1..]) or zero if the sum is zero.
     pub(crate) high_limb_sum_inv: T,
+}
+
+/// View of the first `CpuGeneralColumns` storing a flag for context pruning.
+#[derive(Copy, Clone)]
+pub(crate) struct CpuContextPruningView<T: Copy> {
+    /// If `context_op` is set, is 1 if the operation is `SET_CONTEXT` and
+    /// `new_ctx < old_ctx`, 0 otherwise.
+    pub(crate) pruning_flag: T,
 }
 
 /// View of the last four `CpuGeneralColumns` storing stack-related variables.

--- a/evm_arithmetization/src/cpu/columns/general.rs
+++ b/evm_arithmetization/src/cpu/columns/general.rs
@@ -158,8 +158,8 @@ pub(crate) struct CpuShiftView<T: Copy> {
 /// View of the first `CpuGeneralColumns` storing a flag for context pruning.
 #[derive(Copy, Clone)]
 pub(crate) struct CpuContextPruningView<T: Copy> {
-    /// If the OP flag `context_op` is set, then this is 1 if the operation is
-    /// `SET_CONTEXT` and `new_ctx < old_ctx`, 0 otherwise.
+    /// The flag is 1 if the OP flag `context_op` is set, the operation is
+    /// `SET_CONTEXT` and `new_ctx < old_ctx`, and 0 otherwise.
     pub(crate) pruning_flag: T,
 }
 

--- a/evm_arithmetization/src/cpu/columns/general.rs
+++ b/evm_arithmetization/src/cpu/columns/general.rs
@@ -77,7 +77,7 @@ impl<T: Copy> CpuGeneralColumnsView<T> {
         unsafe { &mut self.stack }
     }
 
-    /// View of the column for context pruning..
+    /// View of the column for context pruning.
     /// SAFETY: Each view is a valid interpretation of the underlying array.
     pub(crate) fn context_pruning(&self) -> &CpuContextPruningView<T> {
         unsafe { &self.context_pruning }
@@ -158,8 +158,8 @@ pub(crate) struct CpuShiftView<T: Copy> {
 /// View of the first `CpuGeneralColumns` storing a flag for context pruning.
 #[derive(Copy, Clone)]
 pub(crate) struct CpuContextPruningView<T: Copy> {
-    /// If `context_op` is set, is 1 if the operation is `SET_CONTEXT` and
-    /// `new_ctx < old_ctx`, 0 otherwise.
+    /// If the OP flag `context_op` is set, then this is 1 if the operation is
+    /// `SET_CONTEXT` and `new_ctx < old_ctx`, 0 otherwise.
     pub(crate) pruning_flag: T,
 }
 

--- a/evm_arithmetization/src/cpu/cpu_stark.rs
+++ b/evm_arithmetization/src/cpu/cpu_stark.rs
@@ -134,6 +134,65 @@ pub(crate) fn ctl_arithmetic_base_rows<F: Field>() -> TableWithColumns<F> {
     )
 }
 
+/// Returns the `TableWithColumns` for the context pruning inequality. It's a LT
+/// operation on `new_ctx` and `old_ctx`.
+pub(crate) fn ctl_arithmetic_context_pruning<F: Field>() -> TableWithColumns<F> {
+    // Opcode is LT.
+    let mut columns = vec![Column::constant(F::from_canonical_usize(0x10))];
+    // `input0` = `new_ctx`. Context is shifted; higher limbs are all zero.
+    columns.push(Column::single(COL_MAP.mem_channels[0].value[2]));
+    columns.extend(repeat(Column::constant(F::ZERO)).take(VALUE_LIMBS - 1));
+    // `input1` = `old_ctx`. Higher limbs are all zero.
+    columns.push(Column::single(COL_MAP.context));
+    columns.extend(repeat(Column::constant(F::ZERO)).take(VALUE_LIMBS - 1));
+    // `input2` doesn't matter.
+    columns.extend(repeat(Column::constant(F::ZERO)).take(VALUE_LIMBS));
+    // `res` is the first general column. Higher limbs are all zero.
+    columns.push(Column::single(
+        COL_MAP.general.context_pruning().pruning_flag,
+    ));
+    columns.extend(repeat(Column::constant(F::ZERO)).take(VALUE_LIMBS - 1));
+
+    TableWithColumns::new(
+        *Table::Cpu,
+        columns,
+        Some(Filter::new(
+            vec![(
+                Column::single(COL_MAP.op.context_op),
+                Column::single(COL_MAP.opcode_bits[0]),
+            )],
+            vec![],
+        )),
+    )
+}
+
+/// Temporary hack to make things work.
+/// TODO: Remove this.
+pub(crate) fn ctl_arithmetic_dummy<F: Field>() -> TableWithColumns<F> {
+    let mut columns = vec![Column::constant(F::from_canonical_usize(0x10)); 33];
+
+    TableWithColumns::new(
+        *Table::Cpu,
+        columns,
+        Some(Filter::new_simple(Column::constant(F::ZERO))),
+    )
+}
+
+/// Returns a column containing pruned contexts.
+pub(crate) fn ctl_context_pruning_looked<F: Field>() -> TableWithColumns<F> {
+    TableWithColumns::new(
+        *Table::Cpu,
+        vec![Column::single(COL_MAP.context)],
+        Some(Filter::new(
+            vec![(
+                Column::single(COL_MAP.op.context_op),
+                Column::single(COL_MAP.general.context_pruning().pruning_flag),
+            )],
+            vec![],
+        )),
+    )
+}
+
 /// Creates the vector of `Columns` corresponding to the contents of General
 /// Purpose channels when calling byte packing. We use `ctl_data_keccak_sponge`
 /// because the `Columns` are the same as the ones computed for

--- a/evm_arithmetization/src/cpu/cpu_stark.rs
+++ b/evm_arithmetization/src/cpu/cpu_stark.rs
@@ -166,7 +166,7 @@ pub(crate) fn ctl_arithmetic_context_pruning<F: Field>() -> TableWithColumns<F> 
     )
 }
 
-/// Returns a column containing pruned contexts.
+/// Returns a column containing stale contexts.
 pub(crate) fn ctl_context_pruning_looked<F: Field>() -> TableWithColumns<F> {
     TableWithColumns::new(
         *Table::Cpu,

--- a/evm_arithmetization/src/cpu/cpu_stark.rs
+++ b/evm_arithmetization/src/cpu/cpu_stark.rs
@@ -166,18 +166,6 @@ pub(crate) fn ctl_arithmetic_context_pruning<F: Field>() -> TableWithColumns<F> 
     )
 }
 
-/// Temporary hack to make things work.
-/// TODO: Remove this.
-pub(crate) fn ctl_arithmetic_dummy<F: Field>() -> TableWithColumns<F> {
-    let mut columns = vec![Column::constant(F::from_canonical_usize(0x10)); 33];
-
-    TableWithColumns::new(
-        *Table::Cpu,
-        columns,
-        Some(Filter::new_simple(Column::constant(F::ZERO))),
-    )
-}
-
 /// Returns a column containing pruned contexts.
 pub(crate) fn ctl_context_pruning_looked<F: Field>() -> TableWithColumns<F> {
     TableWithColumns::new(

--- a/evm_arithmetization/src/cpu/kernel/asm/account_code.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/account_code.asm
@@ -70,6 +70,10 @@ global sys_extcodesize:
     SWAP1
     // stack: address, kexit_info
     %extcodesize
+    // stack: code_size, codesize_ctx, kexit_info
+    SWAP1
+    // stack: codesize_ctx, code_size, kexit_info
+    %prune_context
     // stack: code_size, kexit_info
     SWAP1
     EXIT_KERNEL
@@ -77,9 +81,7 @@ global sys_extcodesize:
 global extcodesize:
     // stack: address, retdest
     %next_context_id
-    // stack: codesize_ctx, address, retdest
-    SWAP1
-    // stack: address, codesize_ctx, retdest
+    %stack(codesize_ctx, address, retdest) -> (address, codesize_ctx, retdest, codesize_ctx)
     %jump(load_code)
 
 // Loads the code at `address` into memory, in the code segment of the given context, starting at offset 0.

--- a/evm_arithmetization/src/cpu/kernel/asm/account_code.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/account_code.asm
@@ -78,6 +78,8 @@ global sys_extcodesize:
     SWAP1
     EXIT_KERNEL
 
+// Pre stack: address, retdest
+// Post stack: code_size, codesize_ctx
 global extcodesize:
     // stack: address, retdest
     %next_context_id

--- a/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
@@ -112,6 +112,15 @@ calldataload_large_offset:
 codecopy_within_bounds:
     // stack: total_size, segment, src_ctx, kexit_info, dest_offset, offset, size
     POP
+    // stack: segment, src_ctx, kexit_info, dest_offset, offset, size
+    GET_CONTEXT
+    %stack (context, segment, src_ctx, kexit_info, dest_offset, offset, size) ->
+        (src_ctx, segment, offset, @SEGMENT_MAIN_MEMORY, dest_offset, context, size, codecopy_after, src_ctx, kexit_info)
+    %build_address
+    SWAP3 %build_address
+    // stack: DST, SRC, size, codecopy_after, src_ctx, kexit_info
+    %jump(memcpy_bytes)
+
 wcopy_within_bounds:
     // stack: segment, src_ctx, kexit_info, dest_offset, offset, size
     GET_CONTEXT
@@ -131,7 +140,15 @@ wcopy_empty:
 
 codecopy_large_offset:
     // stack: total_size, src_ctx, kexit_info, dest_offset, offset, size
-    %pop2
+    POP
+    // offset is larger than the size of the {CALLDATA,CODE,RETURNDATA}. So we just have to write zeros.
+    // stack: src_ctx, kexit_info, dest_offset, offset, size
+    GET_CONTEXT
+    %stack (context, src_ctx, kexit_info, dest_offset, offset, size) ->
+        (context, @SEGMENT_MAIN_MEMORY, dest_offset, size, codecopy_after, src_ctx, kexit_info)
+    %build_address
+    %jump(memset)
+
 wcopy_large_offset:
     // offset is larger than the size of the {CALLDATA,CODE,RETURNDATA}. So we just have to write zeros.
     // stack: kexit_info, dest_offset, offset, size
@@ -140,6 +157,24 @@ wcopy_large_offset:
         (context, @SEGMENT_MAIN_MEMORY, dest_offset, size, wcopy_after, kexit_info)
     %build_address
     %jump(memset)
+
+codecopy_after:
+    // stack: src_ctx, kexit_info
+    DUP1 GET_CONTEXT
+    // stack: ctx, src_ctx, src_ctx, kexit_info
+    // If ctx == src_ctx, it's a CODECOPY, and we don't need to prune the context.
+    EQ
+    // stack: ctx == src_ctx, src_ctx, kexit_info
+    %jumpi(codecopy_no_prune)
+    // stack: src_ctx, kexit_info
+    %prune_context
+    // stack: kexit_info
+    EXIT_KERNEL
+
+codecopy_no_prune:
+    // stack: src_ctx
+    POP
+    EXIT_KERNEL
 
 wcopy_after:
     // stack: kexit_info
@@ -248,9 +283,37 @@ extcodecopy_contd:
 
     GET_CONTEXT
     %stack (context, new_dest_offset, copy_size, extra_size, segment, src_ctx, kexit_info, dest_offset, offset, size) ->
-        (src_ctx, segment, offset, @SEGMENT_MAIN_MEMORY, dest_offset, context, copy_size, wcopy_large_offset, kexit_info, new_dest_offset, offset, extra_size)
+        (src_ctx, segment, offset, @SEGMENT_MAIN_MEMORY, dest_offset, context, copy_size, codecopy_large_offset, copy_size, src_ctx, kexit_info, new_dest_offset, offset, extra_size)
     %build_address
     SWAP3 %build_address
-    // stack: DST, SRC, copy_size, wcopy_large_offset, kexit_info, new_dest_offset, offset, extra_size
+    // stack: DST, SRC, copy_size, codecopy_large_offset, copy_size, src_ctx, kexit_info, new_dest_offset, offset, extra_size
     %jump(memcpy_bytes)
+%endmacro
+
+// Adds pruned_ctx to the list of pruned contexts. You need to return to a previous, older context with
+// a SET_CONTEXT instruction. By assumption, pruned_ctx is greater than the current context.
+%macro prune_context
+    // stack: pruned_ctx
+    GET_CONTEXT
+    // stack: curr_ctx, pruned_ctx
+    // When we go to pruned_ctx, we want its stack to contain curr_ctx so that we can immediately
+    // call SET_CONTEXT. For that, we need a stack length of 1, and store curr_ctx in Segment::Stack[0].
+    PUSH @SEGMENT_STACK
+    DUP3 ADD
+    // stack: pruned_ctx_stack_addr, curr_ctx, pruned_ctx
+    DUP2
+    // stack: curr_ctx, pruned_ctx_stack_addr, curr_ctx, pruned_ctx
+    MSTORE_GENERAL
+    // stack: curr_ctx, pruned_ctx
+    PUSH @CTX_METADATA_STACK_SIZE
+    DUP3 ADD
+    // stack: pruned_ctx_stack_size_addr, curr_ctx, pruned_ctx
+    PUSH 1
+    MSTORE_GENERAL
+    // stack: curr_ctx, pruned_ctx
+    POP
+    SET_CONTEXT
+    // We're now in pruned_ctx, with stack: curr_ctx
+    SET_CONTEXT
+    // We're now in curr_ctx, with an empty stack.
 %endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
@@ -290,30 +290,30 @@ extcodecopy_contd:
     %jump(memcpy_bytes)
 %endmacro
 
-// Adds pruned_ctx to the list of pruned contexts. You need to return to a previous, older context with
-// a SET_CONTEXT instruction. By assumption, pruned_ctx is greater than the current context.
+// Adds stale_ctx to the list of stale contexts. You need to return to a previous, older context with
+// a SET_CONTEXT instruction. By assumption, stale_ctx is greater than the current context.
 %macro prune_context
-    // stack: pruned_ctx
+    // stack: stale_ctx
     GET_CONTEXT
-    // stack: curr_ctx, pruned_ctx
-    // When we go to pruned_ctx, we want its stack to contain curr_ctx so that we can immediately
+    // stack: curr_ctx, stale_ctx
+    // When we go to stale_ctx, we want its stack to contain curr_ctx so that we can immediately
     // call SET_CONTEXT. For that, we need a stack length of 1, and store curr_ctx in Segment::Stack[0].
     PUSH @SEGMENT_STACK
     DUP3 ADD
-    // stack: pruned_ctx_stack_addr, curr_ctx, pruned_ctx
+    // stack: stale_ctx_stack_addr, curr_ctx, stale_ctx
     DUP2
-    // stack: curr_ctx, pruned_ctx_stack_addr, curr_ctx, pruned_ctx
+    // stack: curr_ctx, stale_ctx_stack_addr, curr_ctx, stale_ctx
     MSTORE_GENERAL
-    // stack: curr_ctx, pruned_ctx
+    // stack: curr_ctx, stale_ctx
     PUSH @CTX_METADATA_STACK_SIZE
     DUP3 ADD
-    // stack: pruned_ctx_stack_size_addr, curr_ctx, pruned_ctx
+    // stack: stale_ctx_stack_size_addr, curr_ctx, stale_ctx
     PUSH 1
     MSTORE_GENERAL
-    // stack: curr_ctx, pruned_ctx
+    // stack: curr_ctx, stale_ctx
     POP
     SET_CONTEXT
-    // We're now in pruned_ctx, with stack: curr_ctx
+    // We're now in stale_ctx, with stack: curr_ctx
     SET_CONTEXT
     // We're now in curr_ctx, with an empty stack.
 %endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
@@ -172,7 +172,7 @@ codecopy_after:
     EXIT_KERNEL
 
 codecopy_no_prune:
-    // stack: src_ctx
+    // stack: src_ctx, kexit_info
     POP
     EXIT_KERNEL
 

--- a/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
@@ -178,7 +178,10 @@ fn test_extcodesize() -> Result<()> {
         HashMap::from([(keccak(&code), code.clone())]);
     interpreter.run()?;
 
-    assert_eq!(interpreter.stack(), vec![code.len().into()]);
+    assert_eq!(
+        interpreter.stack(),
+        vec![U256::one() << CONTEXT_SCALING_FACTOR, code.len().into()]
+    );
 
     Ok(())
 }

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -423,9 +423,14 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
     let (tables, final_values) = timed!(
         timing,
         "convert trace data to tables",
-        state
-            .traces
-            .into_tables(all_stark, &memory_before, trace_lengths, config, timing)
+        state.traces.into_tables(
+            all_stark,
+            &memory_before,
+            state.pruned_contexts,
+            trace_lengths,
+            config,
+            timing
+        )
     );
     Ok((tables, public_values, final_values))
 }

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -426,7 +426,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         state.traces.into_tables(
             all_stark,
             &memory_before,
-            state.pruned_contexts,
+            state.stale_contexts,
             trace_lengths,
             config,
             timing

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -214,7 +214,7 @@ pub(crate) trait State<F: Field> {
                     }
                     let final_mem = if let Some(mut mem) = self.get_full_memory() {
                         // Clear memory we will not use again.
-                        for &ctx in &self.get_generation_state().pruned_contexts {
+                        for &ctx in &self.get_generation_state().stale_contexts {
                             mem.contexts[ctx] = MemoryContextState::default();
                         }
                         Some(mem)
@@ -336,7 +336,7 @@ pub struct GenerationState<F: Field> {
 
     /// Memory used by stale contexts can be pruned so proving segments can be
     /// smaller.
-    pub(crate) pruned_contexts: Vec<usize>,
+    pub(crate) stale_contexts: Vec<usize>,
 
     /// Prover inputs containing RLP data, in reverse order so that the next
     /// input can be obtained via `pop()`.
@@ -387,7 +387,7 @@ impl<F: Field> GenerationState<F> {
             registers: Default::default(),
             memory: MemoryState::new(kernel_code),
             traces: Traces::default(),
-            pruned_contexts: Vec::new(),
+            stale_contexts: Vec::new(),
             rlp_prover_inputs,
             withdrawal_prover_inputs,
             state_key_to_address: HashMap::new(),
@@ -475,7 +475,7 @@ impl<F: Field> GenerationState<F> {
             registers: self.registers,
             memory: self.memory.clone(),
             traces: Traces::default(),
-            pruned_contexts: Vec::new(),
+            stale_contexts: Vec::new(),
             rlp_prover_inputs: self.rlp_prover_inputs.clone(),
             state_key_to_address: self.state_key_to_address.clone(),
             bignum_modmul_result_limbs: self.bignum_modmul_result_limbs.clone(),

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -213,6 +213,7 @@ pub(crate) trait State<F: Field> {
                         assert_eq!(self.get_clock() - final_clock, NUM_EXTRA_CYCLES_AFTER - 1);
                     }
                     let final_mem = if let Some(mut mem) = self.get_full_memory() {
+                        // Clear memory we will not use again.
                         for &ctx in &self.get_generation_state().pruned_contexts {
                             mem.contexts[ctx] = MemoryContextState::default();
                         }
@@ -333,7 +334,8 @@ pub struct GenerationState<F: Field> {
     pub(crate) memory: MemoryState,
     pub(crate) traces: Traces<F>,
 
-    /// Stale contexts you can prune from memory.
+    /// Memory used by stale contexts can be pruned so proving segments can be
+    /// smaller.
     pub(crate) pruned_contexts: Vec<usize>,
 
     /// Prover inputs containing RLP data, in reverse order so that the next

--- a/evm_arithmetization/src/memory/columns.rs
+++ b/evm_arithmetization/src/memory/columns.rs
@@ -42,8 +42,25 @@ pub(crate) const VIRTUAL_FIRST_CHANGE: usize = SEGMENT_FIRST_CHANGE + 1;
 // Contains `next_segment * addr_changed * next_is_read`.
 pub(crate) const INITIALIZE_AUX: usize = VIRTUAL_FIRST_CHANGE + 1;
 
+// Contains the list of pruned contexts. Each pruned context must appear exactly
+// once; unused rows are set to zero.
+pub(crate) const PRUNED_CONTEXTS: usize = INITIALIZE_AUX + 1;
+
+// Inverse of `PRUNED_CONTEXTS`.Used to ascertain it's nonzero.
+pub(crate) const PRUNED_CONTEXTS_INV: usize = PRUNED_CONTEXTS + 1;
+
+// Used for the context pruning lookup.
+pub(crate) const PRUNED_CONTEXTS_FREQUENCIES: usize = PRUNED_CONTEXTS_INV + 1;
+
+// Flag indicating whether the row should be pruned, i.e. whether its
+// `ADDR_CONTEXT` is in `PRUNED_CONTEXTS`.
+pub(crate) const IS_PRUNED: usize = PRUNED_CONTEXTS_FREQUENCIES + 1;
+
+// Filter for the `MemAfter` CTL.
+pub(crate) const MEM_AFTER_FILTER: usize = IS_PRUNED + 1;
+
 // We use a range check to enforce the ordering.
-pub(crate) const RANGE_CHECK: usize = INITIALIZE_AUX + 1;
+pub(crate) const RANGE_CHECK: usize = MEM_AFTER_FILTER + 1;
 /// The counter column (used for the range check) starts from 0 and increments.
 pub(crate) const COUNTER: usize = RANGE_CHECK + 1;
 /// The frequencies column used in logUp.

--- a/evm_arithmetization/src/memory/columns.rs
+++ b/evm_arithmetization/src/memory/columns.rs
@@ -42,22 +42,22 @@ pub(crate) const VIRTUAL_FIRST_CHANGE: usize = SEGMENT_FIRST_CHANGE + 1;
 // Contains `next_segment * addr_changed * next_is_read`.
 pub(crate) const INITIALIZE_AUX: usize = VIRTUAL_FIRST_CHANGE + 1;
 
-// Contains `row_index` if and only if context `row_index` must be pruned,
+// Contains `row_index` if and only if context `row_index` is stale,
 // and zero if not.
-pub(crate) const PRUNED_CONTEXTS: usize = INITIALIZE_AUX + 1;
+pub(crate) const STALE_CONTEXTS: usize = INITIALIZE_AUX + 1;
 
-// Pseudo-inverse of `PRUNED_CONTEXTS`. Used to ascertain it's nonzero.
-pub(crate) const PRUNED_CONTEXTS_INV: usize = PRUNED_CONTEXTS + 1;
+// Pseudo-inverse of `STALE_CONTEXTS`. Used to ascertain it's nonzero.
+pub(crate) const STALE_CONTEXTS_INV: usize = STALE_CONTEXTS + 1;
 
 // Used for the context pruning lookup.
-pub(crate) const PRUNED_CONTEXTS_FREQUENCIES: usize = PRUNED_CONTEXTS_INV + 1;
+pub(crate) const STALE_CONTEXTS_FREQUENCIES: usize = STALE_CONTEXTS_INV + 1;
 
 // Flag indicating whether the row should be pruned, i.e. whether its
-// `ADDR_CONTEXT` is in `PRUNED_CONTEXTS`.
-pub(crate) const IS_PRUNED: usize = PRUNED_CONTEXTS_FREQUENCIES + 1;
+// `ADDR_CONTEXT` is in `STALE_CONTEXTS`.
+pub(crate) const IS_STALE: usize = STALE_CONTEXTS_FREQUENCIES + 1;
 
 // Filter for the `MemAfter` CTL.
-pub(crate) const MEM_AFTER_FILTER: usize = IS_PRUNED + 1;
+pub(crate) const MEM_AFTER_FILTER: usize = IS_STALE + 1;
 
 // We use a range check to enforce the ordering.
 pub(crate) const RANGE_CHECK: usize = MEM_AFTER_FILTER + 1;

--- a/evm_arithmetization/src/memory/columns.rs
+++ b/evm_arithmetization/src/memory/columns.rs
@@ -42,11 +42,11 @@ pub(crate) const VIRTUAL_FIRST_CHANGE: usize = SEGMENT_FIRST_CHANGE + 1;
 // Contains `next_segment * addr_changed * next_is_read`.
 pub(crate) const INITIALIZE_AUX: usize = VIRTUAL_FIRST_CHANGE + 1;
 
-// Contains the list of pruned contexts. Each pruned context must appear exactly
-// once; unused rows are set to zero.
+// Contains `row_index` if and only if context `row_index` must be pruned,
+// and zero if not.
 pub(crate) const PRUNED_CONTEXTS: usize = INITIALIZE_AUX + 1;
 
-// Inverse of `PRUNED_CONTEXTS`.Used to ascertain it's nonzero.
+// Pseudo-inverse of `PRUNED_CONTEXTS`. Used to ascertain it's nonzero.
 pub(crate) const PRUNED_CONTEXTS_INV: usize = PRUNED_CONTEXTS + 1;
 
 // Used for the context pruning lookup.

--- a/evm_arithmetization/src/memory/memory_stark.rs
+++ b/evm_arithmetization/src/memory/memory_stark.rs
@@ -249,15 +249,13 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
             {
                 trace_col_vecs[IS_PRUNED][i] = F::ONE;
                 trace_col_vecs[PRUNED_CONTEXTS_FREQUENCIES][addr_ctx_usize] += F::ONE;
-            } else {
-                if trace_col_vecs[FILTER][i].is_one()
-                    && (trace_col_vecs[CONTEXT_FIRST_CHANGE][i].is_one()
-                        || trace_col_vecs[SEGMENT_FIRST_CHANGE][i].is_one()
-                        || trace_col_vecs[VIRTUAL_FIRST_CHANGE][i].is_one())
-                {
-                    // `mem_after_filter = filter * address_changed * (1 - pruned)`
-                    trace_col_vecs[MEM_AFTER_FILTER][i] = F::ONE;
-                }
+            } else if trace_col_vecs[FILTER][i].is_one()
+                && (trace_col_vecs[CONTEXT_FIRST_CHANGE][i].is_one()
+                    || trace_col_vecs[SEGMENT_FIRST_CHANGE][i].is_one()
+                    || trace_col_vecs[VIRTUAL_FIRST_CHANGE][i].is_one())
+            {
+                // `mem_after_filter = filter * address_changed * (1 - pruned)`
+                trace_col_vecs[MEM_AFTER_FILTER][i] = F::ONE;
             }
         }
     }
@@ -347,7 +345,7 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
         }
     }
 
-    fn insert_pruned_contexts(trace_rows: &mut Vec<[F; NUM_COLUMNS]>, pruned_contexts: Vec<usize>) {
+    fn insert_pruned_contexts(trace_rows: &mut [[F; NUM_COLUMNS]], pruned_contexts: Vec<usize>) {
         let mut dedup_vec = pruned_contexts.clone();
         dedup_vec.sort();
         dedup_vec.dedup();

--- a/evm_arithmetization/src/memory/memory_stark.rs
+++ b/evm_arithmetization/src/memory/memory_stark.rs
@@ -223,6 +223,8 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
 
     /// Generates the `COUNTER`, `RANGE_CHECK` and `FREQUENCIES` columns, given
     /// a trace in column-major form.
+    /// Also generates the `IS_PRUNED`, `PRUNED_CONTEXT_FREQUENCIES` and
+    /// `MEM_AFTER_FILTER` columns.
     fn generate_trace_col_major(trace_col_vecs: &mut [Vec<F>], pruned_contexts: Vec<usize>) {
         let height = trace_col_vecs[0].len();
         trace_col_vecs[COUNTER] = (0..height).map(|i| F::from_canonical_usize(i)).collect();

--- a/evm_arithmetization/src/memory/memory_stark.rs
+++ b/evm_arithmetization/src/memory/memory_stark.rs
@@ -13,16 +13,20 @@ use plonky2::util::timing::TimingTree;
 use plonky2::util::transpose;
 use plonky2_maybe_rayon::*;
 use starky::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
+use starky::cross_table_lookup::TableWithColumns;
 use starky::evaluation_frame::StarkEvaluationFrame;
 use starky::lookup::{Column, Filter, Lookup};
 use starky::stark::Stark;
 
+use super::columns::{
+    MEM_AFTER_FILTER, PRUNED_CONTEXTS, PRUNED_CONTEXTS_FREQUENCIES, PRUNED_CONTEXTS_INV,
+};
 use super::segments::Segment;
-use crate::all_stark::EvmStarkFrame;
+use crate::all_stark::{EvmStarkFrame, Table};
 use crate::memory::columns::{
     value_limb, ADDR_CONTEXT, ADDR_SEGMENT, ADDR_VIRTUAL, CONTEXT_FIRST_CHANGE, COUNTER, FILTER,
-    FREQUENCIES, INITIALIZE_AUX, IS_READ, NUM_COLUMNS, RANGE_CHECK, SEGMENT_FIRST_CHANGE,
-    TIMESTAMP, TIMESTAMP_INV, VIRTUAL_FIRST_CHANGE,
+    FREQUENCIES, INITIALIZE_AUX, IS_PRUNED, IS_READ, NUM_COLUMNS, RANGE_CHECK,
+    SEGMENT_FIRST_CHANGE, TIMESTAMP, TIMESTAMP_INV, VIRTUAL_FIRST_CHANGE,
 };
 use crate::memory::VALUE_LIMBS;
 use crate::witness::memory::MemoryOpKind::Read;
@@ -55,6 +59,21 @@ pub(crate) fn ctl_looking_mem<F: Field>() -> Vec<Column<F>> {
     res
 }
 
+/// Returns the (non-zero) pruned contexts.
+pub(crate) fn ctl_context_pruning_looking<F: Field>() -> TableWithColumns<F> {
+    TableWithColumns::new(
+        *Table::Memory,
+        vec![Column::single(PRUNED_CONTEXTS)],
+        Some(Filter::new(
+            vec![(
+                Column::single(PRUNED_CONTEXTS),
+                Column::single(PRUNED_CONTEXTS_INV),
+            )],
+            vec![],
+        )),
+    )
+}
+
 /// CTL filter for initialization writes.
 /// Initialization operations have timestamp 0.
 /// The filter is `1 - timestamp * timestamp_inv`.
@@ -72,17 +91,7 @@ pub(crate) fn ctl_filter_mem_before<F: Field>() -> Filter<F> {
 /// Final values are the last row with a given address.
 /// The filter is `address_changed`.
 pub(crate) fn ctl_filter_mem_after<F: Field>() -> Filter<F> {
-    Filter::new(
-        vec![(
-            Column::single(FILTER),
-            Column::sum([
-                CONTEXT_FIRST_CHANGE,
-                SEGMENT_FIRST_CHANGE,
-                VIRTUAL_FIRST_CHANGE,
-            ]),
-        )],
-        vec![],
-    )
+    Filter::new_simple(Column::single(MEM_AFTER_FILTER))
 }
 
 #[derive(Copy, Clone, Default)]
@@ -214,7 +223,7 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
 
     /// Generates the `COUNTER`, `RANGE_CHECK` and `FREQUENCIES` columns, given
     /// a trace in column-major form.
-    fn generate_trace_col_major(trace_col_vecs: &mut [Vec<F>]) {
+    fn generate_trace_col_major(trace_col_vecs: &mut [Vec<F>], pruned_contexts: Vec<usize>) {
         let height = trace_col_vecs[0].len();
         trace_col_vecs[COUNTER] = (0..height).map(|i| F::from_canonical_usize(i)).collect();
 
@@ -231,6 +240,23 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
                     trace_col_vecs[FREQUENCIES][x_val] += F::ONE;
                 } else {
                     trace_col_vecs[FREQUENCIES][0] += F::ONE;
+                }
+            }
+
+            let addr_ctx = trace_col_vecs[ADDR_CONTEXT][i];
+            let addr_ctx_usize = addr_ctx.to_canonical_u64() as usize;
+            if addr_ctx.is_nonzero() && addr_ctx == trace_col_vecs[PRUNED_CONTEXTS][addr_ctx_usize]
+            {
+                trace_col_vecs[IS_PRUNED][i] = F::ONE;
+                trace_col_vecs[PRUNED_CONTEXTS_FREQUENCIES][addr_ctx_usize] += F::ONE;
+            } else {
+                if trace_col_vecs[FILTER][i].is_one()
+                    && (trace_col_vecs[CONTEXT_FIRST_CHANGE][i].is_one()
+                        || trace_col_vecs[SEGMENT_FIRST_CHANGE][i].is_one()
+                        || trace_col_vecs[VIRTUAL_FIRST_CHANGE][i].is_one())
+                {
+                    // `mem_after_filter = filter * address_changed * (1 - pruned)`
+                    trace_col_vecs[MEM_AFTER_FILTER][i] = F::ONE;
                 }
             }
         }
@@ -299,6 +325,8 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
         // desired size, with a few changes:
         // - We change its filter to 0 to indicate that this is a dummy operation.
         // - We make sure it's a read, since dummy operations must be reads.
+        // - We change the address so that the last operation can still be included in
+        //   `MemAfterStark`.
         let padding_addr = MemoryAddress {
             virt: last_op.address.virt + 1,
             ..last_op.address
@@ -311,9 +339,29 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
             value: U256::zero(),
         };
         let num_ops = memory_ops.len();
-        let num_ops_padded = num_ops.next_power_of_two();
+        // We want at least one padded row, so that the last real operation can have its
+        // flags set correctly.
+        let num_ops_padded = (num_ops + 1).next_power_of_two();
         for _ in num_ops..num_ops_padded {
             memory_ops.push(padding_op);
+        }
+    }
+
+    fn insert_pruned_contexts(trace_rows: &mut Vec<[F; NUM_COLUMNS]>, pruned_contexts: Vec<usize>) {
+        let mut dedup_vec = pruned_contexts.clone();
+        dedup_vec.sort();
+        dedup_vec.dedup();
+
+        assert!(
+            dedup_vec.len() == pruned_contexts.len(),
+            "Pruned contexts are not unique.",
+        );
+
+        for ctx in pruned_contexts {
+            assert!(ctx != 0, "Context 0 cannot be pruned.");
+            let ctx_field = F::from_canonical_usize(ctx);
+            trace_rows[ctx][PRUNED_CONTEXTS] = ctx_field;
+            trace_rows[ctx][PRUNED_CONTEXTS_INV] = ctx_field.inverse();
         }
     }
 
@@ -321,6 +369,7 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
         &self,
         mut memory_ops: Vec<MemoryOp>,
         mem_before_values: &[(MemoryAddress, U256)],
+        pruned_contexts: Vec<usize>,
         timing: &mut TimingTree,
     ) -> (Vec<PolynomialValues<F>>, Vec<Vec<F>>, usize) {
         // First, push `mem_before` operations.
@@ -334,41 +383,32 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
             });
         }
         // Generate most of the trace in row-major form.
-        let (trace_rows, unpadded_length) = timed!(
+        let (mut trace_rows, unpadded_length) = timed!(
             timing,
             "generate trace rows",
             self.generate_trace_row_major(memory_ops)
         );
-        // Extract final values for `MemoryAfterStark`.
-        let mut final_values = Vec::<Vec<_>>::new();
-        let trace_row_vecs: Vec<_> = trace_rows
-            .into_iter()
-            .map(|row| {
-                if row[CONTEXT_FIRST_CHANGE] + row[SEGMENT_FIRST_CHANGE] + row[VIRTUAL_FIRST_CHANGE]
-                    == F::ONE
-                    && row[FILTER].is_one()
-                {
-                    let mut addr_val = vec![F::ONE];
-                    addr_val.extend(&row[ADDR_CONTEXT..CONTEXT_FIRST_CHANGE]);
-                    final_values.push(addr_val);
-                }
-                row.to_vec()
-            })
-            .collect();
+
+        Self::insert_pruned_contexts(&mut trace_rows, pruned_contexts.clone());
+
+        let trace_row_vecs: Vec<_> = trace_rows.into_iter().map(|row| row.to_vec()).collect();
 
         // Transpose to column-major form.
         let mut trace_col_vecs = transpose(&trace_row_vecs);
 
         // A few final generation steps, which work better in column-major form.
-        Self::generate_trace_col_major(&mut trace_col_vecs);
+        Self::generate_trace_col_major(&mut trace_col_vecs, pruned_contexts);
 
         let final_rows = transpose(&trace_col_vecs);
 
-        for row in 0..final_rows.len() - 1 {
-            let next_addr_context = final_rows[row + 1][ADDR_CONTEXT];
-            let initialize_aux = final_rows[row][INITIALIZE_AUX];
-            let next_values_limbs: Vec<_> =
-                (0..8).map(|i| final_rows[row + 1][value_limb(i)]).collect();
+        // Extract `MemoryAfterStark` values.
+        let mut mem_after_values = Vec::<Vec<_>>::new();
+        for row in final_rows {
+            if row[MEM_AFTER_FILTER].is_one() {
+                let mut addr_val = vec![F::ONE];
+                addr_val.extend(&row[ADDR_CONTEXT..CONTEXT_FIRST_CHANGE]);
+                mem_after_values.push(addr_val);
+            }
         }
 
         (
@@ -376,7 +416,7 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
                 .into_iter()
                 .map(|column| PolynomialValues::new(column))
                 .collect(),
-            final_values,
+            mem_after_values,
             unpadded_length,
         )
     }
@@ -497,6 +537,14 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for MemoryStark<F
                     * next_values_limbs[i],
             );
         }
+
+        // Validate `mem_after_filter`. Its value is `filter * address_changed * (1 -
+        // is_pruned)`
+        let mem_after_filter = local_values[MEM_AFTER_FILTER];
+        let is_pruned = local_values[IS_PRUNED];
+        yield_constr.constraint_transition(
+            mem_after_filter + filter * not_address_unchanged * (is_pruned - P::ONES),
+        );
 
         // Validate timestamp_inv. Since it's used as a CTL filter, its value must be
         // checked.
@@ -670,6 +718,17 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for MemoryStark<F
             yield_constr.constraint_transition(builder, zero_init_constraint);
         }
 
+        // Validate `mem_after_filter`. Its value is `filter * address_changed * (1 -
+        // is_pruned)`
+        let mem_after_filter = local_values[MEM_AFTER_FILTER];
+        let is_pruned = local_values[IS_PRUNED];
+        {
+            let rhs = builder.mul_extension(filter, not_address_unchanged);
+            let rhs = builder.mul_sub_extension(rhs, is_pruned, rhs);
+            let constr = builder.add_extension(mem_after_filter, rhs);
+            yield_constr.constraint_transition(builder, constr);
+        }
+
         // Validate timestamp_inv. Since it's used as a CTL filter, its value must be
         // checked.
         let timestamp_inv = local_values[TIMESTAMP_INV];
@@ -693,21 +752,29 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for MemoryStark<F
     }
 
     fn lookups(&self) -> Vec<Lookup<F>> {
-        vec![Lookup {
-            columns: vec![
-                Column::single(RANGE_CHECK),
-                Column::single_next_row(ADDR_VIRTUAL),
-            ],
-            table_column: Column::single(COUNTER),
-            frequencies_column: Column::single(FREQUENCIES),
-            filter_columns: vec![
-                None,
-                Some(Filter::new_simple(Column::sum([
-                    CONTEXT_FIRST_CHANGE,
-                    SEGMENT_FIRST_CHANGE,
-                ]))),
-            ],
-        }]
+        vec![
+            Lookup {
+                columns: vec![
+                    Column::single(RANGE_CHECK),
+                    Column::single_next_row(ADDR_VIRTUAL),
+                ],
+                table_column: Column::single(COUNTER),
+                frequencies_column: Column::single(FREQUENCIES),
+                filter_columns: vec![
+                    None,
+                    Some(Filter::new_simple(Column::sum([
+                        CONTEXT_FIRST_CHANGE,
+                        SEGMENT_FIRST_CHANGE,
+                    ]))),
+                ],
+            },
+            Lookup {
+                columns: vec![Column::single(ADDR_CONTEXT)],
+                table_column: Column::single(PRUNED_CONTEXTS),
+                frequencies_column: Column::single(PRUNED_CONTEXTS_FREQUENCIES),
+                filter_columns: vec![Some(Filter::new_simple(Column::single(IS_PRUNED)))],
+            },
+        ]
     }
 
     fn requires_ctls(&self) -> bool {

--- a/evm_arithmetization/src/memory/memory_stark.rs
+++ b/evm_arithmetization/src/memory/memory_stark.rs
@@ -348,12 +348,13 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
     }
 
     fn insert_pruned_contexts(trace_rows: &mut [[F; NUM_COLUMNS]], pruned_contexts: Vec<usize>) {
-        let mut dedup_vec = pruned_contexts.clone();
-        dedup_vec.sort();
-        dedup_vec.dedup();
-
-        assert!(
-            dedup_vec.len() == pruned_contexts.len(),
+        debug_assert!(
+            {
+                let mut dedup_vec = pruned_contexts.clone();
+                dedup_vec.sort();
+                dedup_vec.dedup();
+                dedup_vec.len() == pruned_contexts.len()
+            },
             "Pruned contexts are not unique.",
         );
 

--- a/evm_arithmetization/src/witness/operation.rs
+++ b/evm_arithmetization/src/witness/operation.rs
@@ -339,6 +339,11 @@ pub(crate) fn generate_set_context<F: Field, T: Transition<F>>(
         None
     };
 
+    if new_ctx < old_ctx {
+        row.general.context_pruning_mut().pruning_flag = F::ONE;
+        generation_state.pruned_contexts.push(old_ctx);
+    }
+
     generation_state.registers.context = new_ctx;
     generation_state.registers.stack_len = new_sp;
     if let Some(mem_op) = log_read_new_top {
@@ -346,6 +351,11 @@ pub(crate) fn generate_set_context<F: Field, T: Transition<F>>(
     }
     state.push_memory(log_write_old_sp);
     state.push_memory(log_read_new_sp);
+    state.push_arithmetic(arithmetic::Operation::binary(
+        BinaryOperator::Lt,
+        new_ctx.into(),
+        old_ctx.into(),
+    ));
     state.push_cpu(row);
 
     Ok(())

--- a/evm_arithmetization/src/witness/operation.rs
+++ b/evm_arithmetization/src/witness/operation.rs
@@ -341,7 +341,7 @@ pub(crate) fn generate_set_context<F: Field, T: Transition<F>>(
 
     if new_ctx < old_ctx {
         row.general.context_pruning_mut().pruning_flag = F::ONE;
-        generation_state.pruned_contexts.push(old_ctx);
+        generation_state.stale_contexts.push(old_ctx);
     }
 
     generation_state.registers.context = new_ctx;

--- a/evm_arithmetization/src/witness/traces.rs
+++ b/evm_arithmetization/src/witness/traces.rs
@@ -124,6 +124,7 @@ impl<T: Copy> Traces<T> {
         self,
         all_stark: &AllStark<T, D>,
         mem_before_values: &MemBeforeValues,
+        pruned_contexts: Vec<usize>,
         mut trace_lengths: TraceCheckpoint,
         config: &StarkConfig,
         timing: &mut TimingTree,
@@ -180,9 +181,12 @@ impl<T: Copy> Traces<T> {
         let (memory_trace, final_values, unpadded_memory_length) = timed!(
             timing,
             "generate memory trace",
-            all_stark
-                .memory_stark
-                .generate_trace(memory_ops, mem_before_values, timing)
+            all_stark.memory_stark.generate_trace(
+                memory_ops,
+                mem_before_values,
+                pruned_contexts,
+                timing
+            )
         );
         trace_lengths.memory_len = unpadded_memory_length;
 

--- a/evm_arithmetization/src/witness/traces.rs
+++ b/evm_arithmetization/src/witness/traces.rs
@@ -124,7 +124,7 @@ impl<T: Copy> Traces<T> {
         self,
         all_stark: &AllStark<T, D>,
         mem_before_values: &MemBeforeValues,
-        pruned_contexts: Vec<usize>,
+        stale_contexts: Vec<usize>,
         mut trace_lengths: TraceCheckpoint,
         config: &StarkConfig,
         timing: &mut TimingTree,
@@ -184,7 +184,7 @@ impl<T: Copy> Traces<T> {
             all_stark.memory_stark.generate_trace(
                 memory_ops,
                 mem_before_values,
-                pruned_contexts,
+                stale_contexts,
                 timing
             )
         );


### PR DESCRIPTION
Implements the pruning of stale contexts. A context is stale when it returns to its parent context; after it returns, it can never be accessed again and can be omitted from the memory of subsequent segments.

To detect when a context goes stale, we instrument `SET_CONTEXT`, and check if `new_ctx < old_ctx`. Since contexts are attributed in a strictly increasing order, this means that `new_ctx` is the parent context of `old_ctx`, and thus that `old_ctx` is stale.

This check is made in the `CPU` table. All the stale `old_ctx` values are then transmitted to the `Memory` table via a CTL.
In `Memory`, for each row, we check if `ADDR_CONTEXT` is contained in the `PRUNED_CONTEXTS` column via a lookup. If that's the case, it will be omitted from the CTL to `MemAfter`.

~~This PR contains #109 and #111. These are required fixes which aren't merged upstream yet. It's opened as a draft so people can look at it and run the test suite on it if they wish, but will wait for these PRs to be merged before opening it in earnest.~~
Edit: Done.

Closes #24 