### PR TITLE
Prepare for removal of obsolete `ceil_div_usize` in `plonky2_util`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ serde_json = "1.0.96"
 thiserror = "1.0.49"
 
 # plonky2-related dependencies
-plonky2 = "0.2.2"
-plonky2_maybe_rayon = "0.2.0"
-plonky2_util = "0.2.0"
-starky = "0.4.0"
+plonky2 = "0.2"
+plonky2_maybe_rayon = "0.2"
+plonky2_util = "0.2"
+starky = "0.4"
 
 
 [workspace.package]
@@ -32,3 +32,10 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/0xPolygonZero/zk_evm"
 homepage = "https://github.com/0xPolygonZero/zk_evm"
 keywords = ["cryptography", "STARK", "plonky2", "ethereum", "zk"]
+
+# Remove the patch, once the new plonky2 related dependencies are properly released.
+[patch.crates-io]
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", branch = "main" }
+plonky2_maybe_rayon = { git = "https://github.com/0xPolygonZero/plonky2.git", branch = "main" }
+plonky2_util = { git = "https://github.com/0xPolygonZero/plonky2.git", branch = "main" }
+starky = { git = "https://github.com/0xPolygonZero/plonky2.git", branch = "main" }

--- a/evm_arithmetization/src/cpu/kernel/tests/bignum/mod.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/bignum/mod.rs
@@ -9,7 +9,6 @@ use itertools::Itertools;
 use num::{BigUint, One, Zero};
 use num_bigint::RandBigInt;
 use plonky2::field::goldilocks_field::GoldilocksField as F;
-use plonky2_util::ceil_div_usize;
 use rand::Rng;
 
 use crate::cpu::kernel::aggregator::KERNEL;
@@ -90,7 +89,7 @@ fn max_bignum(bit_size: usize) -> BigUint {
 }
 
 fn bignum_len(a: &BigUint) -> usize {
-    ceil_div_usize(a.bits() as usize, BIGNUM_LIMB_BITS)
+    (a.bits() as usize).div_ceil(BIGNUM_LIMB_BITS)
 }
 
 fn run_test(fn_label: &str, memory: Vec<U256>, stack: Vec<U256>) -> Result<(Vec<U256>, Vec<U256>)> {

--- a/evm_arithmetization/src/cpu/kernel/utils.rs
+++ b/evm_arithmetization/src/cpu/kernel/utils.rs
@@ -1,7 +1,6 @@
 use core::fmt::Debug;
 
 use ethereum_types::U256;
-use plonky2_util::ceil_div_usize;
 
 /// Enumerate the length `W` windows of `vec`, and run `maybe_replace` on each
 /// one.
@@ -28,7 +27,7 @@ where
 }
 
 pub(crate) fn u256_to_trimmed_be_bytes(u256: &U256) -> Vec<u8> {
-    let num_bytes = ceil_div_usize(u256.bits(), 8);
+    let num_bytes = u256.bits().div_ceil(8);
     // `byte` is little-endian, so we manually reverse it.
     (0..num_bytes).rev().map(|i| u256.byte(i)).collect()
 }

--- a/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm_arithmetization/src/keccak_sponge/keccak_sponge_stark.rs
@@ -13,7 +13,6 @@ use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::timed;
 use plonky2::util::timing::TimingTree;
 use plonky2::util::transpose;
-use plonky2_util::ceil_div_usize;
 use starky::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 use starky::evaluation_frame::StarkEvaluationFrame;
 use starky::lookup::{Column, Filter, Lookup};
@@ -137,7 +136,7 @@ pub(crate) fn ctl_looking_memory<F: Field>(i: usize) -> Vec<Column<F>> {
 /// Returns the number of `KeccakSponge` tables looking into the `LogicStark`.
 pub(crate) const fn num_logic_ctls() -> usize {
     const U8S_PER_CTL: usize = 32;
-    ceil_div_usize(KECCAK_RATE_BYTES, U8S_PER_CTL)
+    KECCAK_RATE_BYTES.div_ceil(U8S_PER_CTL)
 }
 
 /// Creates the vector of `Columns` required to perform the `i`th logic CTL.

--- a/evm_arithmetization/src/logic.rs
+++ b/evm_arithmetization/src/logic.rs
@@ -10,7 +10,6 @@ use plonky2::hash::hash_types::RichField;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::timed;
 use plonky2::util::timing::TimingTree;
-use plonky2_util::ceil_div_usize;
 use starky::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 use starky::evaluation_frame::StarkEvaluationFrame;
 use starky::lookup::{Column, Filter};
@@ -28,7 +27,7 @@ const VAL_BITS: usize = 256;
 pub(crate) const PACKED_LIMB_BITS: usize = 32;
 /// Number of field elements needed to store each input/output at the specified
 /// packing.
-const PACKED_LEN: usize = ceil_div_usize(VAL_BITS, PACKED_LIMB_BITS);
+const PACKED_LEN: usize = VAL_BITS.div_ceil(PACKED_LIMB_BITS);
 
 /// `LogicStark` columns.
 pub(crate) mod columns {


### PR DESCRIPTION
Please don't merge as-is.

You can use it to prepare for when the new `plonky2_util` releases, and I am using it to test https://github.com/0xPolygonZero/plonky2/pull/1577