### PR TITLE
Charge gas before SLOAD and refactor `insert_accessed_storage_keys`

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
@@ -325,11 +325,11 @@ insert_storage_key:
     DUP1
     // stack: new_next_ptr, new_next_ptr, value_ptr, next_ptr, addr, key, retdest
     SWAP3
-    // stack: next_ptr, new_next_ptr, value_ptr, next_ptr, addr, key, retdest
+    // stack: next_ptr, new_next_ptr, value_ptr, new_next_ptr, addr, key, retdest
     MSTORE_GENERAL
-    // stack: value_ptr, next_ptr, addr, key, retdest
+    // stack: value_ptr, new_next_ptr, addr, key, retdest
     SWAP1
-    // stack: next_ptr, value_ptr, addr, key, retdest
+    // stack: new_next_ptr, value_ptr, addr, key, retdest
     %increment
     %mstore_global_metadata(@GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN)
     // stack: value_ptr, addr, key, retdest

--- a/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
@@ -220,7 +220,7 @@ global remove_accessed_addresses:
 
 /// Inserts the storage key into the access list if it is not already present.
 /// Return `1, value_ptr` if the storage key was inserted, `0, value_ptr` if it was already present.
-/// Callers to this function must ensure the current storage value is stored at `value_ptr`.
+/// Callers to this function must ensure the original storage value is stored at `value_ptr`.
 global insert_accessed_storage_keys:
     // stack: addr, key, retdest
     PROVER_INPUT(access_lists::storage_insert)

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/storage/storage_read.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/storage/storage_read.asm
@@ -39,18 +39,18 @@ global sys_sload:
     SWAP1
     DUP1
     // stack: slot, slot, kexit_info
-    %sload_current
-
-    %stack (value, slot, kexit_info) -> (slot, value, kexit_info, value)
     %address
-    // stack: addr, slot, value, kexit_info, value
+    // stack: address, slot, slot, kexit_info
     %insert_accessed_storage_keys
-    // stack: cold_access, old_value, kexit_info, value
-    SWAP1 POP
-    // stack: cold_access, kexit_info, value
+    // stack: cold_access, value_ptr, slot, kexit_info
     %mul_const(@GAS_COLDSLOAD_MINUS_WARMACCESS)
     %add_const(@GAS_WARMACCESS)
+    %stack (gas, value_ptr, slot, kexit_info) -> (gas, kexit_info, value_ptr, slot)
     %charge_gas
+
+    %stack (kexit_info, value_ptr, slot) -> (slot, value_ptr, kexit_info)
+    %sload_current
+    %stack (value, value_ptr, kexit_info) -> (value, value_ptr, kexit_info, value)
+    MSTORE_GENERAL
     // stack: kexit_info, value
     EXIT_KERNEL
-

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/storage/storage_read.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/storage/storage_read.asm
@@ -43,14 +43,24 @@ global sys_sload:
     // stack: address, slot, slot, kexit_info
     %insert_accessed_storage_keys
     // stack: cold_access, value_ptr, slot, kexit_info
+    DUP1
     %mul_const(@GAS_COLDSLOAD_MINUS_WARMACCESS)
     %add_const(@GAS_WARMACCESS)
-    %stack (gas, value_ptr, slot, kexit_info) -> (gas, kexit_info, value_ptr, slot)
+    %stack (gas, cold_access, value_ptr, slot, kexit_info) -> (gas, kexit_info, cold_access, value_ptr, slot)
     %charge_gas
 
-    %stack (kexit_info, value_ptr, slot) -> (slot, value_ptr, kexit_info)
+    %stack (kexit_info, cold_access, value_ptr, slot) -> (slot, cold_access, value_ptr, kexit_info)
     %sload_current
+    // stack: value, cold_access, value_ptr, kexit_info
+    SWAP1 %jumpi(sload_cold_access)
+    %stack (value, value_ptr, kexit_info) -> (kexit_info, value)
+    %jump(sload_end)
+
+sload_cold_access:
+    // stack: value, value_ptr, kexit_info
     %stack (value, value_ptr, kexit_info) -> (value, value_ptr, kexit_info, value)
     MSTORE_GENERAL
+
+sload_end:
     // stack: kexit_info, value
     EXIT_KERNEL

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/storage/storage_read.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/storage/storage_read.asm
@@ -54,13 +54,10 @@ global sys_sload:
     // stack: value, cold_access, value_ptr, kexit_info
     SWAP1 %jumpi(sload_cold_access)
     %stack (value, value_ptr, kexit_info) -> (kexit_info, value)
-    %jump(sload_end)
+    EXIT_KERNEL
 
 sload_cold_access:
     // stack: value, value_ptr, kexit_info
     %stack (value, value_ptr, kexit_info) -> (value, value_ptr, kexit_info, value)
     MSTORE_GENERAL
-
-sload_end:
-    // stack: kexit_info, value
     EXIT_KERNEL

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/storage/storage_write.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/storage/storage_write.asm
@@ -18,7 +18,7 @@ global sys_sstore:
     // stack: original_value, current_value, kexit_info, slot, value
     PUSH 0
     // stack: gas, original_value, current_value, kexit_info, slot, value
