### PR TITLE
Add `%alloc_rlp_block` back in `type_0.asm`

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/transactions/type_0.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/transactions/type_0.asm
@@ -84,6 +84,7 @@ type_0_compute_signed_data:
     // otherwise, it is
     //     keccak256(rlp([nonce, gas_price, gas_limit, to, value, data]))
 
+    %alloc_rlp_block POP // Doesn't work otherwise. TODO: Figure out why.
     %alloc_rlp_block
     // stack: rlp_addr_start, retdest
     %mload_txn_field(@TXN_FIELD_NONCE)


### PR DESCRIPTION
Was erroneously removed in #130.