### PR TITLE
Disabling logging from the interpreter

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -19,7 +19,7 @@ use crate::generation::debug_inputs;
 use crate::generation::mpt::load_all_mpts;
 use crate::generation::rlp::all_rlp_prover_inputs_reversed;
 use crate::generation::state::{
-    all_withdrawals_prover_inputs_reversed, GenerationState, GenerationStateCheckpoint,
+    all_withdrawals_prover_inputs_reversed, GenerationState, GenerationStateCheckpoint, StateLog,
 };
 use crate::generation::{state::State, GenerationInputs};
 use crate::keccak_sponge::columns::KECCAK_WIDTH_BYTES;
@@ -857,8 +857,6 @@ impl<F: Field> State<F> for Interpreter<F> {
 
         if registers.is_kernel {
             log_kernel_instruction(self, op);
-        } else {
-            log::debug!("User instruction: {:?}", op);
         }
 
         let generation_state = self.get_mut_generation_state();
@@ -921,6 +919,12 @@ impl<F: Field> Transition<F> for Interpreter<F> {
 
         Ok(())
     }
+}
+
+impl<F: Field> StateLog for Interpreter<F> {
+    fn log_log(_: log::Level, _: &str) {}
+
+    fn log_debug(_: &str) {}
 }
 
 fn get_mnemonic(opcode: u8) -> &'static str {

--- a/evm_arithmetization/src/generation/prover_input.rs
+++ b/evm_arithmetization/src/generation/prover_input.rs
@@ -268,7 +268,6 @@ impl<F: Field> GenerationState<F> {
 
         if self.jumpdest_table.is_none() {
             self.generate_jumpdest_table()?;
-            log::debug!("jdt  = {:?}", self.jumpdest_table);
         }
 
         let Some(jumpdest_table) = &mut self.jumpdest_table else {
@@ -282,11 +281,6 @@ impl<F: Field> GenerationState<F> {
         if let Some(ctx_jumpdest_table) = jumpdest_table.get_mut(&context)
             && let Some(next_jumpdest_address) = ctx_jumpdest_table.pop()
         {
-            log::debug!(
-                "jumpdest_table_len = {:?}, ctx_jumpdest_table.len = {:?}",
-                jd_len,
-                ctx_jumpdest_table.len()
-            );
             Ok((next_jumpdest_address + 1).into())
         } else {
             jumpdest_table.remove(&context);
@@ -308,11 +302,6 @@ impl<F: Field> GenerationState<F> {
         if let Some(ctx_jumpdest_table) = jumpdest_table.get_mut(&context)
             && let Some(next_jumpdest_proof) = ctx_jumpdest_table.pop()
         {
-            log::debug!(
-                "jumpdest_table_len = {:?}, ctx_jumpdest_table.len = {:?}",
-                jd_len,
-                ctx_jumpdest_table.len()
-            );
             Ok(next_jumpdest_proof.into())
         } else {
             Err(ProgramError::ProverInputError(


### PR DESCRIPTION
The simulation for jumpdest analysis was printing too much info in the logs. To avoid that, now all logging for `GenerationState` or `Interpreter` is done by calling the methods of a new trait `StateLog` which both `GenerationState` and `Interpreter` implement