### PR TITLE
continuations: Remove `GenerationInputs` cloning for segment generation

### DIFF
--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -1389,7 +1389,7 @@ where
         abort_signal: Option<Arc<AtomicBool>>,
     ) -> anyhow::Result<Vec<ProverOutputData<F, C, D>>> {
         let mut all_data_segments =
-            generate_all_data_segments::<F>(Some(max_cpu_len_log), generation_inputs.clone())?;
+            generate_all_data_segments::<F>(Some(max_cpu_len_log), &generation_inputs)?;
         let mut proofs = Vec::with_capacity(all_data_segments.len());
         for mut data in all_data_segments {
             let proof = self.prove_segment(

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -367,14 +367,14 @@ fn get_all_memory_address_and_values<F: RichField + Extendable<D>, const D: usiz
 type TablesWithPVsAndFinalMem<F> = ([Vec<PolynomialValues<F>>; NUM_TABLES], PublicValues);
 pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
     all_stark: &AllStark<F, D>,
-    inputs: GenerationInputs,
+    inputs: &GenerationInputs,
     config: &StarkConfig,
     segment_data: &mut GenerationSegmentData,
     timing: &mut TimingTree,
 ) -> anyhow::Result<TablesWithPVsAndFinalMem<F>> {
-    debug_inputs(&inputs);
+    debug_inputs(inputs);
 
-    let mut state = GenerationState::<F>::new(&inputs, &KERNEL.code)
+    let mut state = GenerationState::<F>::new(inputs, &KERNEL.code)
         .map_err(|err| anyhow!("Failed to parse all the initial prover inputs: {:?}", err))?;
 
     state.set_segment_data(segment_data);
@@ -400,7 +400,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
 
     let registers_before: RegistersData = RegistersData::from(*registers_before);
     let registers_after: RegistersData = RegistersData::from(*registers_after);
-    apply_metadata_and_tries_memops(&mut state, &inputs, &registers_before, &registers_after);
+    apply_metadata_and_tries_memops(&mut state, inputs, &registers_before, &registers_after);
 
     let cpu_res = timed!(
         timing,
@@ -443,8 +443,8 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
     let public_values = PublicValues {
         trie_roots_before,
         trie_roots_after,
-        block_metadata: inputs.block_metadata,
-        block_hashes: inputs.block_hashes,
+        block_metadata: inputs.block_metadata.clone(),
+        block_hashes: inputs.block_hashes.clone(),
         extra_block_data,
         registers_before,
         registers_after,

--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -69,7 +69,7 @@ where
     let (traces, mut public_values) = timed!(
         timing,
         "generate all traces",
-        generate_traces(all_stark, inputs, config, segment_data, timing)?
+        generate_traces(all_stark, &inputs, config, segment_data, timing)?
     );
 
     check_abort_signal(abort_signal.clone())?;
@@ -474,14 +474,14 @@ pub fn check_abort_signal(abort_signal: Option<Arc<AtomicBool>>) -> Result<()> {
 /// of a transaction.
 pub fn generate_all_data_segments<F: RichField>(
     max_cpu_len_log: Option<usize>,
-    inputs: GenerationInputs,
+    inputs: &GenerationInputs,
 ) -> anyhow::Result<Vec<GenerationSegmentData>> {
     let mut all_seg_data = vec![];
 
     let mut interpreter = Interpreter::<F>::new_with_generation_inputs(
         KERNEL.global_labels["init"],
         vec![],
-        &inputs,
+        inputs,
         max_cpu_len_log,
     );
 
@@ -583,7 +583,7 @@ pub mod testing {
         C: GenericConfig<D, F = F>,
     {
         let mut segment_idx = 0;
-        let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), inputs.clone())?;
+        let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), &inputs)?;
 
         let mut proofs = Vec::with_capacity(data.len());
         for mut d in data {

--- a/evm_arithmetization/tests/add11_yml.rs
+++ b/evm_arithmetization/tests/add11_yml.rs
@@ -184,7 +184,7 @@ fn add11_yml() -> anyhow::Result<()> {
     let inputs = get_generation_inputs();
 
     let max_cpu_len_log = 20;
-    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), inputs.clone())?;
+    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), &inputs)?;
 
     let mut timing = TimingTree::new("prove", log::Level::Debug);
 

--- a/evm_arithmetization/tests/basic_smart_contract.rs
+++ b/evm_arithmetization/tests/basic_smart_contract.rs
@@ -199,7 +199,7 @@ fn test_basic_smart_contract() -> anyhow::Result<()> {
     };
 
     let max_cpu_len_log = 20;
-    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), inputs.clone())?;
+    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), &inputs)?;
 
     let mut timing = TimingTree::new("prove", log::Level::Debug);
     let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut data[0], &mut timing, None)?;

