### PR TITLE
Insert blob versioned hashes in signature payload for hashing

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/transactions/type_3.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/transactions/type_3.asm
@@ -119,6 +119,9 @@ after_serializing_access_list:
             rlp_addr, rlp_start, retdest)
     %jump(memcpy_bytes)
 after_serializing_blob_versioned_hashes:
+    // stack: rlp_addr, rlp_start, retdest
+    %mload_global_metadata(@GLOBAL_METADATA_BLOB_VERSIONED_HASHES_RLP_LEN) ADD
+    // stack: rlp_addr, rlp_start, retdest
     %prepend_rlp_list_prefix
     // stack: prefix_start_pos, rlp_len, retdest
 


### PR DESCRIPTION
We were not increasing the RLP blob length with the blob versioned hashes, which were then being ignored when processing type 3 txn hashing.

cc @wborgeaud, while looking at this, I noticed something concerning. The txn hash was invalid, but the return value of ECRECOVER wasn't `U256::MAX` (i.e. failure signal), but instead an arbitrary (wrong) recovered sender address.