### PR TITLE
Charge call value gas prior to call

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/call_gas.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/call_gas.asm
@@ -71,7 +71,13 @@ global xfer_cost:
     %jump(after_xfer_cost)
 xfer_cost_nonzero:
     // stack: cost, is_call_or_staticcall, is_call_or_callcode, address, gas, kexit_info, value, retdest
-    %add_const(@GAS_CALLVALUE)
+    SWAP5
+    // stack: kexit_info, is_call_or_staticcall, is_call_or_callcode, address, gas, cost, value, retdest
+    PUSH @GAS_CALLVALUE
+    // stack: call_value_gas, kexit_info, is_call_or_staticcall, is_call_or_callcode, address, gas, cost, value, retdest
+    %charge_gas
+    // stack: kexit_info, is_call_or_staticcall, is_call_or_callcode, address, gas, cost, value, retdest
+    SWAP5
     // stack: cost, is_call_or_staticcall, is_call_or_callcode, address, gas, kexit_info, value, retdest
     %jump(after_xfer_cost)
 


### PR DESCRIPTION
This PR modified the call gas logic to charge for call value gas prior to invoking the call. I have tested this on a prior failing block and it has solved the issue. 

closes #194 