### PR TITLE
Fix data overwrite in RLP segment

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/main.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/main.asm
@@ -17,7 +17,11 @@ global main:
 
     // Initialize the RLP DATA pointer to its initial position, 
     // skipping over the preinitialized empty node.
+    // Because hashing with the SMT doesn't require RLP encoding,
+    // we shift the initial pointer by MAX_RLP_BLOB_SIZE to not
+    // overwrite any transaction field.
     PUSH @INITIAL_TXN_RLP_ADDR
+    %add_const(@MAX_RLP_BLOB_SIZE)
     %mstore_global_metadata(@GLOBAL_METADATA_RLP_DATA_SIZE)
 
     // Encode constant nodes

--- a/evm_arithmetization/src/cpu/kernel/asm/transactions/type_0.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/transactions/type_0.asm
@@ -84,7 +84,6 @@ type_0_compute_signed_data:
     // otherwise, it is
     //     keccak256(rlp([nonce, gas_price, gas_limit, to, value, data]))
 
-    %alloc_rlp_block POP // Doesn't work otherwise. TODO: Figure out why.
     %alloc_rlp_block
     // stack: rlp_addr_start, retdest
     %mload_txn_field(@TXN_FIELD_NONCE)

--- a/evm_arithmetization/src/cpu/kernel/asm/transactions/type_1.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/transactions/type_1.asm
@@ -38,7 +38,6 @@ global process_type_1_txn:
 // The signatureYParity, signatureR, signatureS elements of this transaction represent a secp256k1 signature
 // over keccak256(0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])).
 type_1_compute_signed_data:
-    %alloc_rlp_block POP // Doesn't work otherwise. TODO: Figure out why.
     %alloc_rlp_block
     // stack: rlp_addr_start, retdest
     %mload_txn_field(@TXN_FIELD_CHAIN_ID)

--- a/evm_arithmetization/src/cpu/kernel/asm/transactions/type_2.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/transactions/type_2.asm
@@ -41,7 +41,6 @@ global process_type_2_txn:
 // The signature_y_parity, signature_r, signature_s elements of this transaction represent a secp256k1 signature over
 // keccak256(0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list]))
 type_2_compute_signed_data:
-    %alloc_rlp_block POP // Doesn't work otherwise. TODO: Figure out why.
     %alloc_rlp_block
     // stack: rlp_addr_start, retdest
     %mload_txn_field(@TXN_FIELD_CHAIN_ID)


### PR DESCRIPTION
The MPT design requires RLP encoding while hashing the trie, hence calling `%alloc_rlp_block` at least once, preserving the section reserved for the txn RLP.

The SMT design doesn't need to RLP encode, hence needs an additional shift when initializing the RLP pointer to make sure we don't overwrite the txn data. This can be observed for instance when looking at the trace for `erc20` and removing the dummy `%alloc_rlp_block`, the empty access_list becomes overwritten with 199 (should be 192 = 0xc0).

@wborgeaud that's also why we could remove it for type-0 txns, they're too small to be overwritten :) 