### PR TITLE
Fix-kzg-precompile-init

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/precompiles/blake2_f.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/precompiles/blake2_f.asm
@@ -1,6 +1,6 @@
 global precompile_blake2_f:
-    // stack: retdest, new_ctx, (old stack)
-    POP
+    // stack: address, retdest, new_ctx, (old stack)
+    %pop2
     // stack: new_ctx, (old stack)
     %set_new_ctx_parent_pc(after_precompile)
     // stack: new_ctx, (old stack)

--- a/evm_arithmetization/src/cpu/kernel/asm/core/precompiles/kzg_peval.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/precompiles/kzg_peval.asm
@@ -1,6 +1,6 @@
 global precompile_kzg_peval:
-    // stack: address, retdest, new_ctx, (old stack)
-    %pop2
+    // stack: retdest, new_ctx, (old stack)
+    POP
     // stack: new_ctx, (old stack)
     %set_new_ctx_parent_pc(after_precompile)
     // stack: new_ctx, (old stack)


### PR DESCRIPTION
Initial stack when entering `precompile_kzg_peval` wasn't correct (and similarly the `blake2f` one wasn't properly updated as it isn't the last precompile anymore).