### PR TITLE
Add segment indexing

### DIFF
--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -391,6 +391,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
     // previous segment execution, if any.
     let GenerationSegmentData {
         is_dummy,
+        segment_index,
         max_cpu_len_log,
         memory,
         registers_before,

--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -57,6 +57,13 @@ pub struct GenerationSegmentData {
     pub(crate) max_cpu_len_log: Option<usize>,
 }
 
+impl GenerationSegmentData {
+    /// Retrieves the index of this segment.
+    pub fn segment_index(&self) -> usize {
+        self.segment_index
+    }
+}
+
 /// Generate traces, then create all STARK proofs.
 pub fn prove<F, C, const D: usize>(
     all_stark: &AllStark<F, D>,


### PR DESCRIPTION
The new logging approach on zero-bin side isn't compatible with txn segmentation as is, as all segments for a given txn would be logged as the same process.

This change would allow splitting the logs on a segment basis, the new "base" proofs with continuations.