### PR TITLE
Bump with latest starky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make some more functions constant ([#154](https://github.com/0xPolygonZero/zk_evm/pull/154))
 - fix(keccak-sponge): properly constrain padding bytes ([#158](https://github.com/0xPolygonZero/zk_evm/pull/158))
 - Reduce verbosity in logs ([#160](https://github.com/0xPolygonZero/zk_evm/pull/160))
+- Bump with latest starky ([#161](https://github.com/0xPolygonZero/zk_evm/pull/161))
 
 ## [0.3.0] - 2024-04-03
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ serde_json = "1.0.96"
 thiserror = "1.0.49"
 
 # plonky2-related dependencies
-plonky2 = "0.2.1"
+plonky2 = "0.2.2"
 plonky2_maybe_rayon = "0.2.0"
 plonky2_util = "0.2.0"
-starky = "0.3.0"
+starky = "0.4.0"
 
 
 [workspace.package]

--- a/evm_arithmetization/src/all_stark.rs
+++ b/evm_arithmetization/src/all_stark.rs
@@ -138,27 +138,27 @@ fn ctl_byte_packing<F: Field>() -> CrossTableLookup<F> {
     let cpu_packing_looking = TableWithColumns::new(
         *Table::Cpu,
         cpu_stark::ctl_data_byte_packing(),
-        Some(cpu_stark::ctl_filter_byte_packing()),
+        cpu_stark::ctl_filter_byte_packing(),
     );
     let cpu_unpacking_looking = TableWithColumns::new(
         *Table::Cpu,
         cpu_stark::ctl_data_byte_unpacking(),
-        Some(cpu_stark::ctl_filter_byte_unpacking()),
+        cpu_stark::ctl_filter_byte_unpacking(),
     );
     let cpu_push_packing_looking = TableWithColumns::new(
         *Table::Cpu,
         cpu_stark::ctl_data_byte_packing_push(),
-        Some(cpu_stark::ctl_filter_byte_packing_push()),
+        cpu_stark::ctl_filter_byte_packing_push(),
     );
     let cpu_jumptable_read_looking = TableWithColumns::new(
         *Table::Cpu,
         cpu_stark::ctl_data_jumptable_read(),
-        Some(cpu_stark::ctl_filter_syscall_exceptions()),
+        cpu_stark::ctl_filter_syscall_exceptions(),
     );
     let byte_packing_looked = TableWithColumns::new(
         *Table::BytePacking,
         byte_packing_stark::ctl_looked_data(),
-        Some(byte_packing_stark::ctl_looked_filter()),
+        byte_packing_stark::ctl_looked_filter(),
     );
     CrossTableLookup::new(
         vec![
@@ -179,12 +179,12 @@ fn ctl_keccak_inputs<F: Field>() -> CrossTableLookup<F> {
     let keccak_sponge_looking = TableWithColumns::new(
         *Table::KeccakSponge,
         keccak_sponge_stark::ctl_looking_keccak_inputs(),
-        Some(keccak_sponge_stark::ctl_looking_keccak_filter()),
+        keccak_sponge_stark::ctl_looking_keccak_filter(),
     );
     let keccak_looked = TableWithColumns::new(
         *Table::Keccak,
         keccak_stark::ctl_data_inputs(),
-        Some(keccak_stark::ctl_filter_inputs()),
+        keccak_stark::ctl_filter_inputs(),
     );
     CrossTableLookup::new(vec![keccak_sponge_looking], keccak_looked)
 }
@@ -196,12 +196,12 @@ fn ctl_keccak_outputs<F: Field>() -> CrossTableLookup<F> {
     let keccak_sponge_looking = TableWithColumns::new(
         *Table::KeccakSponge,
         keccak_sponge_stark::ctl_looking_keccak_outputs(),
-        Some(keccak_sponge_stark::ctl_looking_keccak_filter()),
+        keccak_sponge_stark::ctl_looking_keccak_filter(),
     );
     let keccak_looked = TableWithColumns::new(
         *Table::Keccak,
         keccak_stark::ctl_data_outputs(),
-        Some(keccak_stark::ctl_filter_outputs()),
+        keccak_stark::ctl_filter_outputs(),
     );
     CrossTableLookup::new(vec![keccak_sponge_looking], keccak_looked)
 }
@@ -212,12 +212,12 @@ fn ctl_keccak_sponge<F: Field>() -> CrossTableLookup<F> {
     let cpu_looking = TableWithColumns::new(
         *Table::Cpu,
         cpu_stark::ctl_data_keccak_sponge(),
-        Some(cpu_stark::ctl_filter_keccak_sponge()),
+        cpu_stark::ctl_filter_keccak_sponge(),
     );
     let keccak_sponge_looked = TableWithColumns::new(
         *Table::KeccakSponge,
         keccak_sponge_stark::ctl_looked_data(),
-        Some(keccak_sponge_stark::ctl_looked_filter()),
+        keccak_sponge_stark::ctl_looked_filter(),
     );
     CrossTableLookup::new(vec![cpu_looking], keccak_sponge_looked)
 }
@@ -228,19 +228,18 @@ fn ctl_logic<F: Field>() -> CrossTableLookup<F> {
     let cpu_looking = TableWithColumns::new(
         *Table::Cpu,
         cpu_stark::ctl_data_logic(),
-        Some(cpu_stark::ctl_filter_logic()),
+        cpu_stark::ctl_filter_logic(),
     );
     let mut all_lookers = vec![cpu_looking];
     for i in 0..keccak_sponge_stark::num_logic_ctls() {
         let keccak_sponge_looking = TableWithColumns::new(
             *Table::KeccakSponge,
             keccak_sponge_stark::ctl_looking_logic(i),
-            Some(keccak_sponge_stark::ctl_looking_logic_filter()),
+            keccak_sponge_stark::ctl_looking_logic_filter(),
         );
         all_lookers.push(keccak_sponge_looking);
     }
-    let logic_looked =
-        TableWithColumns::new(*Table::Logic, logic::ctl_data(), Some(logic::ctl_filter()));
+    let logic_looked = TableWithColumns::new(*Table::Logic, logic::ctl_data(), logic::ctl_filter());
     CrossTableLookup::new(all_lookers, logic_looked)
 }
 
@@ -250,42 +249,42 @@ fn ctl_memory<F: Field>() -> CrossTableLookup<F> {
     let cpu_memory_code_read = TableWithColumns::new(
         *Table::Cpu,
         cpu_stark::ctl_data_code_memory(),
-        Some(cpu_stark::ctl_filter_code_memory()),
+        cpu_stark::ctl_filter_code_memory(),
     );
     let cpu_memory_gp_ops = (0..NUM_GP_CHANNELS).map(|channel| {
         TableWithColumns::new(
             *Table::Cpu,
             cpu_stark::ctl_data_gp_memory(channel),
-            Some(cpu_stark::ctl_filter_gp_memory(channel)),
+            cpu_stark::ctl_filter_gp_memory(channel),
         )
     });
     let cpu_push_write_ops = TableWithColumns::new(
         *Table::Cpu,
         cpu_stark::ctl_data_partial_memory::<F>(),
-        Some(cpu_stark::ctl_filter_partial_memory()),
+        cpu_stark::ctl_filter_partial_memory(),
     );
     let cpu_set_context_write = TableWithColumns::new(
         *Table::Cpu,
         cpu_stark::ctl_data_memory_old_sp_write_set_context::<F>(),
-        Some(cpu_stark::ctl_filter_set_context()),
+        cpu_stark::ctl_filter_set_context(),
     );
     let cpu_set_context_read = TableWithColumns::new(
         *Table::Cpu,
         cpu_stark::ctl_data_memory_new_sp_read_set_context::<F>(),
-        Some(cpu_stark::ctl_filter_set_context()),
+        cpu_stark::ctl_filter_set_context(),
     );
     let keccak_sponge_reads = (0..KECCAK_RATE_BYTES).map(|i| {
         TableWithColumns::new(
             *Table::KeccakSponge,
             keccak_sponge_stark::ctl_looking_memory(i),
-            Some(keccak_sponge_stark::ctl_looking_memory_filter(i)),
+            keccak_sponge_stark::ctl_looking_memory_filter(i),
         )
     });
     let byte_packing_ops = (0..32).map(|i| {
         TableWithColumns::new(
             *Table::BytePacking,
             byte_packing_stark::ctl_looking_memory(i),
-            Some(byte_packing_stark::ctl_looking_memory_filter(i)),
+            byte_packing_stark::ctl_looking_memory_filter(i),
         )
     });
     let all_lookers = vec![
@@ -302,7 +301,7 @@ fn ctl_memory<F: Field>() -> CrossTableLookup<F> {
     let memory_looked = TableWithColumns::new(
         *Table::Memory,
         memory_stark::ctl_data(),
-        Some(memory_stark::ctl_filter()),
+        memory_stark::ctl_filter(),
     );
     CrossTableLookup::new(all_lookers, memory_looked)
 }

--- a/evm_arithmetization/src/arithmetic/arithmetic_stark.rs
+++ b/evm_arithmetization/src/arithmetic/arithmetic_stark.rs
@@ -100,9 +100,7 @@ pub(crate) fn ctl_arithmetic_rows<F: Field>() -> TableWithColumns<F> {
     let mut filter_cols = COMBINED_OPS.to_vec();
     filter_cols.push((columns::IS_RANGE_CHECK, 0x01));
 
-    let filter = Some(Filter::new_simple(Column::sum(
-        filter_cols.iter().map(|(c, _v)| *c),
-    )));
+    let filter = Filter::new_simple(Column::sum(filter_cols.iter().map(|(c, _v)| *c)));
 
     let mut all_combined_cols = COMBINED_OPS.to_vec();
     all_combined_cols.push((columns::OPCODE_COL, 0x01));
@@ -323,7 +321,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for ArithmeticSta
             columns: Column::singles(SHARED_COLS).collect(),
             table_column: Column::single(RANGE_COUNTER),
             frequencies_column: Column::single(RC_FREQUENCIES),
-            filter_columns: vec![None; NUM_SHARED_COLS],
+            filter_columns: vec![Default::default(); NUM_SHARED_COLS],
         }]
     }
 

--- a/evm_arithmetization/src/byte_packing/byte_packing_stark.rs
+++ b/evm_arithmetization/src/byte_packing/byte_packing_stark.rs
@@ -402,7 +402,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for BytePackingSt
             columns: Column::singles(value_bytes(0)..value_bytes(0) + NUM_BYTES).collect(),
             table_column: Column::single(RANGE_COUNTER),
             frequencies_column: Column::single(RC_FREQUENCIES),
-            filter_columns: vec![None; NUM_BYTES],
+            filter_columns: vec![Default::default(); NUM_BYTES],
         }]
     }
 

--- a/evm_arithmetization/src/cpu/cpu_stark.rs
+++ b/evm_arithmetization/src/cpu/cpu_stark.rs
@@ -116,7 +116,7 @@ pub(crate) fn ctl_arithmetic_base_rows<F: Field>() -> TableWithColumns<F> {
     TableWithColumns::new(
         *Table::Cpu,
         columns,
-        Some(Filter::new(
+        Filter::new(
             vec![(Column::single(COL_MAP.op.push_prover_input), col_bit)],
             vec![Column::sum([
                 COL_MAP.op.binary_op,
@@ -126,7 +126,7 @@ pub(crate) fn ctl_arithmetic_base_rows<F: Field>() -> TableWithColumns<F> {
                 COL_MAP.op.syscall,
                 COL_MAP.op.exception,
             ])],
-        )),
+        ),
     )
 }
 

--- a/evm_arithmetization/src/keccak/keccak_stark.rs
+++ b/evm_arithmetization/src/keccak/keccak_stark.rs
@@ -734,7 +734,7 @@ mod tests {
                 gamma: F::ZERO,
             },
             vec![],
-            vec![Some(Filter::new_simple(Column::constant(F::ZERO)))],
+            vec![Filter::new_simple(Column::constant(F::ZERO))],
         );
         let ctl_data = CtlData {
             zs_columns: vec![ctl_z_data.clone(); config.num_challenges],

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -946,7 +946,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
             columns: Column::singles(get_block_bytes_range()).collect(),
             table_column: Column::single(RANGE_COUNTER),
             frequencies_column: Column::single(RC_FREQUENCIES),
-            filter_columns: vec![None; KECCAK_RATE_BYTES],
+            filter_columns: vec![Default::default(); KECCAK_RATE_BYTES],
         }]
     }
 

--- a/evm_arithmetization/src/memory/memory_stark.rs
+++ b/evm_arithmetization/src/memory/memory_stark.rs
@@ -581,11 +581,8 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for MemoryStark<F
             table_column: Column::single(COUNTER),
             frequencies_column: Column::single(FREQUENCIES),
             filter_columns: vec![
-                None,
-                Some(Filter::new_simple(Column::sum([
-                    CONTEXT_FIRST_CHANGE,
-                    SEGMENT_FIRST_CHANGE,
-                ]))),
+                Default::default(),
+                Filter::new_simple(Column::sum([CONTEXT_FIRST_CHANGE, SEGMENT_FIRST_CHANGE])),
             ],
         }]
     }


### PR DESCRIPTION
Bumps deps to `plonky2` v0.2.2 and `starky` v0.4.0.

Includes CTL filtering simplification and compilation fix with AVX-512 instructions enabled.