--- a/evm_arithmetization/tests/erc20.rs
+++ b/evm_arithmetization/tests/erc20.rs
@@ -175,7 +175,7 @@ fn test_erc20() -> anyhow::Result<()> {
     };
 
     let max_cpu_len_log = 20;
-    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), inputs.clone())?;
+    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), &inputs)?;
 
     let mut timing = TimingTree::new("prove", log::Level::Debug);
     let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut data[0], &mut timing, None)?;

--- a/evm_arithmetization/tests/erc721.rs
+++ b/evm_arithmetization/tests/erc721.rs
@@ -179,7 +179,7 @@ fn test_erc721() -> anyhow::Result<()> {
     let mut timing = TimingTree::new("prove", log::Level::Debug);
 
     let max_cpu_len_log = 20;
-    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), inputs.clone())?;
+    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), &inputs)?;
 
     let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut data[0], &mut timing, None)?;
     timing.filter(Duration::from_millis(100)).print();

--- a/evm_arithmetization/tests/log_opcode.rs
+++ b/evm_arithmetization/tests/log_opcode.rs
@@ -239,7 +239,7 @@ fn test_log_opcodes() -> anyhow::Result<()> {
     };
 
     let max_cpu_len_log = 20;
-    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), inputs.clone())?;
+    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), &inputs)?;
 
     let mut timing = TimingTree::new("prove", log::Level::Debug);
     let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut data[0], &mut timing, None)?;

--- a/evm_arithmetization/tests/self_balance_gas_cost.rs
+++ b/evm_arithmetization/tests/self_balance_gas_cost.rs
@@ -186,7 +186,7 @@ fn self_balance_gas_cost() -> anyhow::Result<()> {
     };
 
     let max_cpu_len_log = 20;
-    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), inputs.clone())?;
+    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), &inputs)?;
 
     let mut timing = TimingTree::new("prove", log::Level::Debug);
     let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut data[0], &mut timing, None)?;

--- a/evm_arithmetization/tests/selfdestruct.rs
+++ b/evm_arithmetization/tests/selfdestruct.rs
@@ -138,7 +138,7 @@ fn test_selfdestruct() -> anyhow::Result<()> {
     };
 
     let max_cpu_len_log = 20;
-    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), inputs.clone())?;
+    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), &inputs)?;
 
     let mut timing = TimingTree::new("prove", log::Level::Debug);
     let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut data[0], &mut timing, None)?;

--- a/evm_arithmetization/tests/simple_transfer.rs
+++ b/evm_arithmetization/tests/simple_transfer.rs
@@ -154,7 +154,7 @@ fn test_simple_transfer() -> anyhow::Result<()> {
     };
 
     let max_cpu_len_log = 20;
-    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), inputs.clone())?;
+    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), &inputs)?;
 
     let mut timing = TimingTree::new("prove", log::Level::Debug);
     let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut data[0], &mut timing, None)?;

--- a/evm_arithmetization/tests/withdrawals.rs
+++ b/evm_arithmetization/tests/withdrawals.rs
@@ -83,7 +83,7 @@ fn test_withdrawals() -> anyhow::Result<()> {
     };
 
     let max_cpu_len_log = 20;
-    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), inputs.clone())?;
+    let mut data = generate_all_data_segments::<F>(Some(max_cpu_len_log), &inputs)?;
 
     let mut timing = TimingTree::new("prove", log::Level::Debug);
     let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut data[0], &mut timing, None)?;


### PR DESCRIPTION
Remove cloning for segment data generation. Calling `prove` still consumes the `GenerationInputs`.