### PR TITLE
Bumped all sub-crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-03-19
+
 ### Changed
 - Clean up logging output upon Kernel failure ([#74](https://github.com/0xPolygonZero/zk_evm/pull/74))
 - Fix CPU Cycle display in logs during simulations ([#77](https://github.com/0xPolygonZero/zk_evm/pull/77))

--- a/evm_arithmetization/Cargo.toml
+++ b/evm_arithmetization/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "evm_arithmetization"
 description = "Implementation of STARKs for the Ethereum Virtual Machine"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Daniel Lubarov <daniel@lubarov.com>", "William Borgeaud <williamborgeaud@gmail.com>"]
 readme = "README.md"
 categories = ["cryptography"]
@@ -41,7 +41,7 @@ tiny-keccak = "2.0.2"
 serde_json = { workspace = true }
 
 # Local dependencies
-mpt_trie = { version = "0.1.1", path = "../mpt_trie" }
+mpt_trie = { version = "0.2.0", path = "../mpt_trie" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.5.0"

--- a/mpt_trie/Cargo.toml
+++ b/mpt_trie/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mpt_trie"
 description = "Types and utility functions for building/working with partial Ethereum tries."
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Polygon Zero <bgluth@polygon.technology>"]
 readme = "README.md"
 edition.workspace = true

--- a/proof_gen/Cargo.toml
+++ b/proof_gen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proof_gen"
 description = "Generates block proofs from zero proof IR."
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Polygon Zero <bgluth@polygon.technology>"]
 edition.workspace = true
 license.workspace = true
@@ -17,5 +17,5 @@ plonky2 = { workspace = true }
 serde = { workspace = true }
 
 # Local dependencies
-trace_decoder = { version = "0.1.1", path = "../trace_decoder" }
-evm_arithmetization = { version = "0.1.1", path = "../evm_arithmetization" }
+trace_decoder = { version = "0.2.0", path = "../trace_decoder" }
+evm_arithmetization = { version = "0.1.2", path = "../evm_arithmetization" }

--- a/trace_decoder/Cargo.toml
+++ b/trace_decoder/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trace_decoder"
 description = "Processes trace payloads into Intermediate Representation (IR) format."
 authors = ["Polygon Zero <bgluth@polygon.technology>"]
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -27,8 +27,8 @@ serde_with = "3.4.0"
 thiserror = { workspace = true }
 
 # Local dependencies
-mpt_trie = { version = "0.1.1", path = "../mpt_trie" }
-evm_arithmetization = { version = "0.1.1", path = "../evm_arithmetization" }
+mpt_trie = { version = "0.2.0", path = "../mpt_trie" }
+evm_arithmetization = { version = "0.1.2", path = "../evm_arithmetization" }
 
 [dev-dependencies]
 pretty_env_logger = "0.5.0"


### PR DESCRIPTION
Preparation to do a release for all sub-crates.

Initially I was thinking that we could get away with only bumping individual crates as changes are made to them, but since the crates refer to each other with `{ version = "..." path = "..." }`, I think this forces us to always bump all crate versions together.

Also, you might notice that two crates moved to `0.2.0` instead of `0.1.2`. The reason for this is I'm trying very hard to follow [SemVer](https://semver.org/). I'm using a cargo tool called [cargo-semver-checks)](https://crates.io/crates/cargo-semver-checks), and it's showing that I changed some public facing functions and therefore requires a `minor` version bump. This doesn't apply to the two other crates, so I instead just bumped their `patch` versions. Also this is a bit of an aside, but what should the version of the repo release?

And just as a sanity check, does specifying `version` with `path` give us anything? It's forcing all deps to be updated together when we make a change in just one.