### PR TITLE
Make test_receipt_encoding more meaningful.

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/tests/receipt.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/receipt.rs
@@ -130,7 +130,7 @@ fn test_receipt_encoding() -> Result<()> {
     let expected_rlp = rlp::encode(&rlp::encode(&receipt_1));
 
     // Address at which the encoding is written.
-    let rlp_addr = U256::from(Segment::RlpRaw.unscale()) << SEGMENT_SCALING_FACTOR;
+    let rlp_addr = U256::from(Segment::RlpRaw as usize);
     let initial_stack: Vec<U256> = vec![retdest, 0.into(), 0.into(), rlp_addr];
     let mut interpreter: Interpreter<F> = Interpreter::new(encode_receipt, initial_stack);
 


### PR DESCRIPTION
Following address bundling `encode_receipt` takes the full address as its first argument -- and not just the offset anymore. This means that `test_receipt_encoding` was no longer testing what it was supposed to: the final loop to check RLP values was actually done on an empty vector (since the encoding was no longer stored in `RlpRaw`, as it should). This PR fixes this by setting the initial RLP address correctly.