### PR TITLE
fix(keccak-sponge): properly constrain padding bytes

### DIFF
--- a/evm_arithmetization/src/keccak_sponge/columns.rs
+++ b/evm_arithmetization/src/keccak_sponge/columns.rs
@@ -47,12 +47,10 @@ pub(crate) struct KeccakSpongeColumnsView<T: Copy> {
     /// block.
     pub already_absorbed_bytes: T,
 
-    /// If this row represents a final block row, the `i`th entry should be 1 if
-    /// the final chunk of input has length `i` (in other words if `len -
-    /// already_absorbed == i`), otherwise 0.
+    /// Whether the current byte is a padding byte.
     ///
     /// If this row represents a full input block, this should contain all 0s.
-    pub is_final_input_len: [T; KECCAK_RATE_BYTES],
+    pub is_padding_byte: [T; KECCAK_RATE_BYTES],
 
     /// The initial rate part of the sponge, at the start of this step.
     pub original_rate_u32s: [T; KECCAK_RATE_U32S],

--- a/evm_arithmetization/src/keccak_sponge/columns.rs
+++ b/evm_arithmetization/src/keccak_sponge/columns.rs
@@ -47,7 +47,11 @@ pub(crate) struct KeccakSpongeColumnsView<T: Copy> {
     /// block.
     pub already_absorbed_bytes: T,
 
-    /// Whether the current byte is a padding byte.
+    /// Indicates whether the byte at position `i` is a padding byte.
+    ///
+    /// For a final block, the `i`th entry should be 1 for all bytes that have
+    /// been padded, including the first `1` byte, all subsequent `0` bytes
+    /// and the last byte as per the 10*1 padding scheme.
     ///
     /// If this row represents a full input block, this should contain all 0s.
     pub is_padding_byte: [T; KECCAK_RATE_BYTES],

--- a/evm_arithmetization/src/keccak_sponge/columns.rs
+++ b/evm_arithmetization/src/keccak_sponge/columns.rs
@@ -102,7 +102,7 @@ pub(crate) const RC_FREQUENCIES: usize = NUM_KECCAK_SPONGE_COLUMNS - 1;
 pub(crate) const RANGE_COUNTER: usize = RC_FREQUENCIES - 1;
 
 pub(crate) const BLOCK_BYTES_START: usize =
-    6 + KECCAK_RATE_BYTES + KECCAK_RATE_U32S + KECCAK_CAPACITY_U32S;
+    7 + KECCAK_RATE_BYTES + KECCAK_RATE_U32S + KECCAK_CAPACITY_U32S;
 /// Indices for the range-checked values, i.e. the `block_bytes` section.
 // TODO: Find a better way to access those indices
 pub(crate) const fn get_block_bytes_range() -> Range<usize> {

--- a/evm_arithmetization/src/keccak_sponge/columns.rs
+++ b/evm_arithmetization/src/keccak_sponge/columns.rs
@@ -33,10 +33,6 @@ pub(crate) struct KeccakSpongeColumnsView<T: Copy> {
     /// is an input byte, not a padding byte; 0 otherwise.
     pub is_full_input_block: T,
 
-    /// 1 if this row represents a block containing padding bytes and the
-    /// padding spans more than 1 byte
-    pub is_multi_padding_block: T,
-
     /// The context of the base address at which we will read the input block.
     pub context: T,
     /// The segment of the base address at which we will read the input block.
@@ -102,7 +98,7 @@ pub(crate) const RC_FREQUENCIES: usize = NUM_KECCAK_SPONGE_COLUMNS - 1;
 pub(crate) const RANGE_COUNTER: usize = RC_FREQUENCIES - 1;
 
 pub(crate) const BLOCK_BYTES_START: usize =
-    7 + KECCAK_RATE_BYTES + KECCAK_RATE_U32S + KECCAK_CAPACITY_U32S;
+    6 + KECCAK_RATE_BYTES + KECCAK_RATE_U32S + KECCAK_CAPACITY_U32S;
 /// Indices for the range-checked values, i.e. the `block_bytes` section.
 // TODO: Find a better way to access those indices
 pub(crate) const fn get_block_bytes_range() -> Range<usize> {

--- a/evm_arithmetization/src/keccak_sponge/columns.rs
+++ b/evm_arithmetization/src/keccak_sponge/columns.rs
@@ -33,6 +33,10 @@ pub(crate) struct KeccakSpongeColumnsView<T: Copy> {
     /// is an input byte, not a padding byte; 0 otherwise.
     pub is_full_input_block: T,
 
+    /// 1 if this row represents a block containing padding bytes and the
+    /// padding spans more than 1 byte
+    pub is_multi_padding_block: T,
+
     /// The context of the base address at which we will read the input block.
     pub context: T,
     /// The segment of the base address at which we will read the input block.

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -203,18 +203,18 @@ pub(crate) fn ctl_looking_memory_filter<F: Field>(i: usize) -> Filter<F> {
     if i == KECCAK_RATE_BYTES - 1 {
         Filter::new_simple(Column::single(cols.is_full_input_block))
     } else {
-        Filter::new_simple(Column::linear_combination(
-            once((cols.is_full_input_block, F::ONE))
-                .chain(once((cols.is_padding_byte[KECCAK_RATE_BYTES - 1], F::ONE)))
-                .chain(once((cols.is_padding_byte[i], -F::ONE))),
-        ))
+        Filter::new_simple(Column::linear_combination([
+            (cols.is_full_input_block, F::ONE),
+            (cols.is_padding_byte[KECCAK_RATE_BYTES - 1], F::ONE),
+            (cols.is_padding_byte[i], -F::ONE),
+        ]))
     }
 }
 
 /// CTL filter for looking at XORs in the logic table.
 pub(crate) fn ctl_looking_logic_filter<F: Field>() -> Filter<F> {
     let cols = KECCAK_SPONGE_COL_MAP;
-    Filter::new_simple(Column::sum(vec![
+    Filter::new_simple(Column::sum([
         cols.is_full_input_block,
         cols.is_padding_byte[KECCAK_RATE_BYTES - 1],
     ]))
@@ -223,7 +223,7 @@ pub(crate) fn ctl_looking_logic_filter<F: Field>() -> Filter<F> {
 /// CTL filter for looking at the input and output in the Keccak table.
 pub(crate) fn ctl_looking_keccak_filter<F: Field>() -> Filter<F> {
     let cols = KECCAK_SPONGE_COL_MAP;
-    Filter::new_simple(Column::sum(vec![
+    Filter::new_simple(Column::sum([
         cols.is_full_input_block,
         cols.is_padding_byte[KECCAK_RATE_BYTES - 1],
     ]))

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -871,7 +871,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         yield_constr.constraint_transition(builder, constraint);
 
         // If the first padding byte is at the end of the block, then the block has a
-        // single padding byte
+        // single padding byte.
         let has_single_padding_byte = builder.sub_extension(
             local_values.is_padding_byte[KECCAK_RATE_BYTES - 1],
             local_values.is_padding_byte[KECCAK_RATE_BYTES - 2],

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -878,7 +878,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         );
 
         // If the row has a single padding byte, then it must be the last byte with
-        // value 0b10000001
+        // value 0b10000001.
         let padding_byte = builder.constant_extension(F::Extension::from_canonical_u8(0b10000001));
         let diff = builder.sub_extension(
             local_values.block_bytes[KECCAK_RATE_BYTES - 1],

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -567,17 +567,15 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         let range_max = P::Scalar::from_canonical_u64((BYTE_RANGE_MAX - 1) as u64);
         yield_constr.constraint_last_row(rc1 - range_max);
 
-        // Each flag (full-input block, final block, padding byte or implied dummy flag)
-        // must be boolean.
+        // Each flag (full-input block, padding byte or implied dummy flag) must be
+        // boolean.
         let is_full_input_block = local_values.is_full_input_block;
         yield_constr.constraint(is_full_input_block * (is_full_input_block - P::ONES));
-
-        let is_final_block: P = local_values.is_padding_byte[KECCAK_RATE_BYTES - 1];
-        yield_constr.constraint(is_final_block * (is_final_block - P::ONES));
 
         for &is_padding_byte in local_values.is_padding_byte.iter() {
             yield_constr.constraint(is_padding_byte * (is_padding_byte - P::ONES));
         }
+        let is_final_block: P = local_values.is_padding_byte[KECCAK_RATE_BYTES - 1];
 
         // A padding byte is always followed by another padding byte.
         for i in 1..KECCAK_RATE_BYTES {
@@ -753,15 +751,12 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         );
         yield_constr.constraint(builder, constraint);
 
-        let is_final_block = local_values.is_padding_byte[KECCAK_RATE_BYTES - 1];
-        let constraint = builder.mul_sub_extension(is_final_block, is_final_block, is_final_block);
-        yield_constr.constraint(builder, constraint);
-
         for &is_padding_byte in local_values.is_padding_byte.iter() {
             let constraint =
                 builder.mul_sub_extension(is_padding_byte, is_padding_byte, is_padding_byte);
             yield_constr.constraint(builder, constraint);
         }
+        let is_final_block = local_values.is_padding_byte[KECCAK_RATE_BYTES - 1];
 
         // A padding byte is always followed by another padding byte.
         for i in 1..KECCAK_RATE_BYTES {

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -663,14 +663,14 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
                     - P::from(FE::from_canonical_u8(0b10000001))),
         );
 
-        let is_padding_byte: Vec<P> = local_values
+        let is_padding_byte = local_values
             .is_final_input_len
             .iter()
             .scan(P::ZEROS, |acc, &x| {
                 *acc += x;
                 Some(*acc)
             })
-            .collect();
+            .collect_vec();
         for i in 0..KECCAK_RATE_BYTES - 1 {
             // If the row has multiple padding bytes, the first padding byte must be 1
             yield_constr.constraint_transition(
@@ -860,14 +860,14 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         let constraint = builder.mul_extension(has_single_padding_byte, diff);
         yield_constr.constraint_transition(builder, constraint);
 
-        let is_padding_byte: Vec<ExtensionTarget<D>> = local_values
+        let is_padding_byte = local_values
             .is_final_input_len
             .iter()
             .scan(builder.zero_extension(), |acc, &x| {
                 *acc = builder.add_extension(*acc, x);
                 Some(*acc)
             })
-            .collect();
+            .collect_vec();
         for i in 0..KECCAK_RATE_BYTES - 1 {
             // If the row has multiple padding bytes, the first padding byte must be 1
             let constraint = builder.mul_sub_extension(

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -898,7 +898,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
                     local_values.is_padding_byte[i]
                 }
             };
-            // If the row has multiple padding bytes, the first padding byte must be 1
+            // If the row has multiple padding bytes, the first padding byte must be 1.
             let constraint = builder.mul_sub_extension(
                 is_first_padding_byte,
                 local_values.block_bytes[i],

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -377,8 +377,8 @@ impl<F: RichField + Extendable<D>, const D: usize> KeccakSpongeStark<F, D> {
 
     /// Generates a row containing the last input bytes.
     /// On top of computing one absorption and padding the input,
-    /// we indicate the padding input bytes by setting
-    /// `row.is_padding_byte` to 1.
+    /// we indicate all the padding input bytes by setting the
+    /// corresponding indices in `row.is_padding_byte` to 1.
     fn generate_final_row(
         &self,
         op: &KeccakSpongeOp,

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -45,14 +45,12 @@ pub(crate) fn ctl_looked_data<F: Field>() -> Vec<Column<F>> {
         outputs.push(cur_col);
     }
 
-    // The length of the inputs is `already_absorbed_bytes + is_final_input_len`.
-    let len_col = Column::linear_combination(
-        iter::once((cols.already_absorbed_bytes, F::ONE)).chain(
-            cols.is_final_input_len
-                .iter()
-                .enumerate()
-                .map(|(i, &elt)| (elt, F::from_canonical_usize(i))),
-        ),
+    // The length of the inputs is
+    // `already_absorbed_bytes + (RATE - Σi is_padding_byte[i])`.
+    let len_col = Column::linear_combination_with_constant(
+        iter::once((cols.already_absorbed_bytes, F::ONE))
+            .chain((0..KECCAK_RATE_BYTES).map(|i| (cols.is_padding_byte[i], -F::ONE))),
+        F::from_canonical_usize(KECCAK_RATE_BYTES),
     );
 
     let mut res: Vec<Column<F>> =
@@ -191,7 +189,9 @@ pub(crate) fn ctl_looking_logic<F: Field>(i: usize) -> Vec<Column<F>> {
 pub(crate) fn ctl_looked_filter<F: Field>() -> Filter<F> {
     // The CPU table is only interested in our final-block rows, since those contain
     // the final sponge output.
-    Filter::new_simple(Column::sum(KECCAK_SPONGE_COL_MAP.is_final_input_len))
+    Filter::new_simple(Column::single(
+        KECCAK_SPONGE_COL_MAP.is_padding_byte[KECCAK_RATE_BYTES - 1],
+    ))
 }
 
 /// CTL filter for reading the `i`th byte of input from memory.
@@ -203,8 +203,10 @@ pub(crate) fn ctl_looking_memory_filter<F: Field>(i: usize) -> Filter<F> {
     if i == KECCAK_RATE_BYTES - 1 {
         Filter::new_simple(Column::single(cols.is_full_input_block))
     } else {
-        Filter::new_simple(Column::sum(
-            once(&cols.is_full_input_block).chain(&cols.is_final_input_len[i + 1..]),
+        Filter::new_simple(Column::linear_combination(
+            once((cols.is_full_input_block, F::ONE))
+                .chain(once((cols.is_padding_byte[KECCAK_RATE_BYTES - 1], F::ONE)))
+                .chain(once((cols.is_padding_byte[i], -F::ONE))),
         ))
     }
 }
@@ -212,17 +214,19 @@ pub(crate) fn ctl_looking_memory_filter<F: Field>(i: usize) -> Filter<F> {
 /// CTL filter for looking at XORs in the logic table.
 pub(crate) fn ctl_looking_logic_filter<F: Field>() -> Filter<F> {
     let cols = KECCAK_SPONGE_COL_MAP;
-    Filter::new_simple(Column::sum(
-        once(&cols.is_full_input_block).chain(&cols.is_final_input_len),
-    ))
+    Filter::new_simple(Column::sum(vec![
+        cols.is_full_input_block,
+        cols.is_padding_byte[KECCAK_RATE_BYTES - 1],
+    ]))
 }
 
 /// CTL filter for looking at the input and output in the Keccak table.
 pub(crate) fn ctl_looking_keccak_filter<F: Field>() -> Filter<F> {
     let cols = KECCAK_SPONGE_COL_MAP;
-    Filter::new_simple(Column::sum(
-        once(&cols.is_full_input_block).chain(&cols.is_final_input_len),
-    ))
+    Filter::new_simple(Column::sum(vec![
+        cols.is_full_input_block,
+        cols.is_padding_byte[KECCAK_RATE_BYTES - 1],
+    ]))
 }
 
 /// Information about a Keccak sponge operation needed for witness generation.
@@ -373,8 +377,8 @@ impl<F: RichField + Extendable<D>, const D: usize> KeccakSpongeStark<F, D> {
 
     /// Generates a row containing the last input bytes.
     /// On top of computing one absorption and padding the input,
-    /// we indicate the last non-padding input byte by setting
-    /// `row.is_final_input_len[final_inputs.len()]` to 1.
+    /// we indicate the padding input bytes by setting
+    /// `row.is_padding_byte` to 1.
     fn generate_final_row(
         &self,
         op: &KeccakSpongeOp,
@@ -399,7 +403,9 @@ impl<F: RichField + Extendable<D>, const D: usize> KeccakSpongeStark<F, D> {
             row.block_bytes[KECCAK_RATE_BYTES - 1] = F::from_canonical_u8(0b10000000);
         }
 
-        row.is_final_input_len[final_inputs.len()] = F::ONE;
+        for i in final_inputs.len()..KECCAK_RATE_BYTES {
+            row.is_padding_byte[i] = F::ONE;
+        }
 
         Self::generate_common_fields(&mut row, op, already_absorbed_bytes, sponge_state);
         row
@@ -561,16 +567,23 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         let range_max = P::Scalar::from_canonical_u64((BYTE_RANGE_MAX - 1) as u64);
         yield_constr.constraint_last_row(rc1 - range_max);
 
-        // Each flag (full-input block, final block or implied dummy flag) must be
-        // boolean.
+        // Each flag (full-input block, final block, padding byte or implied dummy flag)
+        // must be boolean.
         let is_full_input_block = local_values.is_full_input_block;
         yield_constr.constraint(is_full_input_block * (is_full_input_block - P::ONES));
 
-        let is_final_block: P = local_values.is_final_input_len.iter().copied().sum();
+        let is_final_block: P = local_values.is_padding_byte[KECCAK_RATE_BYTES - 1];
         yield_constr.constraint(is_final_block * (is_final_block - P::ONES));
 
-        for &is_final_len in local_values.is_final_input_len.iter() {
-            yield_constr.constraint(is_final_len * (is_final_len - P::ONES));
+        for &is_padding_byte in local_values.is_padding_byte.iter() {
+            yield_constr.constraint(is_padding_byte * (is_padding_byte - P::ONES));
+        }
+
+        // A padding byte is always followed by another padding byte
+        for i in 1..KECCAK_RATE_BYTES {
+            yield_constr.constraint(
+                local_values.is_padding_byte[i - 1] * (local_values.is_padding_byte[i] - P::ONES),
+            );
         }
 
         // Ensure that full-input block and final block flags are not set to 1 at the
@@ -653,7 +666,8 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
 
         // If the first padding byte is at the end of the block, then the block has a
         // single padding byte
-        let has_single_padding_byte = local_values.is_final_input_len[KECCAK_RATE_BYTES - 1];
+        let has_single_padding_byte = local_values.is_padding_byte[KECCAK_RATE_BYTES - 1]
+            - local_values.is_padding_byte[KECCAK_RATE_BYTES - 2];
 
         // If the row has a single padding byte, then it must be the last byte with
         // value 0b10000001
@@ -663,24 +677,23 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
                     - P::from(FE::from_canonical_u8(0b10000001))),
         );
 
-        let is_padding_byte = local_values
-            .is_final_input_len
-            .iter()
-            .scan(P::ZEROS, |acc, &x| {
-                *acc += x;
-                Some(*acc)
-            })
-            .collect_vec();
         for i in 0..KECCAK_RATE_BYTES - 1 {
+            let is_first_padding_byte = {
+                if i > 0 {
+                    local_values.is_padding_byte[i] - local_values.is_padding_byte[i - 1]
+                } else {
+                    local_values.is_padding_byte[i]
+                }
+            };
             // If the row has multiple padding bytes, the first padding byte must be 1
             yield_constr.constraint_transition(
-                local_values.is_final_input_len[i] * (local_values.block_bytes[i] - P::ONES),
+                is_first_padding_byte * (local_values.block_bytes[i] - P::ONES),
             );
             // If the row has multiple padding bytes, the other padding bytes
             // except the last one must be 0
             yield_constr.constraint_transition(
-                is_padding_byte[i]
-                    * (local_values.is_final_input_len[i] - P::ONES)
+                local_values.is_padding_byte[i]
+                    * (is_first_padding_byte - P::ONES)
                     * local_values.block_bytes[i],
             );
         }
@@ -695,7 +708,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         // A dummy row is always followed by another dummy row, so the prover can't put
         // dummy rows "in between" to avoid the above checks.
         let is_dummy = P::ONES - is_full_input_block - is_final_block;
-        let next_is_final_block: P = next_values.is_final_input_len.iter().copied().sum();
+        let next_is_final_block: P = next_values.is_padding_byte[KECCAK_RATE_BYTES - 1];
         yield_constr.constraint_transition(
             is_dummy * (next_values.is_full_input_block + next_is_final_block),
         );
@@ -730,8 +743,8 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         let t = builder.sub_extension(rc1, range_max);
         yield_constr.constraint_last_row(builder, t);
 
-        // Each flag (full-input block, final block or implied dummy flag) must be
-        // boolean.
+        // Each flag (full-input block, final block, padding byte or implied dummy flag)
+        // must be boolean.
         let is_full_input_block = local_values.is_full_input_block;
         let constraint = builder.mul_sub_extension(
             is_full_input_block,
@@ -740,12 +753,23 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         );
         yield_constr.constraint(builder, constraint);
 
-        let is_final_block = builder.add_many_extension(local_values.is_final_input_len);
+        let is_final_block = local_values.is_padding_byte[KECCAK_RATE_BYTES - 1];
         let constraint = builder.mul_sub_extension(is_final_block, is_final_block, is_final_block);
         yield_constr.constraint(builder, constraint);
 
-        for &is_final_len in local_values.is_final_input_len.iter() {
-            let constraint = builder.mul_sub_extension(is_final_len, is_final_len, is_final_len);
+        for &is_padding_byte in local_values.is_padding_byte.iter() {
+            let constraint =
+                builder.mul_sub_extension(is_padding_byte, is_padding_byte, is_padding_byte);
+            yield_constr.constraint(builder, constraint);
+        }
+
+        // A padding byte is always followed by another padding byte
+        for i in 1..KECCAK_RATE_BYTES {
+            let constraint = builder.mul_sub_extension(
+                local_values.is_padding_byte[i - 1],
+                local_values.is_padding_byte[i],
+                local_values.is_padding_byte[i - 1],
+            );
             yield_constr.constraint(builder, constraint);
         }
 
@@ -848,7 +872,10 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
 
         // If the first padding byte is at the end of the block, then the block has a
         // single padding byte
-        let has_single_padding_byte = local_values.is_final_input_len[KECCAK_RATE_BYTES - 1];
+        let has_single_padding_byte = builder.sub_extension(
+            local_values.is_padding_byte[KECCAK_RATE_BYTES - 1],
+            local_values.is_padding_byte[KECCAK_RATE_BYTES - 2],
+        );
 
         // If the row has a single padding byte, then it must be the last byte with
         // value 0b10000001
@@ -860,29 +887,31 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         let constraint = builder.mul_extension(has_single_padding_byte, diff);
         yield_constr.constraint_transition(builder, constraint);
 
-        let is_padding_byte = local_values
-            .is_final_input_len
-            .iter()
-            .scan(builder.zero_extension(), |acc, &x| {
-                *acc = builder.add_extension(*acc, x);
-                Some(*acc)
-            })
-            .collect_vec();
         for i in 0..KECCAK_RATE_BYTES - 1 {
+            let is_first_padding_byte = {
+                if i > 0 {
+                    builder.sub_extension(
+                        local_values.is_padding_byte[i],
+                        local_values.is_padding_byte[i - 1],
+                    )
+                } else {
+                    local_values.is_padding_byte[i]
+                }
+            };
             // If the row has multiple padding bytes, the first padding byte must be 1
             let constraint = builder.mul_sub_extension(
-                local_values.is_final_input_len[i],
+                is_first_padding_byte,
                 local_values.block_bytes[i],
-                local_values.is_final_input_len[i],
+                is_first_padding_byte,
             );
             yield_constr.constraint_transition(builder, constraint);
 
             // If the row has multiple padding bytes, the other padding bytes
             // except the last one must be 0
             let sel = builder.mul_sub_extension(
-                is_padding_byte[i],
-                local_values.is_final_input_len[i],
-                is_padding_byte[i],
+                local_values.is_padding_byte[i],
+                is_first_padding_byte,
+                local_values.is_padding_byte[i],
             );
             let constraint = builder.mul_extension(sel, local_values.block_bytes[i]);
             yield_constr.constraint_transition(builder, constraint);
@@ -905,7 +934,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
             let tmp = builder.sub_extension(one, is_final_block);
             builder.sub_extension(tmp, is_full_input_block)
         };
-        let next_is_final_block = builder.add_many_extension(next_values.is_final_input_len);
+        let next_is_final_block = next_values.is_padding_byte[KECCAK_RATE_BYTES - 1];
         let constraint = {
             let tmp = builder.add_extension(next_is_final_block, next_values.is_full_input_block);
             builder.mul_extension(is_dummy, tmp)

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -579,7 +579,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
             yield_constr.constraint(is_padding_byte * (is_padding_byte - P::ONES));
         }
 
-        // A padding byte is always followed by another padding byte
+        // A padding byte is always followed by another padding byte.
         for i in 1..KECCAK_RATE_BYTES {
             yield_constr.constraint(
                 local_values.is_padding_byte[i - 1] * (local_values.is_padding_byte[i] - P::ONES),

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -395,6 +395,7 @@ impl<F: RichField + Extendable<D>, const D: usize> KeccakSpongeStark<F, D> {
             // Both 1s are placed in the same byte.
             row.block_bytes[final_inputs.len()] = F::from_canonical_u8(0b10000001);
         } else {
+            row.is_multi_padding_block = F::ONE;
             row.block_bytes[final_inputs.len()] = F::ONE;
             row.block_bytes[KECCAK_RATE_BYTES - 1] = F::from_canonical_u8(0b10000000);
         }
@@ -561,10 +562,13 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         let range_max = P::Scalar::from_canonical_u64((BYTE_RANGE_MAX - 1) as u64);
         yield_constr.constraint_last_row(rc1 - range_max);
 
-        // Each flag (full-input block, final block or implied dummy flag) must be
-        // boolean.
+        // Each flag (full-input block, multi-padding block, final block or implied
+        // dummy flag) must be boolean.
         let is_full_input_block = local_values.is_full_input_block;
         yield_constr.constraint(is_full_input_block * (is_full_input_block - P::ONES));
+
+        let is_multi_padding_block = local_values.is_multi_padding_block;
+        yield_constr.constraint(is_multi_padding_block * (is_multi_padding_block - P::ONES));
 
         let is_final_block: P = local_values.is_final_input_len.iter().copied().sum();
         yield_constr.constraint(is_final_block * (is_final_block - P::ONES));
@@ -651,6 +655,39 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
                     - next_values.already_absorbed_bytes),
         );
 
+        // If the first padding byte is at the end of the block, then the block has a
+        // single padding byte
+        let has_single_padding_byte = local_values.is_final_input_len[KECCAK_RATE_BYTES - 1];
+
+        // If this is the final block, then it can either contain a single padding byte
+        // or be a row with multiple padding bytes
+        yield_constr.constraint_transition(
+            is_final_block * (P::ONES - has_single_padding_byte) - is_multi_padding_block,
+        );
+
+        // If the row has a single padding byte, then it must be the last byte with
+        // value 0b10000001
+        yield_constr.constraint_transition(
+            has_single_padding_byte
+                * (local_values.block_bytes[KECCAK_RATE_BYTES - 1]
+                    - P::from(FE::from_canonical_u8(0b10000001))),
+        );
+
+        // If the row has multiple padding bytes, then the first padding byte must be 1
+        for i in 0..KECCAK_RATE_BYTES - 1 {
+            yield_constr.constraint_transition(
+                is_multi_padding_block
+                    * local_values.is_final_input_len[i]
+                    * (local_values.block_bytes[i] - P::ONES),
+            );
+        }
+        // If the row has multiple padding bytes, then the last byte must be 0b10000000
+        yield_constr.constraint_transition(
+            is_multi_padding_block
+                * (local_values.block_bytes[KECCAK_RATE_BYTES - 1]
+                    - P::from(FE::from_canonical_u8(0b10000000))),
+        );
+
         // A dummy row is always followed by another dummy row, so the prover can't put
         // dummy rows "in between" to avoid the above checks.
         let is_dummy = P::ONES - is_full_input_block - is_final_block;
@@ -689,13 +726,21 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         let t = builder.sub_extension(rc1, range_max);
         yield_constr.constraint_last_row(builder, t);
 
-        // Each flag (full-input block, final block or implied dummy flag) must be
-        // boolean.
+        // Each flag (full-input block, multi-padding block, final block or implied
+        // dummy flag) must be boolean.
         let is_full_input_block = local_values.is_full_input_block;
         let constraint = builder.mul_sub_extension(
             is_full_input_block,
             is_full_input_block,
             is_full_input_block,
+        );
+        yield_constr.constraint(builder, constraint);
+
+        let is_multi_padding_block = local_values.is_multi_padding_block;
+        let constraint = builder.mul_sub_extension(
+            is_multi_padding_block,
+            is_multi_padding_block,
+            is_multi_padding_block,
         );
         yield_constr.constraint(builder, constraint);
 
@@ -803,6 +848,50 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         let absorbed_diff =
             builder.sub_extension(absorbed_bytes, next_values.already_absorbed_bytes);
         let constraint = builder.mul_extension(is_full_input_block, absorbed_diff);
+        yield_constr.constraint_transition(builder, constraint);
+
+        // If the first padding byte is at the end of the block, then the block has a
+        // single padding byte
+        let has_single_padding_byte = local_values.is_final_input_len[KECCAK_RATE_BYTES - 1];
+
+        // If this is the final block, then it can either contain a single padding byte
+        // or be a row with multiple padding bytes
+        let not_has_single_padding_byte =
+            builder.sub_extension(one, local_values.is_final_input_len[KECCAK_RATE_BYTES - 1]);
+        let constraint = builder.mul_sub_extension(
+            is_final_block,
+            not_has_single_padding_byte,
+            is_multi_padding_block,
+        );
+        yield_constr.constraint_transition(builder, constraint);
+
+        // If the row has a single padding byte, then it must be the last byte with
+        // value 0b10000001
+        let padding_byte = builder.constant_extension(F::Extension::from_canonical_u8(0b10000001));
+        let diff = builder.sub_extension(
+            local_values.block_bytes[KECCAK_RATE_BYTES - 1],
+            padding_byte,
+        );
+        let constraint = builder.mul_extension(has_single_padding_byte, diff);
+        yield_constr.constraint_transition(builder, constraint);
+
+        // If the row has multiple padding bytes, then the first padding byte must be 1
+        for i in 0..KECCAK_RATE_BYTES - 1 {
+            let diff = builder.sub_extension(local_values.block_bytes[i], one);
+            let constraint = {
+                let sel = builder
+                    .mul_extension(is_multi_padding_block, local_values.is_final_input_len[i]);
+                builder.mul_extension(sel, diff)
+            };
+            yield_constr.constraint_transition(builder, constraint);
+        }
+        // If the row has multiple padding bytes, then the last byte must be 0b10000000
+        let padding_byte = builder.constant_extension(F::Extension::from_canonical_u8(0b10000000));
+        let diff = builder.sub_extension(
+            local_values.block_bytes[KECCAK_RATE_BYTES - 1],
+            padding_byte,
+        );
+        let constraint = builder.mul_extension(is_multi_padding_block, diff);
         yield_constr.constraint_transition(builder, constraint);
 
         // A dummy row is always followed by another dummy row, so the prover can't put

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -665,12 +665,12 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
         );
 
         // If the first padding byte is at the end of the block, then the block has a
-        // single padding byte
+        // single padding byte.
         let has_single_padding_byte = local_values.is_padding_byte[KECCAK_RATE_BYTES - 1]
             - local_values.is_padding_byte[KECCAK_RATE_BYTES - 2];
 
         // If the row has a single padding byte, then it must be the last byte with
-        // value 0b10000001
+        // value 0b10000001.
         yield_constr.constraint_transition(
             has_single_padding_byte
                 * (local_values.block_bytes[KECCAK_RATE_BYTES - 1]

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -685,19 +685,19 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
                     local_values.is_padding_byte[i]
                 }
             };
-            // If the row has multiple padding bytes, the first padding byte must be 1
+            // If the row has multiple padding bytes, the first padding byte must be 1.
             yield_constr.constraint_transition(
                 is_first_padding_byte * (local_values.block_bytes[i] - P::ONES),
             );
             // If the row has multiple padding bytes, the other padding bytes
-            // except the last one must be 0
+            // except the last one must be 0.
             yield_constr.constraint_transition(
                 local_values.is_padding_byte[i]
                     * (is_first_padding_byte - P::ONES)
                     * local_values.block_bytes[i],
             );
         }
-        // If the row has multiple padding bytes, then the last byte must be 0b10000000
+        // If the row has multiple padding bytes, then the last byte must be 0b10000000.
         yield_constr.constraint_transition(
             is_final_block
                 * (has_single_padding_byte - P::ONES)
@@ -763,7 +763,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
             yield_constr.constraint(builder, constraint);
         }
 
-        // A padding byte is always followed by another padding byte
+        // A padding byte is always followed by another padding byte.
         for i in 1..KECCAK_RATE_BYTES {
             let constraint = builder.mul_sub_extension(
                 local_values.is_padding_byte[i - 1],
@@ -907,7 +907,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
             yield_constr.constraint_transition(builder, constraint);
 
             // If the row has multiple padding bytes, the other padding bytes
-            // except the last one must be 0
+            // except the last one must be 0.
             let sel = builder.mul_sub_extension(
                 local_values.is_padding_byte[i],
                 is_first_padding_byte,
@@ -917,7 +917,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
             yield_constr.constraint_transition(builder, constraint);
         }
 
-        // If the row has multiple padding bytes, then the last byte must be 0b10000000
+        // If the row has multiple padding bytes, then the last byte must be 0b10000000.
         let sel =
             builder.mul_sub_extension(is_final_block, has_single_padding_byte, is_final_block);
         let padding_byte = builder.constant_extension(F::Extension::from_canonical_u8(0b10000000));


### PR DESCRIPTION
- Replace `is_final_input_len` with `is_padding_byte`
- Added constraints for padding

Fixes #156 