### PR TITLE
Skip trie loading when being passed default inputs

### DIFF
--- a/evm_arithmetization/src/generation/mpt.rs
+++ b/evm_arithmetization/src/generation/mpt.rs
@@ -32,6 +32,16 @@ pub struct TrieRootPtrs {
     pub receipt_root_ptr: usize,
 }
 
+impl Default for TrieRootPtrs {
+    fn default() -> Self {
+        Self {
+            state_root_ptr: 2,
+            txn_root_ptr: 0,
+            receipt_root_ptr: 0,
+        }
+    }
+}
+
 impl Default for AccountRlp {
     fn default() -> Self {
         Self {

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -307,6 +307,10 @@ pub(crate) struct GenerationState<F: Field> {
 
 impl<F: RichField> GenerationState<F> {
     fn preinitialize_mpts(&mut self, trie_inputs: &TrieInputs) -> TrieRootPtrs {
+        if trie_inputs.state_smt == TrieInputs::default().state_smt {
+            return TrieRootPtrs::default();
+        }
+
         let (trie_roots_ptrs, trie_data) =
             load_all_mpts(trie_inputs).expect("Invalid MPT data for preinitialization");
 


### PR DESCRIPTION
Running a CPU simulation with the type 2 fails because of the different default values in the state trie. The default SMT is a vector of 4 0s, messing up the preinitialized segments logic inside the interpreter.
Actual proving logic is unaffected, this only matters in the context of continuations or witness-only generation.