### PR TITLE
Reduce verbosity in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Reduce verbosity in logs ([#160](https://github.com/0xPolygonZero/zk_evm/pull/160))
+
 ## [0.3.0] - 2024-04-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix(keccak-sponge): properly constrain padding bytes ([#158](https://github.com/0xPolygonZero/zk_evm/pull/158))
 - Reduce verbosity in logs ([#160](https://github.com/0xPolygonZero/zk_evm/pull/160))
 
 ## [0.3.0] - 2024-04-03

--- a/trace_decoder/src/utils.rs
+++ b/trace_decoder/src/utils.rs
@@ -1,5 +1,6 @@
 use ethereum_types::H256;
 use keccak_hash::keccak;
+use log::debug;
 use mpt_trie::{
     nibbles::Nibbles,
     partial_trie::{HashedPartialTrie, PartialTrie},
@@ -30,7 +31,7 @@ pub(crate) fn print_value_and_hash_nodes_of_storage_trie(
     trie: &HashedPartialTrie,
 ) {
     let trie_elems = print_value_and_hash_nodes_of_trie_common(trie);
-    println!("Storage trie for {:x}: {:#?}", s_trie_addr, trie_elems);
+    debug!("Storage trie for {:x}: {:#?}", s_trie_addr, trie_elems);
 }
 
 // TODO: Move under a feature flag...


### PR DESCRIPTION
The decoder is always printing the storage tries in the logs, which can be quite cumbersome and noisy especially when the lowest log level is selected.

This moves it from `println!` to `log::debug!`

cc @bgluth