### PR TITLE
Increased the public interface for `trie_tools`

### DIFF
--- a/trace_decoder/src/compact/compact_to_partial_trie.rs
+++ b/trace_decoder/src/compact/compact_to_partial_trie.rs
@@ -104,10 +104,16 @@ pub(super) enum UnexpectedCompactNodeType {
 
 /// Output from constructing a state trie from compact.
 #[derive(Debug, Default)]
-pub(super) struct StateTrieExtractionOutput {
-    pub(super) trie: HashedPartialTrie,
-    pub(super) code: HashMap<CodeHash, Vec<u8>>,
-    pub(super) storage_tries: HashMap<HashedAccountAddr, HashedPartialTrie>,
+pub struct StateTrieExtractionOutput {
+    /// The state trie of the compact.
+    pub state_trie: HashedPartialTrie,
+
+    /// Any embedded contract bytecode that appears in the compact will be
+    /// present here.
+    pub code: HashMap<CodeHash, Vec<u8>>,
+
+    /// All storage tries present in the compact.
+    pub storage_tries: HashMap<HashedAccountAddr, HashedPartialTrie>,
 }
 
 impl CompactToPartialTrieExtractionOutput for StateTrieExtractionOutput {
@@ -125,7 +131,7 @@ impl CompactToPartialTrieExtractionOutput for StateTrieExtractionOutput {
         leaf_node_data: &LeafNodeData,
     ) -> CompactParsingResult<()> {
         process_leaf_common(
-            &mut self.trie,
+            &mut self.state_trie,
             curr_key,
             leaf_key,
             leaf_node_data,
@@ -140,7 +146,7 @@ impl CompactToPartialTrieExtractionOutput for StateTrieExtractionOutput {
         )
     }
     fn trie(&mut self) -> &mut HashedPartialTrie {
-        &mut self.trie
+        &mut self.state_trie
     }
 }
 

--- a/trace_decoder/src/compact/complex_test_payloads.rs
+++ b/trace_decoder/src/compact/complex_test_payloads.rs
@@ -1,9 +1,12 @@
 use evm_arithmetization::generation::mpt::AccountRlp;
 use mpt_trie::partial_trie::PartialTrie;
 
-use super::compact_prestate_processing::{
-    process_compact_prestate, process_compact_prestate_debug, CompactParsingResult,
-    PartialTriePreImages, ProcessedCompactOutput,
+use super::{
+    compact_prestate_processing::{
+        process_compact_prestate, process_compact_prestate_debug, CompactParsingResult,
+        PartialTriePreImages, ProcessedCompactOutput,
+    },
+    compact_to_partial_trie::StateTrieExtractionOutput,
 };
 use crate::{
     trace_protocol::TrieCompact,
@@ -56,23 +59,23 @@ impl TestProtocolInputAndRoot {
             Ok(x) => x,
             Err(err) => panic!("{}", err.to_string()),
         };
-        let trie_hash = out.witness_out.tries.state.hash();
+        let trie_hash = out.witness_out.state_trie.hash();
 
-        print_value_and_hash_nodes_of_trie(&out.witness_out.tries.state);
+        print_value_and_hash_nodes_of_trie(&out.witness_out.state_trie);
 
-        for (hashed_addr, s_trie) in out.witness_out.tries.storage.iter() {
+        for (hashed_addr, s_trie) in out.witness_out.storage_tries.iter() {
             print_value_and_hash_nodes_of_storage_trie(hashed_addr, s_trie);
         }
 
         assert!(out.header.version_is_compatible(1));
         assert_eq!(trie_hash, expected_hash);
 
-        Self::assert_non_all_storage_roots_exist_in_storage_trie_map(&out.witness_out.tries);
+        Self::assert_non_all_storage_roots_exist_in_storage_trie_map(&out.witness_out);
     }
 
-    fn assert_non_all_storage_roots_exist_in_storage_trie_map(images: &PartialTriePreImages) {
-        let non_empty_account_s_roots = images
-            .state
+    fn assert_non_all_storage_roots_exist_in_storage_trie_map(out: &StateTrieExtractionOutput) {
+        let non_empty_account_s_roots = out
+            .state_trie
             .items()
             .filter_map(|(addr, data)| {
                 data.as_val().map(|data| {
@@ -86,7 +89,7 @@ impl TestProtocolInputAndRoot {
             .map(|(addr, _)| addr);
 
         for account_with_non_empty_root in non_empty_account_s_roots {
-            assert!(images.storage.contains_key(&account_with_non_empty_root));
+            assert!(out.storage_tries.contains_key(&account_with_non_empty_root));
         }
     }
 }

--- a/trace_decoder/src/compact/mod.rs
+++ b/trace_decoder/src/compact/mod.rs
@@ -1,5 +1,5 @@
-pub(crate) mod compact_prestate_processing;
-mod compact_to_partial_trie;
+pub mod compact_prestate_processing;
+pub mod compact_to_partial_trie;
 
 #[cfg(test)]
 pub(crate) mod complex_test_payloads;

--- a/trace_decoder/src/processed_block_trace.rs
+++ b/trace_decoder/src/processed_block_trace.rs
@@ -8,7 +8,7 @@ use mpt_trie::nibbles::Nibbles;
 use mpt_trie::partial_trie::{HashedPartialTrie, PartialTrie};
 
 use crate::compact::compact_prestate_processing::{
-    process_compact_prestate_debug, PartialTriePreImages,
+    process_compact_prestate_debug, PartialTriePreImages, ProcessedCompactOutput,
 };
 use crate::decoding::TraceParsingResult;
 use crate::trace_protocol::{
@@ -109,6 +109,21 @@ struct ProcessedBlockTracePreImages {
     extra_code_hash_mappings: Option<HashMap<CodeHash, Vec<u8>>>,
 }
 
+impl From<ProcessedCompactOutput> for ProcessedBlockTracePreImages {
+    fn from(v: ProcessedCompactOutput) -> Self {
+        let tries = PartialTriePreImages {
+            state: v.witness_out.state_trie,
+            storage: v.witness_out.storage_tries,
+        };
+
+        Self {
+            tries,
+            extra_code_hash_mappings: (!v.witness_out.code.is_empty())
+                .then_some(v.witness_out.code),
+        }
+    }
+}
+
 fn process_block_trace_trie_pre_images(
     block_trace_pre_images: BlockTraceTriePreImages,
 ) -> ProcessedBlockTracePreImages {
@@ -169,10 +184,7 @@ fn process_compact_trie(trie: TrieCompact) -> ProcessedBlockTracePreImages {
     // TODO: Make this into a result...
     assert!(out.header.version_is_compatible(COMPATIBLE_HEADER_VERSION));
 
-    ProcessedBlockTracePreImages {
-        tries: out.witness_out.tries,
-        extra_code_hash_mappings: out.witness_out.code,
-    }
+    out.into()
 }
 
 /// Structure storing a function turning a `CodeHash` into bytes.


### PR DESCRIPTION
- `trie_tools` needs to access a bit of currently private logic. Specifically, it needs to be able to process compact bytecode into `mpt_tries` directly.
- I think this change is actually reasonable. I can see realistic use cases where we don't need to process an entire block trace but instead just want to decode some compact bytecode.
- With the current public interface, the caller can only pass in an entire block trace to process.