### PR TITLE
Fix access lists pointers

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
@@ -63,17 +63,22 @@ global init_access_lists:
     POP
 %endmacro
 
-// Multiply the ptr at the top of the stack by 2
-// and abort if 2*ptr - @SEGMENT_ACCESSED_ADDRESSES >= @GLOBAL_METADATA_ACCESSED_ADDRESSES_LEN
-// In this way ptr must be pointing to the begining of a node.
+// Multiply the value at the top of the stack, denoted by ptr/2, by 2
+// and abort if ptr/2 >= mem[@GLOBAL_METADATA_ACCESSED_ADDRESSES_LEN]/2
+// In this way 2*value must be pointing to the begining of a node.
 %macro get_valid_addr_ptr
-    // stack: ptr
+    // stack: ptr/2
+    DUP1
+    // stack: ptr/2, ptr/2
+    %mload_global_metadata(@GLOBAL_METADATA_ACCESSED_ADDRESSES_LEN)
+    // @GLOBAL_METADATA_ACCESSED_ADDRESSES_LEN must be an even number because
+    // both @SEGMENT_ACCESSED_ADDRESSES and the unscaled access addresses list len
+    // must be even numbers
+    %div_const(2)
+    // stack: SEGMENT_ACCESSED_ADDRESSES/2 + access_addr_list_len/2, ptr/2, ptr/2
+    %assert_gt
     %mul_const(2)
-    PUSH @SEGMENT_ACCESSED_ADDRESSES
-    DUP2
-    SUB
-    %assert_lt_const(@GLOBAL_METADATA_ACCESSED_ADDRESSES_LEN)
-    // stack: 2*ptr
+    // stack: ptr
 %endmacro
 
 
@@ -205,17 +210,20 @@ global remove_accessed_addresses:
     // stack: cold_access, value_ptr
 %endmacro
 
-// Multiply the ptr at the top of the stack by 4
-// and abort if 4*ptr - SEGMENT_ACCESSED_STORAGE_KEYS >= @GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN
-// In this way ptr must be pointing to the beginning of a node.
+// Multiply the ptr at the top of the stack, denoted by ptr/4, by 4
+// and abort if ptr/4 >= @GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN/4
+// In this way 4*ptr/4 be pointing to the beginning of a node.
 %macro get_valid_storage_ptr
-    // stack: ptr
+    // stack: ptr/4
+    DUP1
+    %mload_global_metadata(@GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN)
+    // By construction, both @SEGMENT_ACCESSED_STORAGE_KEYS and the unscaled list len
+    // must be multiples of 4
+    %div_const(4)
+    // stack: @SEGMENT_ACCESSED_STORAGE_KEYS/4 + accessed_strg_keys_len/4, ptr/4, ptr/4
+    %assert_gt
     %mul_const(4)
-    PUSH @SEGMENT_ACCESSED_STORAGE_KEYS
-    DUP2
-    SUB
-    %assert_lt_const(@GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN)
-    // stack: 2*ptr
+    // stack: ptr
 %endmacro
 
 /// Inserts the storage key into the access list if it is not already present.

--- a/evm_arithmetization/src/cpu/kernel/asm/util/assertions.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/util/assertions.asm
@@ -56,10 +56,8 @@ global panic:
 %endmacro
 
 %macro assert_gt
-    // %assert_zero is cheaper than %assert_nonzero, so we will leverage the
-    // fact that (x > y) == !(x <= y).
-    LE
-    %assert_zero
+    GT
+    %assert_nonzero
 %endmacro
 
 %macro assert_gt(ret)


### PR DESCRIPTION
For inserting/deleting in the access lists, the prover guesses the predecessor pointer divided by the list node size so that `node_size*guessed_val` always point the beginning of a valid node. In order to do so, it checked that `node_size * guessed_val - SEGMENT_SCALLING < UNSCALED_LIST_LEN`. This is not correct because the guessed value is the scaled pointer divided by `node_size` (prover_input.rs:348), so it shouldn't be unscaled. Additionally, the comparison was done against the address of `UNSCALED_LIST_LEN` istead of the actual value.
On the other hand, I find clearer to check that `guessed_val < UNSCALED_LIST_LEN/node_size` because for some `node_size` it's possible to have `node_size * guessed_val mod 2^256 != 0 mod node_size` (even though this is not possible because `node_size = 2, 4`).
I'm also fixing macro `assert_gt`, which wasn't a problem because it was never used.