-    %jump(sstore_after_cold_access)
+    %jump(sstore_after_cold_access_check)
 
 sstore_cold_access:
     // stack: value_ptr, current_value, kexit_info, slot, value
@@ -28,7 +28,7 @@ sstore_cold_access:
     PUSH @GAS_COLDSLOAD
     // stack: gas, original_value, current_value, kexit_info, slot, value
 
-sstore_after_cold_access:
+sstore_after_cold_access_check:
     // Check for warm access.
     %stack (gas, original_value, current_value, kexit_info, slot, value) ->
         (value, current_value, current_value, original_value, gas, original_value, current_value, kexit_info, slot, value)

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/storage/storage_write.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/storage/storage_write.asm
@@ -9,8 +9,12 @@ global sys_sstore:
     %stack (kexit_info, slot, value) -> (slot, kexit_info, slot, value)
     %sload_current
     %address
-    %stack (addr, current_value, kexit_info, slot, value) -> (addr, slot, current_value, current_value, kexit_info, slot, value)
+    %stack (addr, current_value, kexit_info, slot, value) -> (addr, slot, current_value, kexit_info, slot, value)
     %insert_accessed_storage_keys
+    // stack: cold_access, value_ptr, current_value, kexit_info, slot, value
+    DUP2 MLOAD_GENERAL
+    %stack (original_value, cold_access, value_ptr, current_value) -> (current_value, value_ptr, cold_access, original_value, current_value)
+    MSTORE_GENERAL
     // stack: cold_access, original_value, current_value, kexit_info, slot, value
     %mul_const(@GAS_COLDSLOAD)
 

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/storage/storage_write.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/storage/storage_write.asm
@@ -12,12 +12,23 @@ global sys_sstore:
     %stack (addr, current_value, kexit_info, slot, value) -> (addr, slot, current_value, kexit_info, slot, value)
     %insert_accessed_storage_keys
     // stack: cold_access, value_ptr, current_value, kexit_info, slot, value
-    DUP2 MLOAD_GENERAL
-    %stack (original_value, cold_access, value_ptr, current_value) -> (current_value, value_ptr, cold_access, original_value, current_value)
-    MSTORE_GENERAL
-    // stack: cold_access, original_value, current_value, kexit_info, slot, value
-    %mul_const(@GAS_COLDSLOAD)
+    %jumpi(sstore_cold_access)
+    // stack: value_ptr, current_value, kexit_info, slot, value
+    MLOAD_GENERAL
+    // stack: original_value, current_value, kexit_info, slot, value
+    PUSH 0
+    // stack: gas, original_value, current_value, kexit_info, slot, value
+    %jump(sstore_after_cold_access)
 
+sstore_cold_access:
+    // stack: value_ptr, current_value, kexit_info, slot, value
+    DUP2 MSTORE_GENERAL
+    // stack: current_value, kexit_info, slot, value
+    DUP1
+    PUSH @GAS_COLDSLOAD
+    // stack: gas, original_value, current_value, kexit_info, slot, value
+
+sstore_after_cold_access:
     // Check for warm access.
     %stack (gas, original_value, current_value, kexit_info, slot, value) ->
         (value, current_value, current_value, original_value, gas, original_value, current_value, kexit_info, slot, value)

--- a/evm_arithmetization/src/cpu/kernel/asm/transactions/common_decoding.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/transactions/common_decoding.asm
@@ -226,7 +226,12 @@ insert_accessed_storage_keys_with_original_value:
 after_read:
     %stack (value, addr, key, retdest) -> ( addr, key, value, retdest)
     %insert_accessed_storage_keys
-    %pop2
+    // stack: cold_access, value_ptr, value, retdest
+    SWAP2
+    // stack: value, value_ptr, cold_access, retdest
+    MSTORE_GENERAL
+    // stack: cold_access, retdest
+    POP
     JUMP
 
 

--- a/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
@@ -234,7 +234,7 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
 
     for i in 0..10 {
         // Test for storage key already in list.
-        let (addr, key ) = storage_keys[i];
+        let (addr, key) = storage_keys[i];
         interpreter.push(retaddr);
         interpreter.push(key);
         interpreter.push(U256::from(addr.0.as_slice()));
@@ -257,10 +257,7 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
     interpreter.generation_state.registers.program_counter = insert_accessed_storage_keys;
 
     interpreter.run()?;
-    assert_eq!(
-        interpreter.stack()[1],
-        U256::one()
-    );
+    assert_eq!(interpreter.stack()[1], U256::one());
     assert_eq!(
         interpreter.generation_state.memory.get_with_init(
             MemoryAddress::new_bundle(U256::from(AccessedStorageKeysLen as usize)).unwrap(),


### PR DESCRIPTION
SLOAD currently charges gas after loading the storage slot, which can cause issue in witness generation in case of OOG.
Change that by charging gas before loading the storage. 
Also refactor `insert_accessed_storage_keys` to now return `cold_access, value_ptr`.