### PR TITLE
Some fixes to Cancun

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/beacon_roots.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/beacon_roots.asm
@@ -37,13 +37,13 @@ write_beacon_roots_to_storage:
     %slot_to_storage_key
     // stack: storage_key, value_ptr, after_beacon_roots_storage_insert, retdest
     PUSH 64 // storage_key has 64 nibbles
-    %get_storage_trie(@BEACON_ROOTS_ADDRESS)
+    %get_storage_trie(@BEACON_ROOTS_CONTRACT_STATE_KEY)
     // stack: storage_root_ptr, 64, storage_key, value_ptr, after_beacon_roots_storage_insert, retdest
     %jump(mpt_insert)
 
 after_beacon_roots_storage_insert:
     // stack: new_storage_root_ptr, retdest
-    %get_account_data(@BEACON_ROOTS_ADDRESS)
+    %get_account_data(@BEACON_ROOTS_CONTRACT_STATE_KEY)
     // stack: account_ptr, new_storage_root_ptr, retdest
 
     // Update the copied account with our new storage root pointer.
@@ -60,7 +60,7 @@ delete_root_idx_slot:
     %slot_to_storage_key
     // stack: storage_key, after_root_idx_slot_delete, write_beacon_roots_to_storage, timestamp_idx, timestamp, retdest
     PUSH 64 // storage_key has 64 nibbles
-    %get_storage_trie(@BEACON_ROOTS_ADDRESS)
+    %get_storage_trie(@BEACON_ROOTS_CONTRACT_STATE_KEY)
     // stack: storage_root_ptr, 64, storage_key, after_root_idx_slot_delete, write_beacon_roots_to_storage, timestamp_idx, timestamp, retdest
 
     // If the slot is empty (i.e. ptr defaulting to 0), skip the deletion.
@@ -79,7 +79,7 @@ checkpoint_delete_root_idx:
 
 after_root_idx_slot_delete:
     // stack: new_storage_root_ptr, write_beacon_roots_to_storage, timestamp_idx, timestamp, retdest
-    %get_account_data(@BEACON_ROOTS_ADDRESS)
+    %get_account_data(@BEACON_ROOTS_CONTRACT_STATE_KEY)
     // stack: account_ptr, new_storage_root_ptr, write_beacon_roots_to_storage, timestamp_idx, timestamp, retdest
 
     // Update the copied account with our new storage root pointer.

--- a/evm_arithmetization/src/cpu/kernel/asm/global_exit_root.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/global_exit_root.asm
@@ -1,6 +1,6 @@
 /// At the top of the block, the global exit roots (if any) are written to storage.
 /// Global exit roots (GER) are of the form `(timestamp, root)` and are loaded from prover inputs.
-/// The timestamp is written to the storage of address `ADDRESS_GLOBAL_EXIT_ROOT_MANAGER_L2` in the slot `keccak256(abi.encodePacked(root, GLOBAL_EXIT_ROOT_STORAGE_POS))`.
+/// The timestamp is written to the storage of address `GLOBAL_EXIT_ROOT_MANAGER_L2_STATE_KEY` in the slot `keccak256(abi.encodePacked(root, GLOBAL_EXIT_ROOT_STORAGE_POS))`.
 /// See https://github.com/0xPolygonHermez/cdk-erigon/blob/zkevm/zk/utils/global_exit_root.go for reference.
 ///
 /// *NOTE*: This will panic if one of the provided timestamps is zero.
@@ -48,7 +48,7 @@ write_timestamp_to_storage:
     %slot_to_storage_key
     // stack: storage_key, value_ptr, after_timestamp_storage_insert
     PUSH 64 // storage_key has 64 nibbles
-    %get_storage_trie(@ADDRESS_GLOBAL_EXIT_ROOT_MANAGER_L2)
+    %get_storage_trie(@GLOBAL_EXIT_ROOT_MANAGER_L2_STATE_KEY)
     // stack: storage_root_ptr, 64, storage_key, value_ptr, after_timestamp_storage_insert
     %stack (storage_root_ptr, num_nibbles, storage_key) -> (storage_root_ptr, num_nibbles, storage_key, after_read, storage_root_ptr, num_nibbles, storage_key)
     %jump(mpt_read)
