### PR TITLE
Added a feature flag to disable `jemalloc`

### DIFF
--- a/evm_arithmetization/Cargo.toml
+++ b/evm_arithmetization/Cargo.toml
@@ -56,7 +56,7 @@ sha2 = "0.10.6"
 [features]
 default = ["parallel"]
 asmtools = ["hex"]
-jemalloc_disable = []
+disable_jemalloc = []
 parallel = [
     "plonky2/parallel",
     "plonky2_maybe_rayon/parallel",

--- a/evm_arithmetization/Cargo.toml
+++ b/evm_arithmetization/Cargo.toml
@@ -56,6 +56,7 @@ sha2 = "0.10.6"
 [features]
 default = ["parallel"]
 asmtools = ["hex"]
+jemalloc_disable = []
 parallel = [
     "plonky2/parallel",
     "plonky2_maybe_rayon/parallel",

--- a/evm_arithmetization/src/lib.rs
+++ b/evm_arithmetization/src/lib.rs
@@ -217,7 +217,7 @@ pub mod util;
 use jemallocator::Jemalloc;
 use mpt_trie::partial_trie::HashedPartialTrie;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(any(target_env = "msvc", jemalloc_disable)))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/evm_arithmetization/src/lib.rs
+++ b/evm_arithmetization/src/lib.rs
@@ -217,7 +217,12 @@ pub mod util;
 use jemallocator::Jemalloc;
 use mpt_trie::partial_trie::HashedPartialTrie;
 
-#[cfg(not(any(target_env = "msvc", jemalloc_disable)))]
+// TODO: We are currently re-evaluating if jemalloc brings better performance
+// overall, and we might switch back to the default allocator down the road. For
+// the time being, it will be able to be disabled with a feature flag
+// (`disable_jemalloc`) in order to allow users to use their own allocator if
+// needed.
+#[cfg(not(any(target_env = "msvc", disable_jemalloc)))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
- `trace_decoder` now needs to link against two versions of `evm_arithmetization`.
- Because `#[global_allocator]` can only appear once per build, we need a way to prevent this from occurring twice.
- It also seems to be best practice to only use `#[global_allocator]` in binaries, so maybe this is something that we should look at removing from this library. However, for the time being, this will allow us to do two links against this crate.