### PR TITLE
Update `proof_gen` (partially) to accomodate for type2 changes

### DIFF
--- a/proof_gen/Cargo.toml
+++ b/proof_gen/Cargo.toml
@@ -17,5 +17,5 @@ plonky2 = { workspace = true }
 serde = { workspace = true }
 
 # Local dependencies
-trace_decoder = "0.2.0"
-evm_arithmetization = "0.1.2" # TODO: adapt with type2 and bring back paths
+trace_decoder = "0.2.0" # TODO: adapt with type2 and bring back paths
+evm_arithmetization = { version = "0.1.3", path = "../evm_arithmetization" }

--- a/proof_gen/Cargo.toml
+++ b/proof_gen/Cargo.toml
@@ -17,5 +17,5 @@ plonky2 = { workspace = true }
 serde = { workspace = true }
 
 # Local dependencies
-trace_decoder = "0.2.0" # TODO: adapt with type2 and bring back paths
+# trace_decoder = "0.2.0" # TODO: adapt with type2 and bring back paths
 evm_arithmetization = { version = "0.1.3", path = "../evm_arithmetization" }

--- a/proof_gen/src/constants.rs
+++ b/proof_gen/src/constants.rs
@@ -16,3 +16,5 @@ pub(crate) const DEFAULT_KECCAK_SPONGE_RANGE: Range<usize> = 9..25;
 pub(crate) const DEFAULT_LOGIC_RANGE: Range<usize> = 12..28;
 /// Default range to be used for the `MemoryStark` table.
 pub(crate) const DEFAULT_MEMORY_RANGE: Range<usize> = 17..30;
+/// Default range to be used for the `PoseidonStark` table.
+pub(crate) const DEFAULT_POSEIDON_RANGE: Range<usize> = 4..25;

--- a/proof_gen/src/proof_gen.rs
+++ b/proof_gen/src/proof_gen.rs
@@ -3,15 +3,16 @@
 
 use std::sync::{atomic::AtomicBool, Arc};
 
-use evm_arithmetization::{AllStark, StarkConfig};
+use evm_arithmetization::{AllStark, GenerationInputs, StarkConfig};
 use plonky2::{
     gates::noop::NoopGate,
     iop::witness::PartialWitness,
     plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig},
     util::timing::TimingTree,
 };
-use trace_decoder::types::TxnProofGenIR;
 
+// TODO: bring back import from trace_decoder once SMT logic is implemented
+// use trace_decoder::types::TxnProofGenIR;
 use crate::{
     proof_types::{AggregatableProof, GeneratedAggProof, GeneratedBlockProof, GeneratedTxnProof},
     prover_state::ProverState,
@@ -44,7 +45,9 @@ impl From<String> for ProofGenError {
 /// Generates a transaction proof from some IR data.
 pub fn generate_txn_proof(
     p_state: &ProverState,
-    gen_inputs: TxnProofGenIR,
+    // gen_inputs: TxnProofGenIR, // TODO: bring back import from trace_decoder once SMT logic is
+    // implemented
+    gen_inputs: GenerationInputs,
     abort_signal: Option<Arc<AtomicBool>>,
 ) -> ProofGenResult<GeneratedTxnProof> {
     let (intern, p_vals) = p_state

--- a/proof_gen/src/proof_types.rs
+++ b/proof_gen/src/proof_types.rs
@@ -3,8 +3,8 @@
 
 use evm_arithmetization::proof::PublicValues;
 use serde::{Deserialize, Serialize};
-use trace_decoder::types::BlockHeight;
 
+// use trace_decoder::types::BlockHeight;
 use crate::types::PlonkyProofIntern;
 
 /// A transaction proof along with its public values, for proper connection with
@@ -35,7 +35,7 @@ pub struct GeneratedAggProof {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GeneratedBlockProof {
     /// Associated block height.
-    pub b_height: BlockHeight,
+    pub b_height: u64, // TODO: replace by BlockHeight once trace_decoder is updated
     /// Underlying plonky2 proof.
     pub intern: PlonkyProofIntern,
 }

--- a/proof_gen/src/prover_state.rs
+++ b/proof_gen/src/prover_state.rs
@@ -29,6 +29,7 @@ pub struct ProverStateBuilder {
     pub(crate) keccak_sponge_circuit_size: Range<usize>,
     pub(crate) logic_circuit_size: Range<usize>,
     pub(crate) memory_circuit_size: Range<usize>,
+    pub(crate) poseidon_circuit_size: Range<usize>,
 }
 
 impl Default for ProverStateBuilder {
@@ -48,6 +49,7 @@ impl Default for ProverStateBuilder {
             keccak_sponge_circuit_size: DEFAULT_KECCAK_SPONGE_RANGE,
             logic_circuit_size: DEFAULT_LOGIC_RANGE,
             memory_circuit_size: DEFAULT_MEMORY_RANGE,
+            poseidon_circuit_size: DEFAULT_POSEIDON_RANGE,
         }
     }
 }
@@ -73,6 +75,7 @@ impl ProverStateBuilder {
     define_set_circuit_size_method!(keccak_sponge);
     define_set_circuit_size_method!(logic);
     define_set_circuit_size_method!(memory);
+    define_set_circuit_size_method!(poseidon);
 
     // TODO: Consider adding async version?
     /// Instantiate the prover state from the builder. Note that this is a very
@@ -90,6 +93,7 @@ impl ProverStateBuilder {
                 self.keccak_sponge_circuit_size,
                 self.logic_circuit_size,
                 self.memory_circuit_size,
+                self.poseidon_circuit_size,
             ],
             &StarkConfig::standard_fast_config(),
         );


### PR DESCRIPTION
To test the type2 impl while the `trace_decoder` is being reworked, we can try adapting `eth-tx-proof` but the cross-crate references are a bit messy as `trace_decoder` and `proof_gen` have not been yet adapted with the type2 impl of `evm_arithmetization`.

This tweaks `proof_gen` to take into account the type2 switch, in a way that should be usable by `eth-tx-proof` for testing while #93 is being worked on.