### PR TITLE
Fix withdrawals accesses in state trie

### DIFF
--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -270,14 +270,13 @@ impl ProcessedBlockTrace {
                 e
             })?;
 
-        let dummies_added = Self::pad_gen_inputs_with_dummy_inputs_if_needed(
+        Self::pad_gen_inputs_with_dummy_inputs_if_needed(
             &mut txn_gen_inputs,
             &other_data,
             &extra_data,
             &extra_data_for_dummies,
             &initial_tries_for_dummies,
             &curr_block_tries,
-            !self.withdrawals.is_empty(),
         );
 
         if !self.withdrawals.is_empty() {
@@ -515,10 +514,7 @@ impl ProcessedBlockTrace {
     /// that we have two entries in total. These dummy entries serve only to
     /// allow the proof generation process to finish. Specifically, we need
     /// at least two entries to generate an agg proof, and we need an agg
-    /// proof to generate a block proof. These entries do not mutate state
-    /// (unless there are withdrawals in the block (see
-    /// `[add_withdrawals_to_txns]`), where the final one will mutate the
-    /// state trie.
+    /// proof to generate a block proof. These entries do not mutate state.
     fn pad_gen_inputs_with_dummy_inputs_if_needed(
         gen_inputs: &mut Vec<GenerationInputs>,
         other_data: &OtherBlockData,
@@ -526,8 +522,7 @@ impl ProcessedBlockTrace {
         initial_extra_data: &ExtraBlockData,
         initial_tries: &PartialTrieState,
         final_tries: &PartialTrieState,
-        has_withdrawals: bool,
-    ) -> bool {
+    ) {
         match gen_inputs.len() {
             0 => {
                 debug_assert!(initial_tries.state == final_tries.state);
@@ -538,42 +533,19 @@ impl ProcessedBlockTrace {
                     final_extra_data,
                     initial_tries,
                 ));
-
-                true
             }
             1 => {
                 // We just need one dummy entry.
-                // If there are withdrawals, we will need to append them at the end of the block
-                // execution, in which case we directly append the dummy proof
-                // after the only txn of this block.
-                // If there are no withdrawals, then the dummy proof will be prepended to the
-                // actual txn.
-                match has_withdrawals {
-                    false => {
-                        let dummy_txn =
-                            create_dummy_gen_input(other_data, initial_extra_data, initial_tries);
-                        gen_inputs.insert(0, dummy_txn)
-                    }
-                    true => {
-                        let dummy_txn =
-                            create_dummy_gen_input(other_data, final_extra_data, final_tries);
-                        gen_inputs.push(dummy_txn)
-                    }
-                };
-
-                true
+                // The dummy proof will be prepended to the actual txn.
+                let dummy_txn =
+                    create_dummy_gen_input(other_data, initial_extra_data, initial_tries);
+                gen_inputs.insert(0, dummy_txn)
             }
-            _ => false,
+            _ => (),
         }
     }
 
-    /// The withdrawals are always in the final ir payload. How they are placed
-    /// differs based on whether or not there are already dummy proofs present
-    /// in the IR. The rules for adding withdrawals to the IR list are:
-    /// - If dummy proofs are already present, then the withdrawals are added to
-    ///   the last dummy proof (always index `1`).
-    /// - If no dummy proofs are already present, then a dummy proof that just
-    ///   contains the withdrawals is appended to the end of the IR vec.
+    /// The withdrawals are always in the final ir payload.
     fn add_withdrawals_to_txns(
         txn_ir: &mut [GenerationInputs],
         final_trie_state: &mut PartialTrieState,

--- a/trace_decoder/src/processed_block_trace.rs
+++ b/trace_decoder/src/processed_block_trace.rs
@@ -89,10 +89,32 @@ impl BlockTrace {
             extra_code_hash_mappings: pre_image_data.extra_code_hash_mappings.unwrap_or_default(),
         };
 
+        let last_tx_idx = self.txn_info.len() - 1;
+
         let txn_info = self
             .txn_info
             .into_iter()
-            .map(|t| t.into_processed_txn_info(&all_accounts_in_pre_image, &mut code_hash_resolver))
+            .enumerate()
+            .map(|(i, t)| {
+                // If this is the last transaction, we mark the withdrawal addresses
+                // as accessed in the state trie.
+                if i == last_tx_idx {
+                    t.into_processed_txn_info(
+                        &all_accounts_in_pre_image,
+                        &withdrawals
+                            .iter()
+                            .map(|(addr, _)| hash(addr.as_bytes()))
+                            .collect::<Vec<_>>(),
+                        &mut code_hash_resolver,
+                    )
+                } else {
+                    t.into_processed_txn_info(
+                        &all_accounts_in_pre_image,
+                        &[],
+                        &mut code_hash_resolver,
+                    )
+                }
+            })
             .collect::<Vec<_>>();
 
         ProcessedBlockTrace {
@@ -245,6 +267,7 @@ impl TxnInfo {
     fn into_processed_txn_info<F: CodeHashResolveFunc>(
         self,
         all_accounts_in_pre_image: &[(HashedAccountAddr, AccountRlp)],
+        extra_state_accesses: &[HashedAccountAddr],
         code_hash_resolver: &mut CodeHashResolving<F>,
     ) -> ProcessedTxnInfo {
         let mut nodes_used_by_txn = NodesUsedByTxn::default();
@@ -323,6 +346,10 @@ impl TxnInfo {
             {
                 nodes_used_by_txn.self_destructed_accounts.push(hashed_addr);
             }
+        }
+
+        for &hashed_addr in extra_state_accesses {
+            nodes_used_by_txn.state_accesses.push(hashed_addr);
         }
 
         let accounts_with_storage_accesses: HashSet<_> = HashSet::from_iter(


### PR DESCRIPTION
#168 didn't include withdrawals accesses into the initial payload state trie, causing issues when processing the last transactions. Tested against John's block witnesses.

This fixes it by adding them while doing the initial preprocessing.  Also updates some related outdated comments.