@@ -61,7 +61,7 @@ after_read:
 
 after_timestamp_storage_insert:
     // stack: new_storage_root_ptr, i, num_ger, retdest
-    %get_account_data(@ADDRESS_GLOBAL_EXIT_ROOT_MANAGER_L2)
+    %get_account_data(@GLOBAL_EXIT_ROOT_MANAGER_L2_STATE_KEY)
     // stack: account_ptr, new_storage_root_ptr
     // Update the copied account with our new storage root pointer.
     %add_const(2)

--- a/evm_arithmetization/src/cpu/kernel/asm/main.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/main.asm
@@ -37,7 +37,7 @@ global hash_initial_tries:
     // We initialize the segment length with 1 because the segment contains 
     // the null pointer `0` when the tries are empty.
     PUSH 1
-    %mpt_hash_state_trie  %mload_global_metadata(@GLOBAL_METADATA_STATE_TRIE_DIGEST_BEFORE)    %assert_eq
+    %mpt_hash_state_trie  %mload_global_metadata(@GLOBAL_METADATA_STATE_TRIE_DIGEST_BEFORE)     %assert_eq
     // stack: trie_data_len
     %mpt_hash_txn_trie     %mload_global_metadata(@GLOBAL_METADATA_TXN_TRIE_DIGEST_BEFORE)      %assert_eq
     // stack: trie_data_len

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/accounts.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/accounts.asm
@@ -32,9 +32,9 @@
 %endmacro
 
 // Returns a pointer to the root of the storage trie associated with the provided account.
-%macro get_storage_trie(addr)
+%macro get_storage_trie(key)
     // stack: (empty)
-    %get_account_data($addr)
+    %get_account_data($key)
     // stack: account_ptr
     %add_const(2)
     // stack: storage_root_ptr_ptr

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/read.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/read.asm
@@ -4,6 +4,7 @@
 global mpt_read_state_trie:
     // stack: addr, retdest
     %addr_to_state_key
+global mpt_read_state_trie_from_key:
     // stack: key, retdest
     PUSH 64 // num_nibbles
     %mload_global_metadata(@GLOBAL_METADATA_STATE_TRIE_ROOT) // node_ptr
@@ -14,6 +15,13 @@ global mpt_read_state_trie:
 %macro mpt_read_state_trie
     %stack (addr) -> (addr, %%after)
     %jump(mpt_read_state_trie)
+%%after:
+%endmacro
+
+// Convenience macro to call mpt_read_state_trie_from_key and return where we left off.
+%macro mpt_read_state_trie_from_key
+    %stack (addr) -> (addr, %%after)
+    %jump(mpt_read_state_trie_from_key)
 %%after:
 %endmacro
 

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/read.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/read.asm
@@ -20,7 +20,7 @@ global mpt_read_state_trie_from_key:
 
 // Convenience macro to call mpt_read_state_trie_from_key and return where we left off.
 %macro mpt_read_state_trie_from_key
-    %stack (addr) -> (addr, %%after)
+    %stack (key) -> (key, %%after)
     %jump(mpt_read_state_trie_from_key)
 %%after:
 %endmacro

