### PR TITLE
Remove interpreter-specific preinialization logic from State trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Remove interpreter-specific preinialization logic from State trait ([#139](https://github.com/0xPolygonZero/zk_evm/pull/139))
+
 ## [0.3.0] - 2024-04-03
 
 ### Changed

--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -738,6 +738,20 @@ impl<F: Field> Interpreter<F> {
             .memory
             .set(MemoryAddress::new(0, Segment::RlpRaw, 0), 0x80.into())
     }
+
+    /// Inserts a preinitialized segment, given as a [Segment],
+    /// into the `preinitialized_segments` memory field.
+    fn insert_preinitialized_segment(&mut self, segment: Segment, values: MemorySegmentState) {
+        self.generation_state
+            .memory
+            .insert_preinitialized_segment(segment, values);
+    }
+
+    fn is_preinitialized_segment(&self, segment: usize) -> bool {
+        self.generation_state
+            .memory
+            .is_preinitialized_segment(segment)
+    }
 }
 
 impl<F: Field> State<F> for Interpreter<F> {
@@ -750,18 +764,6 @@ impl<F: Field> State<F> for Interpreter<F> {
             traces: self.generation_state.traces.checkpoint(),
             clock: self.get_clock(),
         }
-    }
-
-    fn insert_preinitialized_segment(&mut self, segment: Segment, values: MemorySegmentState) {
-        self.generation_state
-            .memory
-            .insert_preinitialized_segment(segment, values);
-    }
-
-    fn is_preinitialized_segment(&self, segment: usize) -> bool {
-        self.generation_state
-            .memory
-            .is_preinitialized_segment(segment)
     }
 
     fn incr_gas(&mut self, n: u64) {

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -138,12 +138,6 @@ pub(crate) trait State<F: Field> {
     /// Return the offsets at which execution must halt
     fn get_halt_offsets(&self) -> Vec<usize>;
 
-    /// Inserts a preinitialized segment, given as a [Segment],
-    /// into the `preinitialized_segments` memory field.
-    fn insert_preinitialized_segment(&mut self, segment: Segment, values: MemorySegmentState);
-
-    fn is_preinitialized_segment(&self, segment: usize) -> bool;
-
     /// Simulates the CPU. It only generates the traces if the `State` is a
     /// `GenerationState`.
     fn run_cpu(&mut self) -> anyhow::Result<()>
@@ -426,16 +420,6 @@ impl<F: Field> State<F> for GenerationState<F> {
             traces: self.traces.checkpoint(),
             clock: self.get_clock(),
         }
-    }
-
-    fn insert_preinitialized_segment(&mut self, segment: Segment, values: MemorySegmentState) {
-        panic!(
-            "A `GenerationState` cannot have a nonempty `preinitialized_segment` field in memory."
-        )
-    }
-
-    fn is_preinitialized_segment(&self, segment: usize) -> bool {
-        false
     }
 
     fn incr_gas(&mut self, n: u64) {


### PR DESCRIPTION
The merge of interpreter / generation state introduced a notion of preinitialized segments, decoupled from the actual `MemoryState` segments, which was only used for the `TrieData` segment in context 0.

This PR removes this unnecessary distinction, similarly to how things are done on the actual prover side. It also renames the `get_with_init` method on memory content access with `get_or_default`, as the distinction is simply returning always a value compared to the regular getter.