### PR TITLE
Put kernel code in first MemBefore

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/main.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/main.asm
@@ -61,18 +61,6 @@ global init:
     EXIT_KERNEL
 
 global main:
-    // First, hash the kernel code
-    // Start with PUSH0 to avoid having a BytePacking operation at timestamp 0.
-    // Timestamp 0 is reserved for memory initialization.
-    %mload_global_metadata(@GLOBAL_METADATA_KERNEL_LEN)
-    PUSH 0
-    // stack: addr, len
-    KECCAK_GENERAL
-    // stack: hash
-    %mload_global_metadata(@GLOBAL_METADATA_KERNEL_HASH)
-    // stack: expected_hash, hash
-    %assert_eq
-
     // Initialize accessed addresses and storage keys lists
     %init_access_lists
 

--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -58,6 +58,7 @@ use crate::recursive_verifier::{
     StarkWrapperCircuit,
 };
 use crate::util::{h160_limbs, h256_limbs, u256_limbs};
+use crate::verifier::initial_memory_merkle_cap;
 use crate::witness::memory::MemoryAddress;
 
 /// The recursion threshold. We end a chain of recursive proofs once we reach
@@ -1024,16 +1025,10 @@ where
             .map(|column| PolynomialValues::new(column))
             .collect::<Vec<_>>();
 