--- a/evm_arithmetization/src/cpu/kernel/constants/mod.rs
+++ b/evm_arithmetization/src/cpu/kernel/constants/mod.rs
@@ -58,8 +58,8 @@ pub(crate) fn evm_constants() -> HashMap<String, U256> {
     c.insert(MAX_NONCE.0.into(), U256::from(MAX_NONCE.1));
     c.insert(CALL_STACK_LIMIT.0.into(), U256::from(CALL_STACK_LIMIT.1));
     c.insert(
-        cancun_constants::BEACON_ROOTS_ADDRESS.0.into(),
-        U256::from_big_endian(&cancun_constants::BEACON_ROOTS_ADDRESS.1),
+        cancun_constants::BEACON_ROOTS_CONTRACT_STATE_KEY.0.into(),
+        U256::from_big_endian(&cancun_constants::BEACON_ROOTS_CONTRACT_STATE_KEY.1),
     );
     c.insert(
         cancun_constants::HISTORY_BUFFER_LENGTH.0.into(),
@@ -67,10 +67,10 @@ pub(crate) fn evm_constants() -> HashMap<String, U256> {
     );
 
     c.insert(
-        global_exit_root::ADDRESS_GLOBAL_EXIT_ROOT_MANAGER_L2
+        global_exit_root::GLOBAL_EXIT_ROOT_MANAGER_L2_STATE_KEY
             .0
             .into(),
-        U256::from_big_endian(&global_exit_root::ADDRESS_GLOBAL_EXIT_ROOT_MANAGER_L2.1),
+        U256::from_big_endian(&global_exit_root::GLOBAL_EXIT_ROOT_MANAGER_L2_STATE_KEY.1),
     );
     c.insert(
         global_exit_root::GLOBAL_EXIT_ROOT_STORAGE_POS.0.into(),
@@ -350,8 +350,8 @@ pub mod cancun_constants {
         hex!("000000000000000000000000000000001666c54b0a32529503432fcae0181b4bef79de09fc63671fda5ed1ba9bfa07899495346f3d7ac9cd23048ef30d0a154f"), // y_im
     ];
 
-    pub const BEACON_ROOTS_ADDRESS: (&str, [u8; 20]) = (
-        "BEACON_ROOTS_ADDRESS",
+    pub const BEACON_ROOTS_CONTRACT_STATE_KEY: (&str, [u8; 20]) = (
+        "BEACON_ROOTS_CONTRACT_STATE_KEY",
         hex!("000F3df6D732807Ef1319fB7B8bB8522d0Beac02"),
     );
 
@@ -379,8 +379,8 @@ pub mod global_exit_root {
     use super::*;
 
     /// Taken from https://github.com/0xPolygonHermez/cdk-erigon/blob/61f0b6912055c73f6879ea7e9b5bac22ea5fc85c/zk/utils/global_exit_root.go#L16.
-    pub const ADDRESS_GLOBAL_EXIT_ROOT_MANAGER_L2: (&str, [u8; 20]) = (
-        "ADDRESS_GLOBAL_EXIT_ROOT_MANAGER_L2",
+    pub const GLOBAL_EXIT_ROOT_MANAGER_L2_STATE_KEY: (&str, [u8; 20]) = (
+        "GLOBAL_EXIT_ROOT_MANAGER_L2_STATE_KEY",
         hex!("a40D5f56745a118D0906a34E69aeC8C0Db1cB8fA"),
     );
     /// Taken from https://github.com/0xPolygonHermez/cdk-erigon/blob/61f0b6912055c73f6879ea7e9b5bac22ea5fc85c/zk/utils/global_exit_root.go#L17.

--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -256,6 +256,10 @@ impl<F: Field> Interpreter<F> {
                 GlobalMetadata::BlockExcessBlobGas,
                 metadata.block_excess_blob_gas,
             ),
+            (
+                GlobalMetadata::ParentBeaconBlockRoot,
+                h2u(metadata.parent_beacon_block_root),
+            ),
             (GlobalMetadata::BlockGasUsedBefore, inputs.gas_used_before),
             (GlobalMetadata::BlockGasUsedAfter, inputs.gas_used_after),
             (GlobalMetadata::TxnNumberBefore, inputs.txn_number_before),

--- a/evm_arithmetization/src/generation/mpt.rs
+++ b/evm_arithmetization/src/generation/mpt.rs
@@ -71,6 +71,7 @@ pub(crate) fn parse_receipts(rlp: &[u8]) -> Result<Vec<U256>, ProgramError> {
     let txn_type = match rlp.first().ok_or(ProgramError::InvalidRlp)? {
         1 => 1,
         2 => 2,
+        3 => 3,
         _ => 0,
     };
 


### PR DESCRIPTION
@4l0n50 I squashed all our commits from the debug branch, and also renamed explicitely the GER and Beacon roots variables to `state_key` instead of `address`.