### PR TITLE
feat: swap out the internal U512 inside nibbles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update plonky2 dependencies ([#119](https://github.com/0xPolygonZero/zk_evm/pull/119))
+- Swap out the internal U512 inside nibbles to [u64;5] ([#132](https://github.com/0xPolygonZero/zk_evm/pull/132))
 
 ## [0.2.0] - 2024-03-19
 

--- a/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
@@ -115,7 +115,7 @@ fn prepare_interpreter<F: Field>(
         .push(value_ptr.into())
         .expect("The stack should not overflow"); // value_ptr
     interpreter
-        .push(k.try_into_u256().unwrap())
+        .push(k.try_into().unwrap())
         .expect("The stack should not overflow"); // key
 
     interpreter.run()?;

--- a/evm_arithmetization/src/cpu/kernel/tests/balance.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/balance.rs
@@ -67,7 +67,7 @@ fn prepare_interpreter<F: Field>(
         .push(value_ptr.into())
         .expect("The stack should not overflow"); // value_ptr
     interpreter
-        .push(k.try_into_u256().unwrap())
+        .push(k.try_into().unwrap())
         .expect("The stack should not overflow"); // key
 
     interpreter.run()?;

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/delete.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/delete.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use ethereum_types::{BigEndianHash, H256, U512};
-use mpt_trie::nibbles::Nibbles;
+use mpt_trie::nibbles::{Nibbles, NibblesIntern};
 use mpt_trie::partial_trie::{HashedPartialTrie, PartialTrie};
 use plonky2::field::goldilocks_field::GoldilocksField as F;
 use rand::random;
@@ -70,7 +70,7 @@ fn test_after_mpt_delete_extension_branch() -> Result<()> {
     }
     .into();
     let key = nibbles.merge_nibbles(&Nibbles {
-        packed: U512::zero(),
+        packed: NibblesIntern::zero(),
         count: 64 - nibbles.count,
     });
     test_state_trie(state_trie, key, test_account_2())
@@ -130,7 +130,7 @@ fn test_state_trie(
         .push(value_ptr.into())
         .expect("The stack should not overflow"); // value_ptr
     interpreter
-        .push(k.try_into_u256().unwrap())
+        .push(k.try_into().unwrap())
         .expect("The stack should not overflow"); // key
     interpreter.run()?;
     assert_eq!(
@@ -147,7 +147,7 @@ fn test_state_trie(
         .push(0xDEADBEEFu32.into())
         .expect("The stack should not overflow");
     interpreter
-        .push(k.try_into_u256().unwrap())
+        .push(k.try_into().unwrap())
         .expect("The stack should not overflow");
     interpreter
         .push(64.into())

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/insert.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/insert.rs
@@ -205,7 +205,7 @@ fn test_state_trie(
         .push(value_ptr.into())
         .expect("The stack should not overflow"); // value_ptr
     interpreter
-        .push(k.try_into_u256().unwrap())
+        .push(k.try_into().unwrap())
         .expect("The stack should not overflow"); // key
 
     interpreter.run()?;

--- a/evm_arithmetization/src/generation/mpt.rs
+++ b/evm_arithmetization/src/generation/mpt.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use ethereum_types::{Address, BigEndianHash, H256, U256, U512};
 use keccak_hash::keccak;
-use mpt_trie::nibbles::Nibbles;
+use mpt_trie::nibbles::{Nibbles, NibblesIntern};
 use mpt_trie::partial_trie::{HashedPartialTrie, PartialTrie};
 use rlp::{Decodable, DecoderError, Encodable, PayloadInfo, Rlp, RlpStream};
 use rlp_derive::{RlpDecodable, RlpEncodable};
@@ -120,7 +120,7 @@ fn parse_storage_value(value_rlp: &[u8]) -> Result<Vec<U256>, ProgramError> {
 const fn empty_nibbles() -> Nibbles {
     Nibbles {
         count: 0,
-        packed: U512::zero(),
+        packed: NibblesIntern::zero(),
     }
 }
 
@@ -171,7 +171,7 @@ where
             trie_data.push(nibbles.count.into());
             trie_data.push(
                 nibbles
-                    .try_into_u256()
+                    .try_into()
                     .map_err(|_| ProgramError::IntegerTooLarge)?,
             );
             trie_data.push((trie_data.len() + 1).into());
@@ -187,7 +187,7 @@ where
             trie_data.push(nibbles.count.into());
             trie_data.push(
                 nibbles
-                    .try_into_u256()
+                    .try_into()
                     .map_err(|_| ProgramError::IntegerTooLarge)?,
             );
 
@@ -250,7 +250,7 @@ fn load_state_trie(
             trie_data.push(nibbles.count.into());
             trie_data.push(
                 nibbles
-                    .try_into_u256()
+                    .try_into()
                     .map_err(|_| ProgramError::IntegerTooLarge)?,
             );
             // Set `value_ptr_ptr`.
@@ -286,7 +286,7 @@ fn load_state_trie(
             trie_data.push(nibbles.count.into());
             trie_data.push(
                 nibbles
-                    .try_into_u256()
+                    .try_into()
                     .map_err(|_| ProgramError::IntegerTooLarge)?,
             );
             // Set `value_ptr_ptr`.

--- a/evm_arithmetization/src/generation/trie_extractor.rs
+++ b/evm_arithmetization/src/generation/trie_extractor.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 use ethereum_types::{BigEndianHash, H256, U256, U512};
-use mpt_trie::nibbles::Nibbles;
+use mpt_trie::nibbles::{Nibbles, NibblesIntern};
 use mpt_trie::partial_trie::{HashedPartialTrie, Node, PartialTrie, WrappedNode};
 
 use super::mpt::{AccountRlp, LegacyReceiptRlp, LogRlp};
@@ -47,7 +47,7 @@ pub(crate) fn read_trie<V>(
     let mut res = HashMap::new();
     let empty_nibbles = Nibbles {
         count: 0,
-        packed: U512::zero(),
+        packed: NibblesIntern::zero(),
     };
     read_trie_helper::<V>(memory, ptr, read_value, empty_nibbles, &mut res)?;
     Ok(res)
@@ -259,7 +259,7 @@ pub(crate) fn get_trie<N: PartialTrie>(
 ) -> Result<N, ProgramError> {
     let empty_nibbles = Nibbles {
         count: 0,
-        packed: U512::zero(),
+        packed: NibblesIntern::zero(),
     };
     Ok(N::new(get_trie_helper(
         memory,

--- a/mpt_trie/Cargo.toml
+++ b/mpt_trie/Cargo.toml
@@ -27,6 +27,10 @@ num-traits = "0.2.15"
 uint = "0.9.5"
 rlp = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
+impl-rlp = "0.3.0"
+impl-codec = "0.6.0"
+impl-serde = "0.4.0"
+impl-num-traits = "0.1.2"
 
 [dev-dependencies]
 eth_trie = "0.4.0"

--- a/mpt_trie/src/nibbles.rs
+++ b/mpt_trie/src/nibbles.rs
@@ -27,6 +27,7 @@ pub type Nibble = u8;
 
 construct_uint! {
     /// Used for the internal representation of a sequence of nibbles.
+    #[allow(clippy::assign_op_pattern)]
     pub struct NibblesIntern(5);
 }
 
@@ -150,6 +151,8 @@ macro_rules! impl_to_nibbles {
     ($type:ty) => {
         impl ToNibbles for $type {
             fn to_nibbles(self) -> Nibbles {
+                // Ethereum types don't have `BITS` defined.
+                #[allow(clippy::manual_bits)]
                 let size_bits = size_of::<Self>() * 8;
                 let count = (size_bits - self.leading_zeros() as usize + 3) / 4;
                 let mut packed = NibblesIntern::zero();
@@ -208,9 +211,9 @@ impl<'a> TryFrom<&'a NibblesIntern> for U256 {
     }
 }
 
-impl Into<NibblesIntern> for U256 {
-    fn into(self) -> NibblesIntern {
-        let arr = self.as_u64s();
+impl From<U256> for NibblesIntern {
+    fn from(val: U256) -> Self {
+        let arr = val.as_u64s();
 
         let mut ret = NibblesIntern::zero();
         ret.0[0] = arr[0];
@@ -221,9 +224,9 @@ impl Into<NibblesIntern> for U256 {
     }
 }
 
-impl Into<ethereum_types::U256> for Nibbles {
-    fn into(self) -> ethereum_types::U256 {
-        U256::try_from(&self.packed).unwrap()
+impl From<Nibbles> for U256 {
+    fn from(val: Nibbles) -> Self {
+        U256::try_from(&val.packed).unwrap()
     }
 }
 

--- a/mpt_trie/src/nibbles.rs
+++ b/mpt_trie/src/nibbles.rs
@@ -885,8 +885,6 @@ impl Nibbles {
         (k.bits() + 3) / 4
     }
 
-    // TODO: Make not terrible at some point... Consider moving away from `U256`
-    // internally?
     /// Returns the nibbles bytes in big-endian format.
     pub fn bytes_be(&self) -> Vec<u8> {
         let mut byte_buf = [0; 40];

--- a/mpt_trie/src/nibbles.rs
+++ b/mpt_trie/src/nibbles.rs
@@ -105,14 +105,14 @@ pub enum NibblesToTypeError {
 }
 
 trait AsU64s {
-    fn as_u64s(&self) -> Vec<u64>;
+    fn as_u64s(&self) -> impl Iterator<Item = u64> + '_;
 }
 
 macro_rules! impl_as_u64s_for_primitive {
     ($type:ty) => {
         impl AsU64s for $type {
-            fn as_u64s(&self) -> Vec<u64> {
-                vec![*self as u64]
+            fn as_u64s(&self) -> impl Iterator<Item = u64> + '_ {
+                std::iter::once(*self as u64)
             }
         }
     };
@@ -124,23 +124,20 @@ impl_as_u64s_for_primitive!(u32);
 impl_as_u64s_for_primitive!(u64);
 
 impl AsU64s for U128 {
-    fn as_u64s(&self) -> Vec<u64> {
-        let U128(ref arr) = self;
-        arr.to_vec()
+    fn as_u64s(&self) -> impl Iterator<Item = u64> + '_ {
+        self.0.iter().copied()
     }
 }
 
 impl AsU64s for U256 {
-    fn as_u64s(&self) -> Vec<u64> {
-        let U256(ref arr) = self;
-        arr.to_vec()
+    fn as_u64s(&self) -> impl Iterator<Item = u64> + '_ {
+        self.0.iter().copied()
     }
 }
 
 impl AsU64s for NibblesIntern {
-    fn as_u64s(&self) -> Vec<u64> {
-        let NibblesIntern(ref arr) = self;
-        arr.to_vec()
+    fn as_u64s(&self) -> impl Iterator<Item = u64> + '_ {
+        self.0.iter().copied()
     }
 }
 
@@ -171,7 +168,7 @@ macro_rules! impl_to_nibbles {
                 let mut packed = NibblesIntern::zero();
 
                 let parts = self.as_u64s();
-                for (i, part) in parts.into_iter().enumerate().take(packed.0.len()) {
+                for (i, part) in parts.enumerate().take(packed.0.len()) {
                     packed.0[i] = part;
                 }
 
@@ -235,10 +232,9 @@ impl From<U256> for NibblesIntern {
         let arr = val.as_u64s();
 
         let mut ret = NibblesIntern::zero();
-        ret.0[0] = arr[0];
-        ret.0[1] = arr[1];
-        ret.0[2] = arr[2];
-        ret.0[3] = arr[3];
+        for (i, part) in arr.enumerate() {
+            ret.0[i] = part;
+        }
         ret
     }
 }

--- a/mpt_trie/src/testing_utils.rs
+++ b/mpt_trie/src/testing_utils.rs
@@ -3,12 +3,12 @@ use std::{
     iter::{once, repeat},
 };
 
-use ethereum_types::{H256, U256, U512};
+use ethereum_types::{H256, U256};
 use log::info;
 use rand::{rngs::StdRng, seq::IteratorRandom, Rng, RngCore, SeedableRng};
 
 use crate::{
-    nibbles::Nibbles,
+    nibbles::{Nibbles, NibblesIntern},
     partial_trie::{HashedPartialTrie, Node, PartialTrie},
     trie_ops::{TrieOpResult, ValOrHash},
     utils::is_even,
@@ -29,7 +29,7 @@ type TestInsertEntry<T> = (Nibbles, T);
 // Don't want this exposed publicly, but it is useful for testing.
 impl From<i32> for Nibbles {
     fn from(k: i32) -> Self {
-        let packed = U512::from(k);
+        let packed = NibblesIntern::from(k);
 
         Self {
             count: Self::get_num_nibbles_in_key(&packed),

--- a/mpt_trie/src/utils.rs
+++ b/mpt_trie/src/utils.rs
@@ -7,11 +7,11 @@ use std::{
     sync::Arc,
 };
 
-use ethereum_types::{H256, U512};
+use ethereum_types::H256;
 use num_traits::PrimInt;
 
 use crate::{
-    nibbles::{Nibble, Nibbles},
+    nibbles::{Nibble, Nibbles, NibblesIntern},
     partial_trie::{Node, PartialTrie},
     trie_ops::TrieOpResult,
 };
@@ -71,8 +71,8 @@ pub(crate) fn is_even<T: PrimInt + BitAnd<Output = T>>(num: T) -> bool {
     (num & T::one()) == T::zero()
 }
 
-pub(crate) fn create_mask_of_1s(amt: usize) -> U512 {
-    (U512::one() << amt) - 1
+pub(crate) fn create_mask_of_1s(amt: usize) -> NibblesIntern {
+    (NibblesIntern::one() << amt) - 1
 }
 
 pub(crate) fn bytes_to_h256(b: &[u8; 32]) -> H256 {


### PR DESCRIPTION
Swap out the internal U512 inside Nibbles with [u64;5].

Issue: https://github.com/0xPolygonZero/zk_evm/issues/104