-        let cap = PolynomialBatch::<F, C, D>::from_values(
-            polys,
+        let cap = initial_memory_merkle_cap::<F, C, D>(
             stark_config.fri_config.rate_bits,
-            false,
             stark_config.fri_config.cap_height,
-            &mut TimingTree::default(),
-            None,
-        )
-        .merkle_tree
-        .cap;
+        );
 
         let init_cap_target = MemCapTarget {
             mem_cap: MerkleCapTarget(

--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -982,6 +982,18 @@ where
         // constant and the `ShiftTable`.
         let mut trace = vec![];
 
+        // TODO: put it in a dedicated function.
+        // Push kernel code.
+        for (i, &byte) in KERNEL.code.iter().enumerate() {
+            let mut row = vec![F::ZERO; crate::memory_continuation::columns::NUM_COLUMNS];
+            row[crate::memory_continuation::columns::FILTER] = F::ONE;
+            row[crate::memory_continuation::columns::ADDR_CONTEXT] = F::ZERO;
+            row[crate::memory_continuation::columns::ADDR_SEGMENT] =
+                F::from_canonical_usize(Segment::Code.unscale());
+            row[crate::memory_continuation::columns::ADDR_VIRTUAL] = F::from_canonical_usize(i);
+            row[crate::memory_continuation::columns::value_limb(0)] = F::from_canonical_u8(byte);
+            trace.push(row);
+        }
         // Push shift table.
         for i in 0..256 {
             let mut row = vec![F::ZERO; crate::memory_continuation::columns::NUM_COLUMNS];

--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -982,7 +982,6 @@ where
         // constant and the `ShiftTable`.
         let mut trace = vec![];
 
-        // TODO: put it in a dedicated function.
         // Push kernel code.
         for (i, &byte) in KERNEL.code.iter().enumerate() {
             let mut row = vec![F::ZERO; crate::memory_continuation::columns::NUM_COLUMNS];

--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -85,6 +85,7 @@ where
         let mut shift_addr = MemoryAddress::new(0, Segment::ShiftTable, 0);
         let mut shift_val = U256::one();
 
+        // TODO: move to `generate_traces`.
         for _ in 0..256 {
             memory_before.set(shift_addr, shift_val);
             shift_addr.increment();

--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -91,6 +91,12 @@ where
             shift_val <<= 1;
         }
 
+        let mut code_addr = MemoryAddress::new(0, Segment::Code, 0);
+        for &byte in &KERNEL.code {
+            memory_before.set(code_addr, U256::from(byte));
+            code_addr.increment();
+        }
+
         let actual_mem_before = {
             let mut res = vec![];
             for (ctx_idx, ctx) in memory_before.contexts.iter().enumerate() {

--- a/evm_arithmetization/src/verifier.rs
+++ b/evm_arithmetization/src/verifier.rs
@@ -33,7 +33,7 @@ pub(crate) fn initial_memory_merkle_cap<
 ) -> MerkleCap<F, C::Hasher> {
     // At the start of a transaction proof, `MemBefore` only contains the RLP
     // constant and the `ShiftTable`.
-    let mut trace = vec![];
+    let mut trace = Vec::with_capacity((KERNEL.code.len() + 256).next_power_of_two());
 
     // Push kernel code.
     for (i, &byte) in KERNEL.code.iter().enumerate() {

--- a/evm_arithmetization/src/verifier.rs
+++ b/evm_arithmetization/src/verifier.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use plonky2::field::extension::Extendable;
 use plonky2::field::polynomial::PolynomialValues;
 use plonky2::fri::oracle::PolynomialBatch;
-use plonky2::hash::hash_types::{HashOut, RichField};
+use plonky2::hash::hash_types::RichField;
 use plonky2::hash::merkle_tree::MerkleCap;
 use plonky2::plonk::config::{GenericConfig, GenericHashOut};
 use plonky2::util::timing::TimingTree;
@@ -20,7 +20,7 @@ use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::memory::segments::Segment;
 use crate::memory::VALUE_LIMBS;
-use crate::proof::{AllProof, AllProofChallenges, MemCap, PublicValues};
+use crate::proof::{AllProof, AllProofChallenges, PublicValues};
 use crate::util::h2u;
 
 pub(crate) fn initial_memory_merkle_cap<
@@ -31,8 +31,8 @@ pub(crate) fn initial_memory_merkle_cap<
     rate_bits: usize,
     cap_height: usize,
 ) -> MerkleCap<F, C::Hasher> {
-    // At the start of a transaction proof, `MemBefore` only contains the RLP
-    // constant and the `ShiftTable`.
+    // At the start of a transaction proof, `MemBefore` only contains the kernel
+    // `Code` segment and the `ShiftTable`.
     let mut trace = Vec::with_capacity((KERNEL.code.len() + 256).next_power_of_two());
 
     // Push kernel code.
@@ -46,10 +46,11 @@ pub(crate) fn initial_memory_merkle_cap<
         row[crate::memory_continuation::columns::value_limb(0)] = F::from_canonical_u8(byte);
         trace.push(row);
     }
+    let mut val = U256::one();
     // Push shift table.
     for i in 0..256 {
         let mut row = vec![F::ZERO; crate::memory_continuation::columns::NUM_COLUMNS];
-        let val = U256::from(1) << i;
+
         row[crate::memory_continuation::columns::FILTER] = F::ONE;
         row[crate::memory_continuation::columns::ADDR_CONTEXT] = F::ZERO;
         row[crate::memory_continuation::columns::ADDR_SEGMENT] =
@@ -59,17 +60,16 @@ pub(crate) fn initial_memory_merkle_cap<
             row[j + 4] = F::from_canonical_u32((val >> (j * 32)).low_u32());
         }
         trace.push(row);
+        val <<= 1;
     }
 
     // Padding.
     let num_rows = trace.len();
     let num_rows_padded = num_rows.next_power_of_two();
-    for _ in num_rows..num_rows_padded {
-        trace.push(vec![
-            F::ZERO;
-            crate::memory_continuation::columns::NUM_COLUMNS
-        ]);
-    }
+    trace.resize(
+        num_rows_padded,
+        vec![F::ZERO; crate::memory_continuation::columns::NUM_COLUMNS],
+    );
 
     let cols = transpose(&trace);
     let polys = cols
@@ -87,6 +87,33 @@ pub(crate) fn initial_memory_merkle_cap<
     )
     .merkle_tree
     .cap
+}
+
+fn verify_initial_memory<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
+    public_values: &PublicValues,
+    config: &StarkConfig,
+) -> Result<()> {
+    for (hash1, hash2) in initial_memory_merkle_cap::<F, C, D>(
+        config.fri_config.rate_bits,
+        config.fri_config.cap_height,
+    )
+    .0
+    .iter()
+    .zip(public_values.mem_before.mem_cap.iter())
+    {
+        for (&limb1, limb2) in hash1.to_vec().iter().zip(hash2) {
+            ensure!(
+                limb1 == F::from_canonical_u64(limb2.as_u64()),
+                anyhow::Error::msg("Invalid initial MemBefore Merkle cap.")
+            );
+        }
+    }
+
+    Ok(())
 }
 
 pub fn verify_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
@@ -205,21 +232,7 @@ where
     let public_values = all_proof.public_values;
 
     // Verify shift table and kernel code.
-    for (hash1, hash2) in initial_memory_merkle_cap::<F, C, D>(
-        config.fri_config.rate_bits,
-        config.fri_config.cap_height,
-    )
-    .0
-    .iter()
-    .zip(public_values.mem_before.mem_cap.iter())
-    {
-        for (&limb1, limb2) in hash1.to_vec().iter().zip(hash2) {
-            ensure!(
-                limb1 == F::from_canonical_u64(limb2.as_u64()),
-                anyhow::Error::msg("Invalid initial MemBefore Merkle cap.")
-            );
-        }
-    }
+    verify_initial_memory::<F, C, D>(&public_values, config)?;
 
     // Extra sums to add to the looked last value.
     // Only necessary for the Memory values.

--- a/evm_arithmetization/src/verifier.rs
+++ b/evm_arithmetization/src/verifier.rs
@@ -1,9 +1,14 @@
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use ethereum_types::{BigEndianHash, U256};
 use itertools::Itertools;
 use plonky2::field::extension::Extendable;
-use plonky2::hash::hash_types::RichField;
-use plonky2::plonk::config::GenericConfig;
+use plonky2::field::polynomial::PolynomialValues;
+use plonky2::fri::oracle::PolynomialBatch;
+use plonky2::hash::hash_types::{HashOut, RichField};
+use plonky2::hash::merkle_tree::MerkleCap;
+use plonky2::plonk::config::{GenericConfig, GenericHashOut};
+use plonky2::util::timing::TimingTree;
+use plonky2::util::transpose;
 use starky::config::StarkConfig;
 use starky::cross_table_lookup::{get_ctl_vars_from_proofs, verify_cross_table_lookups};
 use starky::lookup::GrandProductChallenge;
@@ -15,8 +20,74 @@ use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::memory::segments::Segment;
 use crate::memory::VALUE_LIMBS;
-use crate::proof::{AllProof, AllProofChallenges, PublicValues};
+use crate::proof::{AllProof, AllProofChallenges, MemCap, PublicValues};
 use crate::util::h2u;
+
+pub(crate) fn initial_memory_merkle_cap<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
+    rate_bits: usize,
+    cap_height: usize,
+) -> MerkleCap<F, C::Hasher> {
+    // At the start of a transaction proof, `MemBefore` only contains the RLP
+    // constant and the `ShiftTable`.
+    let mut trace = vec![];
+
+    // Push kernel code.
+    for (i, &byte) in KERNEL.code.iter().enumerate() {
+        let mut row = vec![F::ZERO; crate::memory_continuation::columns::NUM_COLUMNS];
+        row[crate::memory_continuation::columns::FILTER] = F::ONE;
+        row[crate::memory_continuation::columns::ADDR_CONTEXT] = F::ZERO;
+        row[crate::memory_continuation::columns::ADDR_SEGMENT] =
+            F::from_canonical_usize(Segment::Code.unscale());
+        row[crate::memory_continuation::columns::ADDR_VIRTUAL] = F::from_canonical_usize(i);
+        row[crate::memory_continuation::columns::value_limb(0)] = F::from_canonical_u8(byte);
+        trace.push(row);
+    }
+    // Push shift table.
+    for i in 0..256 {
+        let mut row = vec![F::ZERO; crate::memory_continuation::columns::NUM_COLUMNS];
+        let val = U256::from(1) << i;
+        row[crate::memory_continuation::columns::FILTER] = F::ONE;
+        row[crate::memory_continuation::columns::ADDR_CONTEXT] = F::ZERO;
+        row[crate::memory_continuation::columns::ADDR_SEGMENT] =
+            F::from_canonical_usize(Segment::ShiftTable.unscale());
+        row[crate::memory_continuation::columns::ADDR_VIRTUAL] = F::from_canonical_usize(i);
+        for j in 0..crate::memory::VALUE_LIMBS {
+            row[j + 4] = F::from_canonical_u32((val >> (j * 32)).low_u32());
+        }
+        trace.push(row);
+    }
+
+    // Padding.
+    let num_rows = trace.len();
+    let num_rows_padded = num_rows.next_power_of_two();
+    for _ in num_rows..num_rows_padded {
+        trace.push(vec![
+            F::ZERO;
+            crate::memory_continuation::columns::NUM_COLUMNS
+        ]);
+    }
+
+    let cols = transpose(&trace);
+    let polys = cols
+        .into_iter()
+        .map(|column| PolynomialValues::new(column))
+        .collect::<Vec<_>>();
+
+    PolynomialBatch::<F, C, D>::from_values(
+        polys,
+        rate_bits,
+        false,
+        cap_height,
+        &mut TimingTree::default(),
+        None,
+    )
+    .merkle_tree
+    .cap
+}
 
 pub fn verify_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
     all_stark: &AllStark<F, D>,
@@ -132,6 +203,23 @@ where
     )?;
 
     let public_values = all_proof.public_values;
+
+    // Verify shift table and kernel code.
+    for (hash1, hash2) in initial_memory_merkle_cap::<F, C, D>(
+        config.fri_config.rate_bits,
+        config.fri_config.cap_height,
+    )
+    .0
+    .iter()
+    .zip(public_values.mem_before.mem_cap.iter())
+    {
+        for (&limb1, limb2) in hash1.to_vec().iter().zip(hash2) {
+            ensure!(
+                limb1 == F::from_canonical_u64(limb2.as_u64()),
+                anyhow::Error::msg("Invalid initial MemBefore Merkle cap.")
+            );
+        }
+    }
 
     // Extra sums to add to the looked last value.
     // Only necessary for the Memory values.


### PR DESCRIPTION
Add the whole kernel code to the first `MemBefore` trace of a transaction, so that it doesn't need to be hashed inside the kernel.
This removes around 10k rows of `Keccak`, at the cost of 60k rows in `MemBefore` and `Memory` (the extra rows in `Memory` will be mitigated in a future PR).
In addition, this solves a critical soundness problem, as the kernel code segment was completely prover-provided up to the hashing in `global main`, which was allowing completely arbitrary code execution in the kernel.