### PR TITLE
Bumped `trace_decoder` version for new `zk_evm` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.3.1] - 2024-04-22
+
+### Changed
+- Fix withdrawals accesses in state trie ([#176](https://github.com/0xPolygonZero/zk_evm/pull/176))
+
 ## [0.3.0] - 2024-04-19
 
 ### Changed

--- a/trace_decoder/Cargo.toml
+++ b/trace_decoder/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trace_decoder"
 description = "Processes trace payloads into Intermediate Representation (IR) format."
 authors = ["Polygon Zero <bgluth@polygon.technology>"]
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Bumped `trace_decoder` for new `zk_evm` release (`v0.3.1`).

There is only one PR in this release (#176), and I think we can get away in this case with only bumping `trace_decoder`.