### PR TITLE
wip: fix todos

### DIFF
--- a/evm_arithmetization/src/cpu/cpu_stark.rs
+++ b/evm_arithmetization/src/cpu/cpu_stark.rs
@@ -17,7 +17,7 @@ use starky::stark::Stark;
 use super::columns::CpuColumnsView;
 use super::halt;
 use super::kernel::constants::context_metadata::ContextMetadata;
-use super::membus::NUM_GP_CHANNELS;
+use super::membus::{NUM_CHANNELS, NUM_GP_CHANNELS};
 use crate::all_stark::{EvmStarkFrame, Table};
 use crate::cpu::columns::{COL_MAP, NUM_CPU_COLUMNS};
 use crate::cpu::{
@@ -25,7 +25,7 @@ use crate::cpu::{
     modfp254, pc, push0, shift, simple_logic, stack, syscalls_exceptions,
 };
 use crate::memory::segments::Segment;
-use crate::memory::{NUM_CHANNELS, VALUE_LIMBS};
+use crate::memory::VALUE_LIMBS;
 
 /// Creates the vector of `Columns` corresponding to the General Purpose
 /// channels when calling the Keccak sponge: the CPU reads the output of the

--- a/evm_arithmetization/src/cpu/kernel/tests/ecc/ecrecover.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/ecc/ecrecover.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
 use std::str::FromStr;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use ethereum_types::U256;
 use plonky2::field::goldilocks_field::GoldilocksField as F;
 
@@ -33,17 +34,18 @@ fn test_invalid_ecrecover(hash: &str, v: &str, r: &str, s: &str) -> Result<()> {
 #[test]
 fn test_ecrecover_real_block() -> Result<()> {
     let f = include_str!("ecrecover_test_data");
-    let convert_v = |v| match v {
-        // TODO: do this properly.
-        "0" => "0x1b",
-        "1" => "0x1c",
-        "37" => "0x1b",
-        "38" => "0x1c",
-        _ => panic!("Invalid v."),
+    let convert_v = {
+        let mut map = HashMap::new();
+        map.insert("0", "0x1b");
+        map.insert("1", "0x1c");
+        map.insert("37", "0x1b");
+        map.insert("38", "0x1c");
+
+        move |v: &str| map.get(v).copied().ok_or_else(|| anyhow!("Invalid v."))
     };
     for line in f.lines().filter(|s| !s.starts_with("//")) {
         let line = line.split_whitespace().collect::<Vec<_>>();
-        test_valid_ecrecover(line[4], convert_v(line[0]), line[1], line[2], line[3])?;
+        test_valid_ecrecover(line[4], convert_v(line[0])?, line[1], line[2], line[3])?;
     }
     Ok(())
 }

--- a/evm_arithmetization/src/memory/mod.rs
+++ b/evm_arithmetization/src/memory/mod.rs
@@ -7,9 +7,6 @@ pub mod columns;
 pub mod memory_stark;
 pub mod segments;
 
-// TODO: Move to CPU module, now that channels have been removed from the memory
-// table.
-pub(crate) const NUM_CHANNELS: usize = crate::cpu::membus::NUM_CHANNELS;
 /// The number of limbs holding the value at a memory address.
 /// Eight limbs of 32 bits can hold a `U256`.
 pub(crate) const VALUE_LIMBS: usize = 8;

--- a/evm_arithmetization/tests/self_balance_gas_cost.rs
+++ b/evm_arithmetization/tests/self_balance_gas_cost.rs
@@ -123,17 +123,12 @@ fn self_balance_gas_cost() -> anyhow::Result<()> {
             code_hash,
             // Storage map: { 1 => 5 }
             storage_root: HashedPartialTrie::from(Node::Leaf {
-                // TODO: Could do keccak(pad32(1))
-                nibbles: Nibbles::from_str(
-                    "0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6",
-                )
-                .unwrap(),
+                nibbles: Nibbles::from_h256_be(keccak(pad32(1))),
                 value: vec![5],
             })
             .hash(),
             ..AccountRlp::default()
         };
-
         let mut expected_state_trie_after = HashedPartialTrie::from(Node::Empty);
         expected_state_trie_after.insert(
             beneficiary_nibbles,
@@ -189,6 +184,12 @@ fn self_balance_gas_cost() -> anyhow::Result<()> {
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)
+}
+
+fn pad32(byte: u8) -> Vec<u8> {
+    let mut data = vec![0; 31];
+    data.push(byte);
+    data
 }
 
 fn init_logger() {

--- a/mpt_trie/src/debug_tools/diff.rs
+++ b/mpt_trie/src/debug_tools/diff.rs
@@ -113,14 +113,15 @@ impl DiffPoint {
     }
 }
 
-// TODO: Redo display method so this is more readable...
 impl Display for DiffPoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Point Diff {{depth: {}, ", self.depth)?;
-        write!(f, "Path: ({}), ", self.path)?;
-        write!(f, "Key: {:x} ", self.key)?;
-        write!(f, "A info: {} ", self.a_info)?;
-        write!(f, "B info: {}}}", self.b_info)
+        writeln!(f, "Point Diff {{")?;
+        writeln!(f, "    Depth: {},", self.depth)?;
+        writeln!(f, "    Path: ({}),", self.path)?;
+        writeln!(f, "    Key: {:x},", self.key)?;
+        writeln!(f, "    A info: {},", self.a_info)?;
+        writeln!(f, "    B info: {}", self.b_info)?;
+        write!(f, "}}")
     }
 }
 
@@ -136,18 +137,20 @@ pub struct NodeInfo {
     hash: H256,
 }
 
-// TODO: Redo display method so this is more readable...
 impl Display for NodeInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(key: {:x} ", self.key)?;
+        write!(f, "NodeInfo {{ Key: 0x{:x}, ", self.key)?;
 
         match &self.value {
             Some(v) => write!(f, "Value: 0x{}, ", hex::encode(v))?,
             None => write!(f, "Value: N/A, ")?,
         }
 
-        write!(f, "Node type: {} ", self.node_type)?;
-        write!(f, "Trie hash: {:x})", self.hash)
+        write!(
+            f,
+            "Node type: {}, Trie hash: 0x{:x} }}",
+            self.node_type, self.hash
+        )
     }
 }
 

--- a/mpt_trie/src/debug_tools/query.rs
+++ b/mpt_trie/src/debug_tools/query.rs
@@ -206,17 +206,13 @@ impl DebugQueryOutput {
         }
     }
 
-    // TODO: Make the output easier to read...
     fn fmt_query_header(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Query Result {{")?;
-
-        writeln!(f, "Queried Key: {}", self.k)?;
-        writeln!(f, "Node found: {}", self.node_found)?;
-
+        writeln!(f, "    Queried Key: {}", self.k)?;
+        writeln!(f, "    Node Found: {}", self.node_found)?;
         writeln!(f, "}}")
     }
 
-    // TODO: Make the output easier to read...
     fn fmt_node_based_on_debug_params(
         f: &mut fmt::Formatter<'_>,
         seg: &TrieSegment,
@@ -224,30 +220,25 @@ impl DebugQueryOutput {
         params: &DebugQueryParams,
     ) -> fmt::Result {
         let node_type = seg.node_type();
+        let mut components = Vec::new();
 
         if params.include_node_type {
-            write!(f, "{}", node_type)?;
+            components.push(format!("{}", node_type));
         }
-
-        write!(f, "(")?;
 
         if params.include_key_piece_per_node {
             if let Some(k_piece) = seg.get_key_piece_from_seg_if_present() {
-                write!(f, "key: {}", k_piece)?;
+                components.push(format!("Key: {}", k_piece));
             }
         }
 
         if params.include_node_specific_values {
             if let Some(extra_seg_info) = extra_seg_info {
-                if params.include_key_piece_per_node {
-                    write!(f, ", ")?;
-                }
-
-                write!(f, "Extra Seg Info: {}", extra_seg_info)?;
+                components.push(format!("Extra Seg Info: {}", extra_seg_info));
             }
         }
 
-        write!(f, ")")?;
+        write!(f, "({})", components.join(", "))?;
 
         Ok(())
     }

--- a/mpt_trie/src/nibbles.rs
+++ b/mpt_trie/src/nibbles.rs
@@ -227,6 +227,19 @@ impl TryInto<U256> for Nibbles {
     }
 }
 
+impl Into<H256> for Nibbles {
+    fn into(self) -> H256 {
+        let mut nib_bytes = self.bytes_be();
+        if nib_bytes.len() < 32 {
+            for _ in nib_bytes.len()..32 {
+                nib_bytes.insert(0, 0);
+            }
+        }
+
+        H256::from_slice(&nib_bytes)
+    }
+}
+
 impl From<U256> for NibblesIntern {
     fn from(val: U256) -> Self {
         let arr = val.as_u64s();

--- a/mpt_trie/src/trie_subsets.rs
+++ b/mpt_trie/src/trie_subsets.rs
@@ -207,32 +207,33 @@ impl<N: PartialTrie> TrackedNodeInfo<N> {
     }
 }
 
-// TODO: Make this interface also work with &[ ... ]...
 /// Create a [`PartialTrie`] subset from a base trie given an iterator of keys
 /// of nodes that may or may not exist in the trie. All nodes traversed by the
 /// keys will not be hashed out in the trie subset. If the key does not exist in
 /// the trie at all, this is not considered an error and will still record which
 /// nodes were visited.
-pub fn create_trie_subset<N, K, I>(trie: &N, keys_involved: I) -> SubsetTrieResult<N>
+pub fn create_trie_subset<N, K>(
+    trie: &N,
+    keys_involved: impl IntoIterator<Item = K>,
+) -> SubsetTrieResult<N>
 where
     N: PartialTrie,
     K: Into<Nibbles>,
-    I: IntoIterator<Item = K>,
 {
     let mut tracked_trie = TrackedNode::new(trie);
     create_trie_subset_intern(&mut tracked_trie, keys_involved.into_iter())
 }
 
-// TODO: Make this interface also work with &[ ... ]...
 /// Create [`PartialTrie`] subsets from a given base `PartialTrie` given a
 /// iterator of keys per subset needed. See [`create_trie_subset`] for more
 /// info.
-pub fn create_trie_subsets<N, K, I, O>(base_trie: &N, keys_involved: O) -> SubsetTrieResult<Vec<N>>
+pub fn create_trie_subsets<N, K>(
+    base_trie: &N,
+    keys_involved: impl IntoIterator<Item = impl IntoIterator<Item = K>>,
+) -> SubsetTrieResult<Vec<N>>
 where
     N: PartialTrie,
     K: Into<Nibbles>,
-    I: IntoIterator<Item = K>,
-    O: IntoIterator<Item = I>,
 {
     let mut tracked_trie = TrackedNode::new(base_trie);
 

--- a/trace_decoder/src/compact/compact_prestate_processing.rs
+++ b/trace_decoder/src/compact/compact_prestate_processing.rs
@@ -14,7 +14,8 @@ use ethereum_types::{H256, U256};
 use log::trace;
 use mpt_trie::{
     nibbles::{FromHexPrefixError, Nibbles},
-    partial_trie::{HashedPartialTrie, PartialTrie},
+    partial_trie::HashedPartialTrie,
+    trie_ops::TrieOpError,
 };
 use serde::de::DeserializeOwned;
 use thiserror::Error;
@@ -26,7 +27,7 @@ use super::compact_to_partial_trie::{
 use crate::{
     decoding::TrieType,
     trace_protocol::TrieCompact,
-    types::{CodeHash, HashedAccountAddr, TrieRootHash},
+    types::{HashedAccountAddr, TrieRootHash},
 };
 
 /// Result alias for any error that can occur when processing encoded compact
@@ -120,10 +121,26 @@ pub enum CompactParsingError {
     /// Error when constructing a key from bytes.
     #[error("Unable to create key nibbles from bytes {0}")]
     KeyError(#[from] FromHexPrefixError),
+
+    /// Failure due to an incompatible version.
+    #[error("Incompatible version, expected: {0}, actual: {1}")]
+    IncompatibleVersion(u8, u8),
+
+    /// Failure due to a trie operation error.
+    #[error("Trie operation error: {0}")]
+    TrieOpError(TrieOpError),
 }
 
+impl From<TrieOpError> for CompactParsingError {
+    fn from(err: TrieOpError) -> Self {
+        CompactParsingError::TrieOpError(err)
+    }
+}
+
+/// Represents detailed error information about issues encountered
+/// while processing byte streams with a cursor.
 #[derive(Debug)]
-pub(crate) struct CursorBytesErrorInfo {
+pub struct CursorBytesErrorInfo {
     error_start_pos: usize,
     bad_bytes_hex: String,
 }
@@ -167,9 +184,12 @@ enum Opcode {
     EmptyRoot = 0x06,
 }
 
+/// Compact witness entry.
 #[derive(Clone, Debug, EnumAsInner)]
-pub(crate) enum WitnessEntry {
+pub enum WitnessEntry {
+    /// An instruction.
     Instruction(Instruction),
+    /// A node.
     Node(NodeEntry),
 }
 
@@ -182,15 +202,22 @@ impl Display for WitnessEntry {
     }
 }
 
-// TODO: Ignore `NEW_TRIE` for now...
+/// A type alias for a list of witness entries.
 #[derive(Clone, Debug, Eq, PartialEq)]
-enum Instruction {
+pub enum Instruction {
+    /// A leaf node.
     Leaf(Nibbles, RawValue),
+    /// An extension node.
     Extension(Nibbles),
+    /// A branch node.
     Branch(BranchMask),
+    /// A hash node.
     Hash(HashValue),
+    /// A code node.
     Code(RawCode),
+    /// An account leaf node.
     AccountLeaf(Nibbles, Nonce, Balance, HasCode, HasStorage),
+    /// An empty root node.
     EmptyRoot,
 }
 
@@ -220,13 +247,20 @@ impl From<Instruction> for WitnessEntry {
     }
 }
 
+/// A node witness entry.
 #[derive(Clone, Debug)]
-pub(crate) enum NodeEntry {
+pub enum NodeEntry {
+    /// A branch node.
     Branch([Option<Box<NodeEntry>>; 16]),
+    /// A code node.
     Code(Vec<u8>),
+    /// An empty node.
     Empty,
+    /// A hash node.
     Hash(HashValue),
+    /// A leaf node.
     Leaf(Nibbles, LeafNodeData),
+    /// An extension node.
     Extension(Nibbles, Box<NodeEntry>),
 }
 
@@ -243,8 +277,9 @@ impl Display for NodeEntry {
     }
 }
 
+/// A value of a node data.
 #[derive(Clone, Debug)]
-pub(super) struct ValueNodeData(pub(super) Vec<u8>);
+pub struct ValueNodeData(pub(super) Vec<u8>);
 
 impl From<Vec<u8>> for ValueNodeData {
     fn from(v: Vec<u8>) -> Self {
@@ -252,15 +287,21 @@ impl From<Vec<u8>> for ValueNodeData {
     }
 }
 
+/// A leaf node data.
 #[derive(Clone, Debug)]
-pub(super) enum LeafNodeData {
+pub enum LeafNodeData {
+    /// A value node.
     Value(ValueNodeData),
+    /// An account node.
     Account(AccountNodeData),
 }
 
+/// An account node code.
 #[derive(Clone, Debug)]
-pub(super) enum AccountNodeCode {
+pub enum AccountNodeCode {
+    /// A code node.
     CodeNode(Vec<u8>),
+    /// A hash node.
     HashNode(TrieRootHash),
 }
 
@@ -276,12 +317,17 @@ impl From<TrieRootHash> for AccountNodeCode {
     }
 }
 
+/// An account node data.
 #[derive(Clone, Debug)]
-pub(super) struct AccountNodeData {
-    pub(super) nonce: Nonce,
-    pub(super) balance: Balance,
-    pub(super) storage_trie: Option<HashedPartialTrie>,
-    pub(super) account_node_code: Option<AccountNodeCode>,
+pub struct AccountNodeData {
+    /// The nonce of the account.
+    pub nonce: Nonce,
+    /// The balance of the account.
+    pub balance: Balance,
+    /// The storage trie of the account.
+    pub storage_trie: Option<HashedPartialTrie>,
+    /// The code of the account.
+    pub account_node_code: Option<AccountNodeCode>,
 }
 
 impl AccountNodeData {
@@ -300,9 +346,11 @@ impl AccountNodeData {
     }
 }
 
+/// A witness header.
 #[derive(Debug)]
-pub(crate) struct Header {
-    version: u8,
+pub struct Header {
+    /// The version of the witness.
+    pub version: u8,
 }
 
 impl Display for Header {
@@ -684,10 +732,7 @@ impl<C: CompactCursor> WitnessBytes<C> {
         Ok((header, self.instrs))
     }
 
-    // TODO: Look at removing code duplication...
-    // TODO: Move behind a feature flag...
-    // TODO: Fairly hacky...
-    // TODO: Replace `unwrap()`s with `Result`s?
+    #[allow(dead_code)]
     fn process_into_instructions_and_keep_bytes_parsed_to_instruction_and_bail_on_first_failure(
         self,
     ) -> (InstructionAndBytesParsedFromBuf, CompactParsingResult<()>) {
@@ -697,6 +742,7 @@ impl<C: CompactCursor> WitnessBytes<C> {
         (instr_and_bytes_buf.into(), res)
     }
 
+    #[allow(dead_code)]
     fn process_into_instructions_and_keep_bytes_parsed_to_instruction_and_bail_on_first_failure_intern(
         mut self,
         instr_and_bytes_buf: &mut Vec<(Instruction, Vec<u8>)>,
@@ -814,9 +860,6 @@ impl<C: CompactCursor> WitnessBytes<C> {
         let _ = Self::read_account_flag_field_if_present_or_default(flags.code_present, || {
             self.byte_cursor.read_t::<u64>("code size")
         })?;
-
-        // TODO: process actual storage trie probably? Wait until we know what is going
-        // on here.
 
         self.push_entry(Instruction::AccountLeaf(
             key,
@@ -1009,7 +1052,6 @@ impl CompactCursorFast {
 #[derive(Debug)]
 struct DebugCompactCursor(CompactCursorFast);
 
-// TODO: There are some decent opportunities to reduce code duplication here...
 impl CompactCursor for DebugCompactCursor {
     fn new(bytes: Vec<u8>) -> Self {
         Self(CompactCursorFast::new(bytes))
@@ -1136,8 +1178,6 @@ struct CollapsableWitnessEntryTraverser<'a> {
     entry_cursor: CursorMut<'a, WitnessEntry>,
 }
 
-// TODO: For now, lets just use pure values in the buffer, but we probably want
-// to switch over to references later...
 impl<'a> CollapsableWitnessEntryTraverser<'a> {
     fn advance(&mut self) {
         self.entry_cursor.move_next();
@@ -1186,6 +1226,7 @@ impl<'a> CollapsableWitnessEntryTraverser<'a> {
     }
 
     // Inclusive.
+    #[allow(dead_code)]
     fn replace_next_n_entries_with_single_entry(&mut self, n: usize, entry: WitnessEntry) {
         for _ in 0..n {
             self.entry_cursor.remove_current();
@@ -1221,6 +1262,7 @@ const fn try_get_node_entry_from_witness_entry(entry: &WitnessEntry) -> Option<&
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 enum TraverserDirection {
     Forwards,
@@ -1284,6 +1326,7 @@ fn process_compact_prestate_common(
 
 // TODO: Move behind a feature flag just used for debugging (but probably not
 // `debug`)...
+#[allow(dead_code)]
 fn parse_just_to_instructions(bytes: Vec<u8>) -> CompactParsingResult<Vec<Instruction>> {
     let witness_bytes = WitnessBytes::<DebugCompactCursor>::new(bytes);
     let (_, entries) = witness_bytes.process_into_instructions_and_header()?;
@@ -1328,6 +1371,7 @@ impl Display for InstructionAndBytesParsedFromBuf {
 }
 
 // TODO: Also move behind a feature flag...
+#[allow(dead_code)]
 fn parse_to_instructions_and_bytes_for_instruction(
     bytes: Vec<u8>,
 ) -> (InstructionAndBytesParsedFromBuf, CompactParsingResult<()>) {
@@ -1336,7 +1380,6 @@ fn parse_to_instructions_and_bytes_for_instruction(
         .process_into_instructions_and_keep_bytes_parsed_to_instruction_and_bail_on_first_failure()
 }
 
-// TODO: This could probably be made a bit faster...
 fn key_bytes_to_nibbles(bytes: &[u8]) -> Nibbles {
     let mut key = Nibbles::default();
 
@@ -1427,15 +1470,12 @@ fn get_bytes_from_cursor<C: CompactCursor>(cursor: &mut C, cursor_start_pos: u64
 
 #[cfg(test)]
 mod tests {
-    use mpt_trie::{nibbles::Nibbles, partial_trie::PartialTrie};
+    use mpt_trie::nibbles::Nibbles;
 
     use super::{key_bytes_to_nibbles, parse_just_to_instructions, Instruction};
-    use crate::compact::{
-        compact_prestate_processing::ParserState,
-        complex_test_payloads::{
-            TEST_PAYLOAD_1, TEST_PAYLOAD_2, TEST_PAYLOAD_3, TEST_PAYLOAD_4, TEST_PAYLOAD_5,
-            TEST_PAYLOAD_6,
-        },
+    use crate::compact::complex_test_payloads::{
+        TEST_PAYLOAD_1, TEST_PAYLOAD_2, TEST_PAYLOAD_3, TEST_PAYLOAD_4, TEST_PAYLOAD_5,
+        TEST_PAYLOAD_6,
     };
 
     const SIMPLE_PAYLOAD_STR: &str = "01004110443132333400411044313233340218300042035044313233350218180158200000000000000000000000000000000000000000000000000000000000000012";
@@ -1451,23 +1491,6 @@ mod tests {
 
     fn h_decode(b_str: &str) -> Vec<u8> {
         hex::decode(b_str).unwrap()
-    }
-
-    // TODO: Refactor (or remove?) this test as it will crash when it tries to
-    // deserialize the trie leaves into `AccountRlp`...
-    #[test]
-    #[ignore]
-    fn simple_full() {
-        init();
-
-        let bytes = hex::decode(SIMPLE_PAYLOAD_STR).unwrap();
-        let (header, parser) = ParserState::create_and_extract_header(bytes).unwrap();
-
-        assert_eq!(header.version, 1);
-        let _ = match parser.parse() {
-            Ok(trie) => trie,
-            Err(err) => panic!("{}", err),
-        };
     }
 
     #[test]

--- a/trace_decoder/src/compact/complex_test_payloads.rs
+++ b/trace_decoder/src/compact/complex_test_payloads.rs
@@ -4,7 +4,7 @@ use mpt_trie::partial_trie::PartialTrie;
 use super::{
     compact_prestate_processing::{
         process_compact_prestate, process_compact_prestate_debug, CompactParsingResult,
-        PartialTriePreImages, ProcessedCompactOutput,
+        ProcessedCompactOutput,
     },
     compact_to_partial_trie::StateTrieExtractionOutput,
 };
@@ -40,6 +40,7 @@ pub(crate) struct TestProtocolInputAndRoot {
 }
 
 impl TestProtocolInputAndRoot {
+    #[allow(dead_code)]
     pub(crate) fn parse_and_check_hash_matches(self) {
         self.parse_and_check_hash_matches_common(process_compact_prestate);
     }

--- a/trace_decoder/src/lib.rs
+++ b/trace_decoder/src/lib.rs
@@ -115,9 +115,6 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
-// TODO: address these lints
-#![allow(unused)]
-#![allow(private_interfaces)]
 
 /// Provides debugging tools and a compact representation of state and storage
 /// tries, used in tests.
@@ -133,6 +130,3 @@ pub mod trace_protocol;
 pub mod types;
 /// Defines useful functions necessary to the other modules.
 pub mod utils;
-
-use trace_protocol::{BlockTrace, TxnInfo};
-use types::OtherBlockData;

--- a/trace_decoder/src/processed_block_trace.rs
+++ b/trace_decoder/src/processed_block_trace.rs
@@ -8,7 +8,8 @@ use mpt_trie::nibbles::Nibbles;
 use mpt_trie::partial_trie::{HashedPartialTrie, PartialTrie};
 
 use crate::compact::compact_prestate_processing::{
-    process_compact_prestate_debug, PartialTriePreImages, ProcessedCompactOutput,
+    process_compact_prestate_debug, CompactParsingError, CompactParsingResult,
+    PartialTriePreImages, ProcessedCompactOutput,
 };
 use crate::decoding::TraceParsingResult;
 use crate::trace_protocol::{
@@ -17,13 +18,11 @@ use crate::trace_protocol::{
     TrieUncompressed, TxnInfo,
 };
 use crate::types::{
-    CodeHash, CodeHashResolveFunc, HashedAccountAddr, HashedNodeAddr, HashedStorageAddr,
-    HashedStorageAddrNibbles, OtherBlockData, TrieRootHash, TxnProofGenIR, EMPTY_CODE_HASH,
-    EMPTY_TRIE_HASH,
+    CodeHash, CodeHashResolveFunc, HashedAccountAddr, HashedNodeAddr, HashedStorageAddrNibbles,
+    OtherBlockData, TrieRootHash, TxnProofGenIR, EMPTY_CODE_HASH, EMPTY_TRIE_HASH,
 };
 use crate::utils::{
-    h_addr_nibs_to_h256, hash, print_value_and_hash_nodes_of_storage_trie,
-    print_value_and_hash_nodes_of_trie,
+    hash, print_value_and_hash_nodes_of_storage_trie, print_value_and_hash_nodes_of_trie,
 };
 
 #[derive(Debug)]
@@ -47,7 +46,7 @@ impl BlockTrace {
         F: CodeHashResolveFunc,
     {
         let processed_block_trace =
-            self.into_processed_block_trace(p_meta, other_data.b_data.withdrawals.clone());
+            self.into_processed_block_trace(p_meta, other_data.b_data.withdrawals.clone())?;
 
         processed_block_trace.into_txn_proof_gen_ir(other_data)
     }
@@ -56,13 +55,13 @@ impl BlockTrace {
         self,
         p_meta: &ProcessingMeta<F>,
         withdrawals: Vec<(Address, U256)>,
-    ) -> ProcessedBlockTrace
+    ) -> TraceParsingResult<ProcessedBlockTrace>
     where
         F: CodeHashResolveFunc,
     {
         // The compact format is able to provide actual code, so if it does, we should
         // take advantage of it.
-        let pre_image_data = process_block_trace_trie_pre_images(self.trie_pre_images);
+        let pre_image_data = process_block_trace_trie_pre_images(self.trie_pre_images)?;
 
         print_value_and_hash_nodes_of_trie(&pre_image_data.tries.state);
 
@@ -75,12 +74,8 @@ impl BlockTrace {
             .state
             .items()
             .filter_map(|(addr, data)| {
-                data.as_val().map(|data| {
-                    (
-                        h_addr_nibs_to_h256(&addr),
-                        rlp::decode::<AccountRlp>(data).unwrap(),
-                    )
-                })
+                data.as_val()
+                    .map(|data| (addr.into(), rlp::decode::<AccountRlp>(data).unwrap()))
             })
             .collect();
 
@@ -95,11 +90,11 @@ impl BlockTrace {
             .map(|t| t.into_processed_txn_info(&all_accounts_in_pre_image, &mut code_hash_resolver))
             .collect::<Vec<_>>();
 
-        ProcessedBlockTrace {
+        Ok(ProcessedBlockTrace {
             tries: pre_image_data.tries,
             txn_info,
             withdrawals,
-        }
+        })
     }
 }
 
@@ -126,27 +121,31 @@ impl From<ProcessedCompactOutput> for ProcessedBlockTracePreImages {
 
 fn process_block_trace_trie_pre_images(
     block_trace_pre_images: BlockTraceTriePreImages,
-) -> ProcessedBlockTracePreImages {
+) -> TraceParsingResult<ProcessedBlockTracePreImages> {
     match block_trace_pre_images {
         BlockTraceTriePreImages::Separate(t) => process_separate_trie_pre_images(t),
         BlockTraceTriePreImages::Combined(t) => process_combined_trie_pre_images(t),
     }
 }
 
-fn process_combined_trie_pre_images(tries: CombinedPreImages) -> ProcessedBlockTracePreImages {
-    process_compact_trie(tries.compact)
+fn process_combined_trie_pre_images(
+    tries: CombinedPreImages,
+) -> TraceParsingResult<ProcessedBlockTracePreImages> {
+    Ok(process_compact_trie(tries.compact)?)
 }
 
-fn process_separate_trie_pre_images(tries: SeparateTriePreImages) -> ProcessedBlockTracePreImages {
+fn process_separate_trie_pre_images(
+    tries: SeparateTriePreImages,
+) -> TraceParsingResult<ProcessedBlockTracePreImages> {
     let tries = PartialTriePreImages {
         state: process_state_trie(tries.state),
         storage: process_storage_tries(tries.storage),
     };
 
-    ProcessedBlockTracePreImages {
+    Ok(ProcessedBlockTracePreImages {
         tries,
         extra_code_hash_mappings: None,
-    }
+    })
 }
 
 fn process_state_trie(trie: SeparateTriePreImage) -> HashedPartialTrie {
@@ -177,14 +176,18 @@ fn process_multiple_storage_tries(
     todo!()
 }
 
-fn process_compact_trie(trie: TrieCompact) -> ProcessedBlockTracePreImages {
-    // TODO: Wrap in proper result type...
-    let out = process_compact_prestate_debug(trie).unwrap();
+fn process_compact_trie(trie: TrieCompact) -> CompactParsingResult<ProcessedBlockTracePreImages> {
+    let out = process_compact_prestate_debug(trie).map_err(|e| e)?; // Handle the error properly by propagating it
 
-    // TODO: Make this into a result...
-    assert!(out.header.version_is_compatible(COMPATIBLE_HEADER_VERSION));
+    if !out.header.version_is_compatible(COMPATIBLE_HEADER_VERSION) {
+        return Err(CompactParsingError::IncompatibleVersion(
+            COMPATIBLE_HEADER_VERSION,
+            out.header.version,
+        ));
+    }
 
-    out.into()
+    Ok(out.into()) // Convert ProcessedCompactOutput to
+                   // ProcessedBlockTracePreImages and return it wrapped in Ok
 }
 
 /// Structure storing a function turning a `CodeHash` into bytes.

--- a/trace_decoder/src/types.rs
+++ b/trace_decoder/src/types.rs
@@ -3,38 +3,35 @@ use evm_arithmetization::{
     generation::GenerationInputs,
     proof::{BlockHashes, BlockMetadata},
 };
-use mpt_trie::{nibbles::Nibbles, partial_trie::HashedPartialTrie};
+use mpt_trie::nibbles::Nibbles;
 use serde::{Deserialize, Serialize};
 
-// TODO: Make these types in the doc comments point to the actual types...
-/// A type alias for `u64` of a block height.
+/// A type alias for [`u64`] of a block height.
 pub type BlockHeight = u64;
-/// A type alias for `[U256; 8]` of a bloom filter.
+/// A type alias for `[`[`U256`]`; 8]` of a bloom filter.
 pub type Bloom = [U256; 8];
-/// A type alias for `H256` of a code hash.
+/// A type alias for [`H256`] of a code hash.
 pub type CodeHash = H256;
-/// A type alias for `H256` of an account address's hash.
+/// A type alias for [`H256`] of an account address's hash.
 pub type HashedAccountAddr = H256;
-/// A type alias for `Nibbles` of an account address's hash.
+/// A type alias for [`Nibbles`] of an account address's hash.
 pub type HashedAccountAddrNibbles = Nibbles;
-/// A type alias for `H256` of a node address's hash.
+/// A type alias for [`H256`] of a node address's hash.
 pub type HashedNodeAddr = H256;
-/// A type alias for `H256` of a storage address's hash.
+/// A type alias for [`H256`] of a storage address's hash.
 pub type HashedStorageAddr = H256;
-/// A type alias for `Nibbles` of a hashed storage address's nibbles.
+/// A type alias for [`Nibbles`] of a hashed storage address's nibbles.
 pub type HashedStorageAddrNibbles = Nibbles;
-/// A type alias for `H256` of a storage address.
+/// A type alias for [`H256`] of a storage address.
 pub type StorageAddr = H256;
-/// A type alias for `H256` of a storage address's nibbles.
+/// A type alias for [`H256`] of a storage address's nibbles.
 pub type StorageAddrNibbles = H256;
-/// A type alias for `U256` of a storage value.
+/// A type alias for [`U256`] of a storage value.
 pub type StorageVal = U256;
-/// A type alias for `H256` of a trie root hash.
+/// A type alias for [`H256`] of a trie root hash.
 pub type TrieRootHash = H256;
-/// A type alias for `usize` of a transaction's index within a block.
+/// A type alias for [`usize`] of a transaction's index within a block.
 pub type TxnIdx = usize;
-
-pub(crate) type TriePathIter = mpt_trie::special_query::TriePathIter<HashedPartialTrie>;
 
 /// A function which turns a code hash into bytes.
 pub trait CodeHashResolveFunc = Fn(&CodeHash) -> Vec<u8>;

--- a/trace_decoder/src/utils.rs
+++ b/trace_decoder/src/utils.rs
@@ -2,7 +2,6 @@ use ethereum_types::H256;
 use keccak_hash::keccak;
 use log::debug;
 use mpt_trie::{
-    nibbles::Nibbles,
     partial_trie::{HashedPartialTrie, PartialTrie},
     trie_ops::ValOrHash,
 };
@@ -45,16 +44,4 @@ fn print_value_and_hash_nodes_of_trie_common(trie: &HashedPartialTrie) -> Vec<St
             format!("{} - {:x}", v_or_h_char, k)
         })
         .collect()
-}
-
-pub(crate) fn h_addr_nibs_to_h256(h_addr_nibs: &Nibbles) -> H256 {
-    // TODO: HACK! This fix really needs to be in `mpt_trie`...
-    let mut nib_bytes = h_addr_nibs.bytes_be();
-    if nib_bytes.len() < 32 {
-        for _ in nib_bytes.len()..32 {
-            nib_bytes.insert(0, 0);
-        }
-    }
-
-    H256::from_slice(&nib_bytes)
 }


### PR DESCRIPTION
Fix TODOs in the zk_evm.

Some TODOs were addressed, but the other still needs to be fixed, mostly in the evm_arithmezation. 
Some TODOs in the `zk_evm/trace_decoder` remained as they were after a discussion with @BGluth.

Issue: https://github.com/0xPolygonZero/zk_evm/issues/16