### PR TITLE
Update decoder processing for cancun

### DIFF
--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -892,7 +892,7 @@ fn account_from_rlped_bytes(bytes: &[u8]) -> TraceParsingResult<AccountRlp> {
 impl TxnMetaState {
     /// Outputs a boolean indicating whether this `TxnMetaState`
     /// represents a dummy payload or an actual transaction.
-    fn is_dummy(&self) -> bool {
+    const fn is_dummy(&self) -> bool {
         self.txn_bytes.is_none()
     }
 

--- a/trace_decoder/src/processed_block_trace.rs
+++ b/trace_decoder/src/processed_block_trace.rs
@@ -87,7 +87,7 @@ impl BlockTrace {
 
         let last_tx_idx = self.txn_info.len().saturating_sub(1);
 
-        let txn_info = self
+        let mut txn_info = self
             .txn_info
             .into_iter()
             .enumerate()
@@ -110,6 +110,10 @@ impl BlockTrace {
                 )
             })
             .collect::<Vec<_>>();
+
+        while txn_info.len() < 2 {
+            txn_info.insert(0, ProcessedTxnInfo::default());
+        }
 
         Ok(ProcessedBlockTrace {
             tries: pre_image_data.tries,
@@ -232,7 +236,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct ProcessedTxnInfo {
     pub(crate) nodes_used_by_txn: NodesUsedByTxn,
     pub(crate) contract_code_accessed: HashMap<CodeHash, Vec<u8>>,


### PR DESCRIPTION
This PR adds EIP-4788 specification within the `trace-decoder` preprocessing to account for the beacon block root update in the first txn payload.

It also simplifies the padding logic with dummy payloads in case we have less than 2 txns in a block. This is simply handled by prepending `Default` `ProcessedTxnInfo` to the vector of inputs to be then converted into generation inputs. These have no state / storage accesses, hence trimming will be as extreme as the custom `fully_hashed_out` method previously used for padding payloads (except that in case of padding, the first dummy payload will contain the beacon root contract in its state and targeted storage slots).

Tested against `jerigon` on https://github.com/0xPolygonZero/zero-bin/tree/feat/cancun