### PR TITLE
continuations: initial cleanup pass

### DIFF
--- a/evm_arithmetization/src/all_stark.rs
+++ b/evm_arithmetization/src/all_stark.rs
@@ -20,11 +20,11 @@ use crate::keccak::keccak_stark::KeccakStark;
 use crate::keccak_sponge::columns::KECCAK_RATE_BYTES;
 use crate::keccak_sponge::keccak_sponge_stark;
 use crate::keccak_sponge::keccak_sponge_stark::KeccakSpongeStark;
+use crate::logic;
 use crate::logic::LogicStark;
 use crate::memory::memory_stark::MemoryStark;
 use crate::memory::memory_stark::{self, ctl_context_pruning_looking};
 use crate::memory_continuation::memory_continuation_stark::{self, MemoryContinuationStark};
-use crate::{logic, memory_continuation};
 
 /// Structure containing all STARKs and the cross-table lookups.
 #[derive(Clone)]
@@ -346,7 +346,7 @@ fn ctl_mem_before<F: Field>() -> CrossTableLookup<F> {
         memory_stark::ctl_looking_mem(),
         memory_stark::ctl_filter_mem_before(),
     );
-    let mut all_lookers = vec![memory_looking];
+    let all_lookers = vec![memory_looking];
     let mem_before_looked = TableWithColumns::new(
         *Table::MemBefore,
         memory_continuation_stark::ctl_data(),
@@ -363,7 +363,7 @@ fn ctl_mem_after<F: Field>() -> CrossTableLookup<F> {
         memory_stark::ctl_looking_mem(),
         memory_stark::ctl_filter_mem_after(),
     );
-    let mut all_lookers = vec![memory_looking];
+    let all_lookers = vec![memory_looking];
     let mem_after_looked = TableWithColumns::new(
         *Table::MemAfter,
         memory_continuation_stark::ctl_data(),

--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -924,20 +924,6 @@ impl<F: Field> State<F> for Interpreter<F> {
         }
     }
 
-    /// Inserts a preinitialized segment, given as a [Segment],
-    /// into the `preinitialized_segments` memory field.
-    fn insert_preinitialized_segment(&mut self, segment: Segment, values: MemorySegmentState) {
-        self.generation_state
-            .memory
-            .insert_preinitialized_segment(segment, values);
-    }
-
-    fn is_preinitialized_segment(&self, segment: usize) -> bool {
-        self.generation_state
-            .memory
-            .is_preinitialized_segment(segment)
-    }
-
     fn incr_gas(&mut self, n: u64) {
         self.generation_state.incr_gas(n);
     }

--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -31,7 +31,7 @@ use crate::witness::errors::ProgramError;
 use crate::witness::memory::{
     MemoryAddress, MemoryContextState, MemoryOp, MemoryOpKind, MemorySegmentState, MemoryState,
 };
-use crate::witness::operation::{Operation, CONTEXT_SCALING_FACTOR};
+use crate::witness::operation::Operation;
 use crate::witness::state::RegistersState;
 use crate::witness::transition::{
     decode, fill_op_flag, get_op_special_length, log_kernel_instruction, Transition,
@@ -1067,9 +1067,7 @@ impl<F: Field> State<F> for Interpreter<F> {
         // Might write in general CPU columns when it shouldn't, but the correct values
         // will overwrite these ones during the op generation.
         if let Some(special_len) = get_op_special_length(op) {
-            let special_len_f = F::from_canonical_usize(special_len);
-            let diff = row.stack_len - special_len_f;
-            if (generation_state.stack().len() != special_len) {
+            if generation_state.stack().len() != special_len {
                 // If the `State` is an interpreter, we cannot rely on the row to carry out the
                 // check.
                 generation_state.registers.is_stack_top_read = true;
@@ -1086,7 +1084,7 @@ impl<F: Field> State<F> for Interpreter<F> {
         log::debug!("{}", msg);
     }
 
-    fn log_info(&self, msg: String) {}
+    fn log_info(&self, _msg: String) {}
 
     fn log_log(&self, level: Level, msg: String) {
         log::log!(level, "{}", msg);

--- a/evm_arithmetization/src/cpu/kernel/tests/add11.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/add11.rs
@@ -12,10 +12,7 @@ use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::interpreter::Interpreter;
 use crate::generation::mpt::{AccountRlp, LegacyReceiptRlp};
 use crate::generation::TrieInputs;
-use crate::memory::segments::Segment;
-use crate::proof::{BlockHashes, BlockMetadata, MemCap, TrieRoots};
-use crate::util::h2u;
-use crate::witness::state::RegistersState;
+use crate::proof::{BlockHashes, BlockMetadata, TrieRoots};
 use crate::GenerationInputs;
 
 #[test]

--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -15,8 +15,7 @@ use plonky2::fri::oracle::PolynomialBatch;
 use plonky2::fri::FriParams;
 use plonky2::gates::constant::ConstantGate;
 use plonky2::gates::noop::NoopGate;
-use plonky2::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField};
-use plonky2::hash::merkle_tree::MerkleCap;
+use plonky2::hash::hash_types::{MerkleCapTarget, RichField};
 use plonky2::iop::challenger::RecursiveChallenger;
 use plonky2::iop::target::{BoolTarget, Target};
 use plonky2::iop::witness::{PartialWitness, WitnessWrite};
@@ -42,12 +41,11 @@ use starky::stark::Stark;
 
 use crate::all_stark::{all_cross_table_lookups, AllStark, Table, NUM_TABLES};
 use crate::cpu::kernel::aggregator::KERNEL;
-use crate::generation::state::GenerationState;
 use crate::generation::GenerationInputs;
 use crate::get_challenges::observe_public_values_target;
 use crate::memory::segments::Segment;
 use crate::proof::{
-    AllProof, BlockHashesTarget, BlockMetadataTarget, ExtraBlockData, ExtraBlockDataTarget, MemCap,
+    AllProof, BlockHashesTarget, BlockMetadataTarget, ExtraBlockData, ExtraBlockDataTarget,
     MemCapTarget, PublicValues, PublicValuesTarget, RegistersDataTarget, TrieRoots,
     TrieRootsTarget,
 };
@@ -57,8 +55,7 @@ use crate::recursive_verifier::{
     recursive_stark_circuit, set_public_value_targets, PlonkWrapperCircuit, PublicInputs,
     StarkWrapperCircuit,
 };
-use crate::util::{h160_limbs, h256_limbs, u256_limbs};
-use crate::witness::memory::MemoryAddress;
+use crate::util::{h256_limbs, u256_limbs};
 
 /// The recursion threshold. We end a chain of recursive proofs once we reach
 /// this size.
@@ -945,7 +942,7 @@ where
         // Check the initial and final register values.
         Self::connect_initial_final_segment(&mut builder, &public_values);
 
-        // Check the initial `MemBefore` `MerklCap` value.
+        // Check the initial `MemBefore` `MerkleCap` value.
         Self::check_init_merkle_cap(&mut builder, &agg_pv, stark_config);
 
         let cyclic_vk = builder.add_verifier_data_public_inputs();

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -329,11 +329,7 @@ pub(crate) fn debug_inputs(inputs: &GenerationInputs) {
     log::debug!("Input contract_code: {:?}", &inputs.contract_code);
 }
 
-type TablesWithPVsAndFinalMem<F> = (
-    [Vec<PolynomialValues<F>>; NUM_TABLES],
-    PublicValues,
-    Vec<Vec<F>>,
-);
+type TablesWithPVsAndFinalMem<F> = ([Vec<PolynomialValues<F>>; NUM_TABLES], PublicValues);
 pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
     all_stark: &AllStark<F, D>,
     inputs: GenerationInputs,
@@ -410,7 +406,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         mem_after: MemCap::default(),
     };
 
-    let (tables, final_values) = timed!(
+    let tables = timed!(
         timing,
         "convert trace data to tables",
         state.traces.into_tables(
@@ -422,7 +418,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
             timing
         )
     );
-    Ok((tables, public_values, final_values))
+    Ok((tables, public_values))
 }
 
 fn simulate_cpu<F: Field>(

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -20,8 +20,6 @@ use GlobalMetadata::{
 use crate::all_stark::{AllStark, NUM_TABLES};
 use crate::cpu::columns::CpuColumnsView;
 use crate::cpu::kernel::aggregator::KERNEL;
-use crate::cpu::kernel::assembler::Kernel;
-use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::generation::state::{GenerationState, State};
 use crate::generation::trie_extractor::{get_receipt_trie, get_state_trie, get_txn_trie};
@@ -29,12 +27,9 @@ use crate::memory::segments::Segment;
 use crate::proof::{
     BlockHashes, BlockMetadata, ExtraBlockData, MemCap, PublicValues, RegistersData, TrieRoots,
 };
-use crate::prover::{check_abort_signal, get_mem_after_value_from_row};
 use crate::util::{h2u, u256_to_usize};
-use crate::witness::errors::{ProgramError, ProverInputError};
 use crate::witness::memory::{MemoryAddress, MemoryChannel, MemoryState};
 use crate::witness::state::RegistersState;
-use crate::witness::traces::Traces;
 
 pub mod mpt;
 pub(crate) mod prover_input;
@@ -42,8 +37,7 @@ pub(crate) mod rlp;
 pub(crate) mod state;
 mod trie_extractor;
 
-use self::mpt::{load_all_mpts, TrieRootPtrs};
-use crate::witness::util::{mem_write_log, mem_write_log_timestamp_zero};
+use crate::witness::util::mem_write_log;
 
 /// Number of cycles to go after having reached the halting state. It is
 /// equal to the number of cycles in `exc_stop` + 1.
@@ -371,16 +365,12 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         "simulate CPU",
         simulate_cpu(&mut state, max_cpu_len_log)
     );
-    let (final_registers, mem_after) = if let Ok(res) = cpu_res {
-        res
-    } else {
-        output_debug_tries(&state);
-
+    if cpu_res.is_err() {
+        output_debug_tries(&state)?;
         cpu_res?;
-        (RegistersState::default(), None)
     };
 
-    let mut trace_lengths = state.traces.get_lengths();
+    let trace_lengths = state.traces.get_lengths();
 
     let read_metadata = |field| state.memory.read_global_metadata(field);
     let trie_roots_before = TrieRoots {

--- a/evm_arithmetization/src/generation/mpt.rs
+++ b/evm_arithmetization/src/generation/mpt.rs
@@ -2,7 +2,7 @@ use core::ops::Deref;
 use std::collections::HashMap;
 
 use bytes::Bytes;
-use ethereum_types::{Address, BigEndianHash, H256, U256, U512};
+use ethereum_types::{Address, BigEndianHash, H256, U256};
 use keccak_hash::keccak;
 use mpt_trie::nibbles::{Nibbles, NibblesIntern};
 use mpt_trie::partial_trie::{HashedPartialTrie, PartialTrie};

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -316,7 +316,7 @@ pub(crate) trait State<F: Field> {
     }
 
     /// Logs `msg` in `debug` mode, in the interpreter.
-    fn log_debug(&self, msg: String) {}
+    fn log_debug(&self, _msg: String) {}
 
     /// Logs `msg` in `info` mode, in the interpreter.
     fn log_info(&self, msg: String) {
@@ -324,7 +324,7 @@ pub(crate) trait State<F: Field> {
     }
 
     /// Logs `msg` at `level`, during witness generation.
-    fn log_log(&self, level: Level, msg: String) {}
+    fn log_log(&self, _level: Level, _msg: String) {}
 }
 
 #[derive(Debug)]
@@ -499,13 +499,13 @@ impl<F: Field> State<F> for GenerationState<F> {
         }
     }
 
-    fn insert_preinitialized_segment(&mut self, segment: Segment, values: MemorySegmentState) {
+    fn insert_preinitialized_segment(&mut self, _segment: Segment, _values: MemorySegmentState) {
         panic!(
             "A `GenerationState` cannot have a nonempty `preinitialized_segment` field in memory."
         )
     }
 
-    fn is_preinitialized_segment(&self, segment: usize) -> bool {
+    fn is_preinitialized_segment(&self, _segment: usize) -> bool {
         false
     }
 
@@ -587,7 +587,7 @@ impl<F: Field> State<F> for GenerationState<F> {
                 row.general.stack_mut().stack_inv = inv;
                 row.general.stack_mut().stack_inv_aux = F::ONE;
                 self.registers.is_stack_top_read = true;
-            } else if (self.stack().len() != special_len) {
+            } else if self.stack().len() != special_len {
                 // If the `State` is an interpreter, we cannot rely on the row to carry out the
                 // check.
                 self.registers.is_stack_top_read = true;
@@ -606,7 +606,7 @@ impl<F: Field> Transition<F> for GenerationState<F> {
         Ok(op)
     }
 
-    fn generate_jumpdest_analysis(&mut self, dst: usize) -> bool {
+    fn generate_jumpdest_analysis(&mut self, _dst: usize) -> bool {
         false
     }
 

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -1,5 +1,5 @@
 use core::borrow::Borrow;
-use core::iter::{self, once, repeat};
+use core::iter::{self, repeat};
 use core::marker::PhantomData;
 use core::mem::size_of;
 

--- a/evm_arithmetization/src/memory/memory_stark.rs
+++ b/evm_arithmetization/src/memory/memory_stark.rs
@@ -225,7 +225,7 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
     /// a trace in column-major form.
     /// Also generates the `STALE_CONTEXTS`, `STALE_CONTEXTS_FREQUENCIES` and
     /// `MEM_AFTER_FILTER` columns.
-    fn generate_trace_col_major(trace_col_vecs: &mut [Vec<F>], stale_contexts: Vec<usize>) {
+    fn generate_trace_col_major(trace_col_vecs: &mut [Vec<F>]) {
         let height = trace_col_vecs[0].len();
         trace_col_vecs[COUNTER] = (0..height).map(|i| F::from_canonical_usize(i)).collect();
 
@@ -397,7 +397,7 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
         let mut trace_col_vecs = transpose(&trace_row_vecs);
 
         // A few final generation steps, which work better in column-major form.
-        Self::generate_trace_col_major(&mut trace_col_vecs, stale_contexts);
+        Self::generate_trace_col_major(&mut trace_col_vecs);
 
         let final_rows = transpose(&trace_col_vecs);
 

--- a/evm_arithmetization/src/proof.rs
+++ b/evm_arithmetization/src/proof.rs
@@ -1,21 +1,9 @@
-use std::hash::Hash;
-
-use ethereum_types::{Address, H160, H256, U256};
-use itertools::Itertools;
-use plonky2::field::extension::{Extendable, FieldExtension};
-use plonky2::fri::oracle::PolynomialBatch;
-use plonky2::fri::proof::{FriChallenges, FriChallengesTarget, FriProof, FriProofTarget};
-use plonky2::fri::structure::{
-    FriOpeningBatch, FriOpeningBatchTarget, FriOpenings, FriOpeningsTarget,
-};
-use plonky2::hash::hash_types::{
-    HashOut, HashOutTarget, MerkleCapTarget, RichField, NUM_HASH_OUT_ELTS,
-};
-use plonky2::hash::merkle_tree::MerkleCap;
-use plonky2::iop::ext_target::ExtensionTarget;
+use ethereum_types::{Address, H256, U256};
+use plonky2::field::extension::Extendable;
+use plonky2::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField, NUM_HASH_OUT_ELTS};
 use plonky2::iop::target::{BoolTarget, Target};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
-use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, GenericHashOut, Hasher};
+use plonky2::plonk::config::GenericConfig;
 use plonky2::util::serialization::{Buffer, IoResult, Read, Write};
 use serde::{Deserialize, Serialize};
 use starky::config::StarkConfig;
@@ -23,10 +11,7 @@ use starky::lookup::GrandProductChallengeSet;
 use starky::proof::{MultiProof, StarkProofChallenges};
 
 use crate::all_stark::NUM_TABLES;
-use crate::generation::mpt::TrieRootPtrs;
-use crate::generation::MemBeforeValues;
 use crate::util::{get_h160, get_h256, get_u256, h2u};
-use crate::witness::memory::MemoryAddress;
 
 /// A STARK proof for each table, plus some metadata used to create recursive
 /// wrapper proofs.

--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -1,18 +1,14 @@
-use std::any::type_name;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, Result};
 use ethereum_types::U256;
 use hashbrown::HashMap;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use plonky2::field::extension::Extendable;
-use plonky2::field::packable::Packable;
-use plonky2::field::packed::PackedField;
-use plonky2::field::polynomial::{PolynomialCoeffs, PolynomialValues};
-use plonky2::field::types::{Field, PrimeField64};
-use plonky2::field::zero_poly_coset::ZeroPolyOnCoset;
+use plonky2::field::polynomial::PolynomialValues;
+use plonky2::field::types::Field;
 use plonky2::fri::oracle::PolynomialBatch;
 use plonky2::hash::hash_types::RichField;
 use plonky2::hash::merkle_tree::MerkleCap;
@@ -22,8 +18,7 @@ use plonky2::timed;
 use plonky2::util::timing::TimingTree;
 use starky::config::StarkConfig;
 use starky::cross_table_lookup::{get_ctl_data, CtlData};
-use starky::evaluation_frame::StarkEvaluationFrame;
-use starky::lookup::{get_grand_product_challenge_set, GrandProductChallengeSet, Lookup};
+use starky::lookup::GrandProductChallengeSet;
 use starky::proof::{MultiProof, StarkProofWithMetadata};
 use starky::prover::prove_with_commitment;
 use starky::stark::Stark;
@@ -32,7 +27,7 @@ use crate::all_stark::{AllStark, Table, NUM_TABLES};
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::interpreter::{generate_segment, ExtraSegmentData};
 use crate::generation::state::GenerationState;
-use crate::generation::{generate_traces, GenerationInputs, MemBeforeValues, SegmentData};
+use crate::generation::{generate_traces, GenerationInputs, SegmentData};
 use crate::get_challenges::observe_public_values;
 use crate::memory::segments::Segment;
 use crate::proof::{AllProof, MemCap, PublicValues, RegistersData};
@@ -136,7 +131,7 @@ where
             registers_after: registers_data_after,
         };
 
-        let (traces, mut public_values, final_values) = timed!(
+        let (traces, mut public_values, _final_values) = timed!(
             timing,
             "generate all traces",
             generate_traces(all_stark, inputs, config, segment_data, timing)?
@@ -323,12 +318,12 @@ fn prove_with_commitments<F, C, const D: usize>(
     ctl_challenges: &GrandProductChallengeSet<F>,
     timing: &mut TimingTree,
     abort_signal: Option<Arc<AtomicBool>>,
-) -> Result<(ProofWithMemCaps<F, C, C::Hasher, D>)>
+) -> Result<ProofWithMemCaps<F, C, C::Hasher, D>>
 where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
 {
-    let (arithmetic_proof, arithmetic_cap) = timed!(
+    let (arithmetic_proof, _) = timed!(
         timing,
         "prove Arithmetic STARK",
         prove_single_table(
@@ -343,7 +338,7 @@ where
             abort_signal.clone(),
         )?
     );
-    let (byte_packing_proof, bp_cap) = timed!(
+    let (byte_packing_proof, _) = timed!(
         timing,
         "prove byte packing STARK",
         prove_single_table(
@@ -358,7 +353,7 @@ where
             abort_signal.clone(),
         )?
     );
-    let (cpu_proof, cpu_cap) = timed!(
+    let (cpu_proof, _) = timed!(
         timing,
         "prove CPU STARK",
         prove_single_table(
@@ -373,7 +368,7 @@ where
             abort_signal.clone(),
         )?
     );
-    let (keccak_proof, keccak_cap) = timed!(
+    let (keccak_proof, _) = timed!(
         timing,
         "prove Keccak STARK",
         prove_single_table(
@@ -388,7 +383,7 @@ where
             abort_signal.clone(),
         )?
     );
-    let (keccak_sponge_proof, keccak_sponge_cap) = timed!(
+    let (keccak_sponge_proof, _) = timed!(
         timing,
         "prove Keccak sponge STARK",
         prove_single_table(
@@ -403,7 +398,7 @@ where
             abort_signal.clone(),
         )?
     );
-    let (logic_proof, logic_cap) = timed!(
+    let (logic_proof, _) = timed!(
         timing,
         "prove logic STARK",
         prove_single_table(
@@ -418,7 +413,7 @@ where
             abort_signal.clone(),
         )?
     );
-    let (memory_proof, mem_cap) = timed!(
+    let (memory_proof, _) = timed!(
         timing,
         "prove memory STARK",
         prove_single_table(
@@ -479,24 +474,6 @@ where
         mem_before_cap,
         mem_after_cap,
     ))
-}
-
-/// Returns a memory value in the form `(MemoryAddress, U256)`,
-/// taken from a row in `MemAfterStark`.
-pub(crate) fn get_mem_after_value_from_row<F: RichField>(row: &[F]) -> (MemoryAddress, U256) {
-    // The row has shape (1, context, segment, virt, [values]) where [values] are 8
-    // 32-bit elements representing one U256 word.
-    let mem_address = MemoryAddress {
-        context: row[1].to_canonical_u64() as usize,
-        segment: row[2].to_canonical_u64() as usize,
-        virt: row[3].to_canonical_u64() as usize,
-    };
-
-    let value: U256 = row[4..]
-        .iter()
-        .rev()
-        .fold(0.into(), |acc, v| (acc << 32) + v.to_canonical_u64());
-    (mem_address, value)
 }
 
 type ProofSingleWithCap<F, C, H, const D: usize> =

--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -131,7 +131,7 @@ where
             registers_after: registers_data_after,
         };
 
-        let (traces, mut public_values, _final_values) = timed!(
+        let (traces, mut public_values) = timed!(
             timing,
             "generate all traces",
             generate_traces(all_stark, inputs, config, segment_data, timing)?

--- a/evm_arithmetization/src/recursive_verifier.rs
+++ b/evm_arithmetization/src/recursive_verifier.rs
@@ -7,9 +7,8 @@ use plonky2::field::extension::Extendable;
 use plonky2::gates::exponentiation::ExponentiationGate;
 use plonky2::gates::gate::GateRef;
 use plonky2::gates::noop::NoopGate;
-use plonky2::hash::hash_types::{HashOut, HashOutTarget, MerkleCapTarget, RichField};
+use plonky2::hash::hash_types::{HashOut, MerkleCapTarget, RichField};
 use plonky2::hash::hashing::PlonkyPermutation;
-use plonky2::hash::merkle_tree::MerkleCap;
 use plonky2::iop::challenger::RecursiveChallenger;
 use plonky2::iop::target::Target;
 use plonky2::iop::witness::{PartialWitness, Witness, WitnessWrite};
@@ -40,7 +39,7 @@ use crate::proof::{
     ExtraBlockDataTarget, MemCap, MemCapTarget, PublicValues, PublicValuesTarget, RegistersData,
     RegistersDataTarget, TrieRoots, TrieRootsTarget,
 };
-use crate::util::{h256_limbs, h2u, u256_limbs, u256_to_u32, u256_to_u64};
+use crate::util::{h256_limbs, u256_limbs, u256_to_u32, u256_to_u64};
 use crate::witness::errors::ProgramError;
 
 pub(crate) struct PublicInputs<T: Copy + Default + Eq + PartialEq + Debug, P: PlonkyPermutation<T>>

--- a/evm_arithmetization/src/witness/operation.rs
+++ b/evm_arithmetization/src/witness/operation.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use ethereum_types::{BigEndianHash, U256};
 use itertools::Itertools;
 use keccak_hash::keccak;

--- a/evm_arithmetization/src/witness/state.rs
+++ b/evm_arithmetization/src/witness/state.rs
@@ -5,14 +5,6 @@ use crate::cpu::kernel::aggregator::KERNEL;
 
 const KERNEL_CONTEXT: usize = 0;
 
-/// Structure for the state of the registers before and after
-/// the current execution.
-#[derive(Copy, Clone, Default)]
-pub struct PublicRegisterStates {
-    registers_before: RegistersState,
-    registers_after: RegistersState,
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct RegistersState {
     pub program_counter: usize,

--- a/evm_arithmetization/src/witness/traces.rs
+++ b/evm_arithmetization/src/witness/traces.rs
@@ -6,8 +6,6 @@ use plonky2::util::timing::TimingTree;
 use starky::config::StarkConfig;
 use starky::util::trace_rows_to_poly_values;
 
-use super::memory::MemoryAddress;
-use super::state::RegistersState;
 use crate::all_stark::{AllStark, NUM_TABLES};
 use crate::arithmetic::{BinaryOperator, Operation};
 use crate::byte_packing::byte_packing_stark::BytePackingOp;
@@ -195,14 +193,14 @@ impl<T: Copy> Traces<T> {
             "generate mem_before trace",
             all_stark
                 .mem_before_stark
-                .generate_trace(mem_before_values_to_rows(mem_before_values), timing)
+                .generate_trace(mem_before_values_to_rows(mem_before_values))
         );
         let mem_after_trace = timed!(
             timing,
             "generate mem_after trace",
             all_stark
                 .mem_after_stark
-                .generate_trace(final_values.clone(), timing)
+                .generate_trace(final_values.clone())
         );
 
         log::info!(

--- a/evm_arithmetization/src/witness/traces.rs
+++ b/evm_arithmetization/src/witness/traces.rs
@@ -126,7 +126,7 @@ impl<T: Copy> Traces<T> {
         mut trace_lengths: TraceCheckpoint,
         config: &StarkConfig,
         timing: &mut TimingTree,
-    ) -> ([Vec<PolynomialValues<T>>; NUM_TABLES], Vec<Vec<T>>)
+    ) -> [Vec<PolynomialValues<T>>; NUM_TABLES]
     where
         T: RichField + Extendable<D>,
     {
@@ -210,20 +210,17 @@ impl<T: Copy> Traces<T> {
             final_values.len()
         );
 
-        (
-            [
-                arithmetic_trace,
-                byte_packing_trace,
-                cpu_trace,
-                keccak_trace,
-                keccak_sponge_trace,
-                logic_trace,
-                memory_trace,
-                mem_before_trace,
-                mem_after_trace,
-            ],
-            final_values,
-        )
+        [
+            arithmetic_trace,
+            byte_packing_trace,
+            cpu_trace,
+            keccak_trace,
+            keccak_sponge_trace,
+            logic_trace,
+            memory_trace,
+            mem_before_trace,
+            mem_after_trace,
+        ]
     }
 }
 

--- a/evm_arithmetization/src/witness/transition.rs
+++ b/evm_arithmetization/src/witness/transition.rs
@@ -10,7 +10,7 @@ use crate::cpu::membus::NUM_GP_CHANNELS;
 use crate::cpu::stack::{
     EQ_STACK_BEHAVIOR, IS_ZERO_STACK_BEHAVIOR, JUMPI_OP, JUMP_OP, MIGHT_OVERFLOW, STACK_BEHAVIORS,
 };
-use crate::generation::state::{GenerationState, State};
+use crate::generation::state::State;
 use crate::memory::segments::Segment;
 use crate::witness::errors::ProgramError;
 use crate::witness::gas::gas_to_charge;
@@ -304,8 +304,6 @@ where
 
     fn final_exception(&mut self) -> anyhow::Result<()> {
         let checkpoint = self.checkpoint();
-
-        let gen_state = self.get_mut_generation_state();
 
         let (row, _) = self.base_row();
 

--- a/evm_arithmetization/src/witness/util.rs
+++ b/evm_arithmetization/src/witness/util.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use ethereum_types::U256;
 use plonky2::field::types::Field;
 

--- a/evm_arithmetization/src/witness/util.rs
+++ b/evm_arithmetization/src/witness/util.rs
@@ -146,15 +146,6 @@ pub(crate) fn mem_write_log<F: Field>(
     )
 }
 
-pub(crate) fn mem_write_log_timestamp_zero<F: Field>(
-    address: MemoryAddress,
-    state: &GenerationState<F>,
-    val: U256,
-) -> MemoryOp {
-    // `Code` corresponds to channel number 0.
-    MemoryOp::new(MemoryChannel::Code, 0, address, MemoryOpKind::Write, val)
-}
-
 pub(crate) fn mem_read_code_with_log_and_fill<F: Field>(
     address: MemoryAddress,
     state: &GenerationState<F>,


### PR DESCRIPTION
No code refactor or whatsoever, just removing all dead code from initial continuations work.
Also removing `interpreter` specific methods from the `State` trait which probably came back from an imperfect merge with `develop`.