### PR TITLE
Bring back support for multi-txn batches

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
@@ -17,7 +17,6 @@ global init_access_lists:
     PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_ACCESS_LIST_DATA_COST)
     PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_ACCESS_LIST_RLP_LEN)
     PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_ACCESS_LIST_RLP_START)
-    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN)
     
     // Store @U256_MAX at the beggining of the segment
     PUSH @SEGMENT_ACCESSED_ADDRESSES // ctx == virt == 0

--- a/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
@@ -12,6 +12,13 @@
 // Initialize SEGMENT_ACCESSED_ADDRESSES
 global init_access_lists:
     // stack: (empty)
+
+    // Reset access lists data.
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_ACCESS_LIST_DATA_COST)
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_ACCESS_LIST_RLP_LEN)
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_ACCESS_LIST_RLP_START)
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN)
+    
     // Store @U256_MAX at the beggining of the segment
     PUSH @SEGMENT_ACCESSED_ADDRESSES // ctx == virt == 0
     DUP1

--- a/evm_arithmetization/src/cpu/kernel/asm/core/create_receipt.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/create_receipt.asm
@@ -207,9 +207,19 @@ process_receipt_after_write:
     %mpt_insert_receipt_trie
     // stack: new_cum_gas, txn_nb, num_nibbles, retdest
 
-    // We don't need to reset the bloom filter segment as we only process a single transaction.
-    // TODO: Revert in case we add back support for multi-txn proofs.
-
+    // Now, we set the Bloom filter back to 0. We proceed by chunks of 32 bytes.
+    PUSH @SEGMENT_TXN_BLOOM // ctx == offset == 0
+    %rep 8
+        // stack: addr, new_cum_gas, txn_nb, num_nibbles, retdest
+        PUSH 0 // we will fill the memory segment with zeroes
+        DUP2
+        // stack: addr, 0, addr, new_cum_gas, txn_nb, num_nibbles, retdest
+        MSTORE_32BYTES_32
+        // stack: new_addr, addr, new_cum_gas, txn_nb, num_nibbles, retdest
+        SWAP1 POP
+    %endrep
+    POP
+    // stack: new_cum_gas, txn_nb, num_nibbles, retdest
     %stack (new_cum_gas, txn_nb, num_nibbles, retdest) -> (retdest, new_cum_gas)
     JUMP
     

--- a/evm_arithmetization/src/cpu/kernel/asm/core/create_receipt.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/create_receipt.asm
@@ -212,11 +212,10 @@ process_receipt_after_write:
     %rep 8
         // stack: addr, new_cum_gas, txn_nb, num_nibbles, retdest
         PUSH 0 // we will fill the memory segment with zeroes
-        DUP2
-        // stack: addr, 0, addr, new_cum_gas, txn_nb, num_nibbles, retdest
+        SWAP1
+        // stack: addr, 0, new_cum_gas, txn_nb, num_nibbles, retdest
         MSTORE_32BYTES_32
-        // stack: new_addr, addr, new_cum_gas, txn_nb, num_nibbles, retdest
-        SWAP1 POP
+        // stack: new_addr, new_cum_gas, txn_nb, num_nibbles, retdest
     %endrep
     POP
     // stack: new_cum_gas, txn_nb, num_nibbles, retdest

--- a/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
@@ -449,22 +449,22 @@ global invalid_txn:
     POP
     %mload_txn_field(@TXN_FIELD_GAS_LIMIT)
     PUSH 0
-    %jump(txn_after)
+    %jump(txn_loop_after)
 
 global invalid_txn_1:
     %pop2
     %mload_txn_field(@TXN_FIELD_GAS_LIMIT)
     PUSH 0
-    %jump(txn_after)
+    %jump(txn_loop_after)
 
 global invalid_txn_2:
     %pop3
     %mload_txn_field(@TXN_FIELD_GAS_LIMIT)
     PUSH 0
-    %jump(txn_after)
+    %jump(txn_loop_after)
 
 global invalid_txn_3:
     %pop4
     %mload_txn_field(@TXN_FIELD_GAS_LIMIT)
     PUSH 0
-    %jump(txn_after)
+    %jump(txn_loop_after)

--- a/evm_arithmetization/src/cpu/kernel/asm/main.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/main.asm
@@ -94,7 +94,7 @@ global hash_initial_tries:
     // stack: trie_data_full_len
     %mstore_global_metadata(@GLOBAL_METADATA_TRIE_DATA_SIZE)
 
-global start_txn:
+global start_txns:
     // stack: (empty)
     // The special case of an empty trie (i.e. for the first transaction)
     // is handled outside of the kernel.
@@ -103,35 +103,41 @@ global start_txn:
     DUP1 %scalar_to_rlp
     // stack: txn_counter, txn_nb
     DUP1 %num_bytes %mul_const(2)
-    // stack: num_nibbles, txn_counter, txn_nb
-    %increment_bounded_rlp
-    // stack: txn_counter, num_nibbles, next_txn_counter, next_num_nibbles,  txn_nb
+    SWAP1
+    // stack: txn_counter, num_nibbles, txn_nb
     %mload_global_metadata(@GLOBAL_METADATA_BLOCK_GAS_USED_BEFORE)
 
-    // stack: init_gas_used, txn_counter, num_nibbles, next_txn_counter, next_num_nibbles, txn_nb
-
-    // If the prover has no txn for us to process, halt.
-    PROVER_INPUT(no_txn)
+    // stack: init_gas_used, txn_counter, num_nibbles, txn_nb
+global txn_loop:
+    // If the prover has no more txns for us to process, halt.
+    PROVER_INPUT(end_of_txns)
     %jumpi(execute_withdrawals)
 
+    // Initialize memory values.
+    %initialize_memory_pre_txn
+    
     // Call route_txn. When we return, we will process the txn receipt.
-    PUSH txn_after
-    // stack: retdest, prev_gas_used, txn_counter, num_nibbles, next_txn_counter, next_num_nibbles, txn_nb
-    DUP4 DUP4
-
+    PUSH txn_loop_after
+   
+    // stack: retdest, prev_gas_used, txn_counter, num_nibbles, txn_nb
+    %stack(retdest, prev_gas_used, txn_counter, num_nibbles) -> (txn_counter, num_nibbles, retdest, prev_gas_used, txn_counter, num_nibbles) 
     %jump(route_txn)
 
-global txn_after:
-    // stack: success, leftover_gas, cur_cum_gas, prev_txn_counter, prev_num_nibbles, txn_counter, num_nibbles, txn_nb
+global txn_loop_after:
+    // stack: success, leftover_gas, cur_cum_gas, prev_txn_counter, prev_num_nibbles, txn_nb
+    DUP5 DUP5 %increment_bounded_rlp
+    // stack: txn_counter, num_nibbles, success, leftover_gas, cur_cum_gas, prev_txn_counter, prev_num_nibbles, txn_nb
+    %stack (txn_counter, num_nibbles, success, leftover_gas, cur_cum_gas, prev_txn_counter, prev_num_nibbles) -> (success, leftover_gas, cur_cum_gas, prev_txn_counter, prev_num_nibbles, txn_counter, num_nibbles)
     %process_receipt
+
     // stack: new_cum_gas, txn_counter, num_nibbles, txn_nb
     SWAP3 %increment SWAP3
-    %jump(execute_withdrawals_post_stack_op)
+
+    // stack: new_cum_gas, txn_counter, num_nibbles, new_txn_number
+    %jump(txn_loop)
 
 global execute_withdrawals:
-    // stack: cum_gas, txn_counter, num_nibbles, next_txn_counter, next_num_nibbles, txn_nb
-    %stack (cum_gas, txn_counter, num_nibbles, next_txn_counter, next_num_nibbles) -> (cum_gas, txn_counter, num_nibbles)
-execute_withdrawals_post_stack_op:
+    // stack: cum_gas, txn_counter, num_nibbles, txn_nb
     %withdrawals
 
 global perform_final_checks:
@@ -155,3 +161,19 @@ global check_receipt_trie:
     SET_CONTEXT
     
     %jump(halt)
+
+%macro initialize_memory_pre_txn
+    // Initialize accessed addresses and storage keys lists
+    %init_access_lists
+
+    // Initialize metadata
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_CONTRACT_CREATION)
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_IS_PRECOMPILE_FROM_EOA)
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_LOGS_LEN)
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_LOGS_DATA_LEN)
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_LOGS_PAYLOAD_LEN)
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_JOURNAL_LEN)
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_JOURNAL_DATA_LEN)
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_REFUND_COUNTER)
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_SELFDESTRUCT_LIST_LEN)
+%endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/rlp/increment_bounded_rlp.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/rlp/increment_bounded_rlp.asm
@@ -2,8 +2,8 @@
 // its number of nibbles when required. Shouldn't be
 // called with rlp_index > 0x82 ff ff
 global increment_bounded_rlp:
-    // stack: num_nibbles, rlp_index, retdest
-    DUP2
+    // stack: rlp_index, num_nibbles, retdest
+    DUP1
     %eq_const(0x80)
     %jumpi(case_0x80)
     DUP1
@@ -14,19 +14,19 @@ global increment_bounded_rlp:
     %jumpi(case_0x81ff)
     // If rlp_index != 0x80 and rlp_index != 0x7f and rlp_index != 0x81ff
     // we only need to add one and keep the number of nibbles
-    DUP2 %increment DUP2
-    %stack (next_num_nibbles, next_rlp_index, num_nibbles, rlp_index, retdest) -> (retdest, rlp_index, num_nibbles, next_rlp_index, next_num_nibbles)
+    %increment
+    %stack (next_rlp_index, next_num_nibbles, retdest) -> (retdest, next_rlp_index, next_num_nibbles)
     JUMP
 
 case_0x80:
-    %stack (num_nibbles, rlp_index, retdest) -> (retdest, 0x80, 2, 0x01, 2)
+    %stack (num_nibbles, rlp_index, retdest) -> (retdest, 0x01, 2)
     JUMP
 case_0x7f:
-    %stack (num_nibbles, rlp_index, retdest) -> (retdest, 0x7f, 2, 0x8180, 4)
+    %stack (num_nibbles, rlp_index, retdest) -> (retdest, 0x8180, 4)
     JUMP
 
 case_0x81ff:
-    %stack (num_nibbles, rlp_index, retdest) -> (retdest, 0x81ff, 4, 0x820100, 6)
+    %stack (num_nibbles, rlp_index, retdest) -> (retdest, 0x820100, 6)
     JUMP
     
     

--- a/evm_arithmetization/src/cpu/kernel/tests/add11.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/add11.rs
@@ -138,7 +138,7 @@ fn test_add11_yml() {
     };
 
     let inputs = GenerationInputs {
-        signed_txn: Some(txn.to_vec()),
+        signed_txns: vec![txn.to_vec()],
         withdrawals: vec![],
         tries: tries_before,
         trie_roots_after,
@@ -279,7 +279,7 @@ fn test_add11_yml_with_exception() {
     };
 
     let inputs = GenerationInputs {
-        signed_txn: Some(txn.to_vec()),
+        signed_txns: vec![txn.to_vec()],
         withdrawals: vec![],
         tries: tries_before,
         trie_roots_after,

--- a/evm_arithmetization/src/cpu/kernel/tests/init_exc_stop.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/init_exc_stop.rs
@@ -42,7 +42,7 @@ fn test_init_exc_stop() {
     };
 
     let inputs = GenerationInputs {
-        signed_txn: None,
+        signed_txns: vec![],
         withdrawals: vec![],
         tries: TrieInputs {
             state_trie,

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -64,7 +64,7 @@ pub struct GenerationInputs {
 
     /// A None would yield an empty proof, otherwise this contains the encoding
     /// of a transaction.
-    pub signed_txn: Option<Vec<u8>>,
+    pub signed_txns: Vec<Vec<u8>>,
     /// Withdrawal pairs `(addr, amount)`. At the end of the txs, `amount` is
     /// added to `addr`'s balance. See EIP-4895.
     pub withdrawals: Vec<(Address, U256)>,
@@ -105,7 +105,7 @@ pub(crate) struct TrimmedGenerationInputs {
     pub(crate) gas_used_after: U256,
 
     /// Indicates whether there is an actual transaction or a dummy payload.
-    pub(crate) has_txn: bool,
+    pub(crate) txns_len: usize,
 
     /// Expected trie roots after the transactions are executed.
     pub(crate) trie_roots_after: TrieRoots,
@@ -160,7 +160,7 @@ impl GenerationInputs {
             txn_number_before: self.txn_number_before,
             gas_used_before: self.gas_used_before,
             gas_used_after: self.gas_used_after,
-            has_txn: self.signed_txn.is_some(),
+            txns_len: self.signed_txns.len(),
             trie_roots_after: self.trie_roots_after.clone(),
             checkpoint_state_trie_root: self.checkpoint_state_trie_root,
             contract_code: self.contract_code.clone(),
@@ -204,7 +204,7 @@ fn apply_metadata_and_tries_memops<F: RichField + Extendable<D>, const D: usize>
         (GlobalMetadata::TxnNumberBefore, inputs.txn_number_before),
         (
             GlobalMetadata::TxnNumberAfter,
-            inputs.txn_number_before + if inputs.signed_txn.is_some() { 1 } else { 0 },
+            inputs.txn_number_before + inputs.signed_txns.len(),
         ),
         (
             GlobalMetadata::StateTrieRootDigestBefore,
@@ -314,7 +314,7 @@ fn apply_metadata_and_tries_memops<F: RichField + Extendable<D>, const D: usize>
 }
 
 pub(crate) fn debug_inputs(inputs: &GenerationInputs) {
-    log::debug!("Input signed_txn: {:?}", &inputs.signed_txn);
+    log::debug!("Input signed_txns: {:?}", &inputs.signed_txns);
     log::debug!("Input state_trie: {:?}", &inputs.tries.state_trie);
     log::debug!(
         "Input transactions_trie: {:?}",

--- a/evm_arithmetization/src/generation/rlp.rs
+++ b/evm_arithmetization/src/generation/rlp.rs
@@ -1,22 +1,25 @@
 use ethereum_types::U256;
 
-pub(crate) fn all_rlp_prover_inputs_reversed(signed_txn: &[u8]) -> Vec<U256> {
-    let mut inputs = all_rlp_prover_inputs(signed_txn);
+pub(crate) fn all_rlp_prover_inputs_reversed(signed_txns: &[Vec<u8>]) -> Vec<U256> {
+    let mut inputs = all_rlp_prover_inputs(signed_txns);
     inputs.reverse();
     inputs
 }
 
-fn all_rlp_prover_inputs(signed_txn: &[u8]) -> Vec<U256> {
+fn all_rlp_prover_inputs(signed_txns: &[Vec<u8>]) -> Vec<U256> {
     let mut prover_inputs = vec![];
-    prover_inputs.push(signed_txn.len().into());
-    let mut chunks = signed_txn.chunks_exact(32);
-    for bytes in chunks.by_ref() {
-        prover_inputs.push(U256::from_big_endian(bytes));
+    for txn in signed_txns {
+        prover_inputs.push(txn.len().into());
+        let mut chunks = txn.chunks_exact(32);
+        for bytes in chunks.by_ref() {
+            prover_inputs.push(U256::from_big_endian(bytes));
+        }
+        let mut last_chunk = chunks.remainder().to_vec();
+        if !last_chunk.is_empty() {
+            last_chunk.extend_from_slice(&vec![0u8; 32 - last_chunk.len()]);
+            prover_inputs.push(U256::from_big_endian(&last_chunk));
+        }
     }
-    let mut last_chunk = chunks.remainder().to_vec();
-    if !last_chunk.is_empty() {
-        last_chunk.extend_from_slice(&vec![0u8; 32 - last_chunk.len()]);
-        prover_inputs.push(U256::from_big_endian(&last_chunk));
-    }
+
     prover_inputs
 }

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -343,6 +343,8 @@ pub struct GenerationState<F: Field> {
     pub(crate) memory: MemoryState,
     pub(crate) traces: Traces<F>,
 
+    pub(crate) next_txn_index: usize,
+
     /// Memory used by stale contexts can be pruned so proving segments can be
     /// smaller.
     pub(crate) stale_contexts: Vec<usize>,
@@ -386,8 +388,7 @@ impl<F: Field> GenerationState<F> {
         trie_roots_ptrs
     }
     pub(crate) fn new(inputs: &GenerationInputs, kernel_code: &[u8]) -> Result<Self, ProgramError> {
-        let rlp_prover_inputs =
-            all_rlp_prover_inputs_reversed(inputs.signed_txn.as_ref().unwrap_or(&vec![]));
+        let rlp_prover_inputs = all_rlp_prover_inputs_reversed(&inputs.signed_txns);
         let withdrawal_prover_inputs = all_withdrawals_prover_inputs_reversed(&inputs.withdrawals);
         let bignum_modmul_result_limbs = Vec::new();
 
@@ -396,6 +397,7 @@ impl<F: Field> GenerationState<F> {
             registers: Default::default(),
             memory: MemoryState::new(kernel_code),
             traces: Traces::default(),
+            next_txn_index: 0,
             stale_contexts: Vec::new(),
             rlp_prover_inputs,
             withdrawal_prover_inputs,
@@ -484,6 +486,7 @@ impl<F: Field> GenerationState<F> {
             registers: self.registers,
             memory: self.memory.clone(),
             traces: Traces::default(),
+            next_txn_index: 0,
             stale_contexts: Vec::new(),
             rlp_prover_inputs: self.rlp_prover_inputs.clone(),
             state_key_to_address: self.state_key_to_address.clone(),
@@ -511,6 +514,7 @@ impl<F: Field> GenerationState<F> {
             .clone_from(&segment_data.extra_data.trie_root_ptrs);
         self.jumpdest_table
             .clone_from(&segment_data.extra_data.jumpdest_table);
+        self.next_txn_index = segment_data.extra_data.next_txn_index;
         self.registers = RegistersState {
             program_counter: self.registers.program_counter,
             is_kernel: self.registers.is_kernel,

--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -511,6 +511,7 @@ fn build_segment_data<F: RichField>(
                 .clone(),
             trie_root_ptrs: interpreter.generation_state.trie_root_ptrs.clone(),
             jumpdest_table: interpreter.generation_state.jumpdest_table.clone(),
+            next_txn_index: interpreter.generation_state.next_txn_index,
         },
     }
 }

--- a/evm_arithmetization/tests/add11_yml.rs
+++ b/evm_arithmetization/tests/add11_yml.rs
@@ -68,7 +68,7 @@ fn get_generation_inputs() -> GenerationInputs {
         .unwrap();
 
     let tries_before = TrieInputs {
-        state_trie: state_trie_before,
+        state_trie: state_trie_before.clone(),
         transactions_trie: Node::Empty.into(),
         receipts_trie: Node::Empty.into(),
         storage_tries: vec![(to_hashed, Node::Empty.into())],
@@ -157,13 +157,13 @@ fn get_generation_inputs() -> GenerationInputs {
     };
 
     GenerationInputs {
-        signed_txn: Some(txn.to_vec()),
+        signed_txns: vec![txn.to_vec()],
         withdrawals: vec![],
         tries: tries_before,
         trie_roots_after,
         contract_code,
         block_metadata,
-        checkpoint_state_trie_root: HashedPartialTrie::from(Node::Empty).hash(),
+        checkpoint_state_trie_root: state_trie_before.hash(),
         txn_number_before: 0.into(),
         gas_used_before: 0.into(),
         gas_used_after: 0xa868u64.into(),

--- a/evm_arithmetization/tests/basic_smart_contract.rs
+++ b/evm_arithmetization/tests/basic_smart_contract.rs
@@ -182,7 +182,7 @@ fn test_basic_smart_contract() -> anyhow::Result<()> {
     };
 
     let inputs = GenerationInputs {
-        signed_txn: Some(txn.to_vec()),
+        signed_txns: vec![txn.to_vec()],
         withdrawals: vec![],
         tries: tries_before,
         trie_roots_after,

--- a/evm_arithmetization/tests/empty_txn_list.rs
+++ b/evm_arithmetization/tests/empty_txn_list.rs
@@ -52,7 +52,7 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
     let mut initial_block_hashes = vec![H256::default(); 256];
     initial_block_hashes[255] = H256::from_uint(&0x200.into());
     let inputs = GenerationInputs {
-        signed_txn: None,
+        signed_txns: vec![],
         withdrawals: vec![],
         tries: TrieInputs {
             state_trie,

--- a/evm_arithmetization/tests/erc20.rs
+++ b/evm_arithmetization/tests/erc20.rs
@@ -158,7 +158,7 @@ fn test_erc20() -> anyhow::Result<()> {
     };
 
     let inputs = GenerationInputs {
-        signed_txn: Some(txn.to_vec()),
+        signed_txns: vec![txn.to_vec()],
         withdrawals: vec![],
         tries: tries_before,
         trie_roots_after,

--- a/evm_arithmetization/tests/erc721.rs
+++ b/evm_arithmetization/tests/erc721.rs
@@ -160,7 +160,7 @@ fn test_erc721() -> anyhow::Result<()> {
     };
 
     let inputs = GenerationInputs {
-        signed_txn: Some(txn.to_vec()),
+        signed_txns: vec![txn.to_vec()],
         withdrawals: vec![],
         tries: tries_before,
         trie_roots_after,

--- a/evm_arithmetization/tests/log_opcode.rs
+++ b/evm_arithmetization/tests/log_opcode.rs
@@ -219,7 +219,7 @@ fn test_log_opcodes() -> anyhow::Result<()> {
     };
 
     let inputs = GenerationInputs {
-        signed_txn: Some(txn.to_vec()),
+        signed_txns: vec![txn.to_vec()],
         withdrawals: vec![],
         tries: tries_before,
         trie_roots_after,
@@ -429,7 +429,7 @@ fn test_log_with_aggreg() -> anyhow::Result<()> {
     let mut block_hashes = vec![H256::default(); 256];
 
     let inputs_first = GenerationInputs {
-        signed_txn: Some(txn.to_vec()),
+        signed_txns: vec![txn.to_vec()],
         withdrawals: vec![],
         tries: tries_before,
         trie_roots_after: tries_after,
@@ -579,7 +579,7 @@ fn test_log_with_aggreg() -> anyhow::Result<()> {
     };
 
     let inputs = GenerationInputs {
-        signed_txn: Some(txn_2.to_vec()),
+        signed_txns: vec![txn_2.to_vec()],
         withdrawals: vec![],
         tries: tries_before,
         trie_roots_after: trie_roots_after.clone(),
@@ -671,7 +671,7 @@ fn test_log_with_aggreg() -> anyhow::Result<()> {
 
     let max_cpu_len_log = 13;
     let inputs = GenerationInputs {
-        signed_txn: None,
+        signed_txns: vec![],
         withdrawals: vec![],
         tries: TrieInputs {
             state_trie: expected_state_trie_after,

--- a/evm_arithmetization/tests/self_balance_gas_cost.rs
+++ b/evm_arithmetization/tests/self_balance_gas_cost.rs
@@ -164,7 +164,7 @@ fn self_balance_gas_cost() -> anyhow::Result<()> {
     };
 
     let inputs = GenerationInputs {
-        signed_txn: Some(txn.to_vec()),
+        signed_txns: vec![txn.to_vec()],
         withdrawals: vec![],
         tries: tries_before,
         trie_roots_after,

--- a/evm_arithmetization/tests/selfdestruct.rs
+++ b/evm_arithmetization/tests/selfdestruct.rs
@@ -121,7 +121,7 @@ fn test_selfdestruct() -> anyhow::Result<()> {
     };
 
     let inputs = GenerationInputs {
-        signed_txn: Some(txn.to_vec()),
+        signed_txns: vec![txn.to_vec()],
         withdrawals: vec![],
         tries: tries_before,
         trie_roots_after,

--- a/evm_arithmetization/tests/simple_transfer.rs
+++ b/evm_arithmetization/tests/simple_transfer.rs
@@ -137,7 +137,7 @@ fn test_simple_transfer() -> anyhow::Result<()> {
     };
 
     let inputs = GenerationInputs {
-        signed_txn: Some(txn.to_vec()),
+        signed_txns: vec![txn.to_vec()],
         withdrawals: vec![],
         tries: tries_before,
         trie_roots_after,

--- a/evm_arithmetization/tests/withdrawals.rs
+++ b/evm_arithmetization/tests/withdrawals.rs
@@ -61,7 +61,7 @@ fn test_withdrawals() -> anyhow::Result<()> {
     };
 
     let inputs = GenerationInputs {
-        signed_txn: None,
+        signed_txns: vec![],
         withdrawals,
         tries: TrieInputs {
             state_trie: state_trie_before,

--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -365,9 +365,8 @@ impl ProcessedBlockTrace {
                 .into_iter(),
         )?;
 
-        let txn_nibbles = txn_range
-            .map(|txn_idx| Nibbles::from_bytes_be(&rlp::encode(&txn_idx)).unwrap())
-            .into_iter();
+        let txn_nibbles =
+            txn_range.map(|txn_idx| Nibbles::from_bytes_be(&rlp::encode(&txn_idx)).unwrap());
 
         let transactions_trie =
             create_trie_subset_wrapped(&curr_block_tries.txn, txn_nibbles.clone(), TrieType::Txn)?;

--- a/trace_decoder/src/processed_block_trace.rs
+++ b/trace_decoder/src/processed_block_trace.rs
@@ -42,12 +42,16 @@ impl BlockTrace {
         self,
         p_meta: &ProcessingMeta<F>,
         other_data: OtherBlockData,
+        batch_size: usize,
     ) -> TraceParsingResult<Vec<GenerationInputs>>
     where
         F: CodeHashResolveFunc,
     {
-        let processed_block_trace =
-            self.into_processed_block_trace(p_meta, other_data.b_data.withdrawals.clone())?;
+        let processed_block_trace = self.into_processed_block_trace(
+            p_meta,
+            other_data.b_data.withdrawals.clone(),
+            batch_size,
+        )?;
 
         processed_block_trace.into_txn_proof_gen_ir(other_data)
     }
@@ -56,6 +60,7 @@ impl BlockTrace {
         self,
         p_meta: &ProcessingMeta<F>,
         withdrawals: Vec<(Address, U256)>,
+        batch_size: usize,
     ) -> TraceParsingResult<ProcessedBlockTrace>
     where
         F: CodeHashResolveFunc,
@@ -85,11 +90,11 @@ impl BlockTrace {
             extra_code_hash_mappings: pre_image_data.extra_code_hash_mappings.unwrap_or_default(),
         };
 
-        let last_tx_idx = self.txn_info.len().saturating_sub(1);
+        let last_tx_idx = self.txn_info.len().saturating_sub(1) / batch_size;
 
         let txn_info = self
             .txn_info
-            .into_iter()
+            .chunks(batch_size)
             .enumerate()
             .map(|(i, t)| {
                 let extra_state_accesses = if last_tx_idx == i {
@@ -103,7 +108,8 @@ impl BlockTrace {
                     Vec::new()
                 };
 
-                t.into_processed_txn_info(
+                TxnInfo::into_processed_txn_info(
+                    t,
                     &all_accounts_in_pre_image,
                     &extra_state_accesses,
                     &mut code_hash_resolver,
@@ -236,7 +242,7 @@ where
 pub(crate) struct ProcessedTxnInfo {
     pub(crate) nodes_used_by_txn: NodesUsedByTxn,
     pub(crate) contract_code_accessed: HashMap<CodeHash, Vec<u8>>,
-    pub(crate) meta: TxnMetaState,
+    pub(crate) meta: Vec<TxnMetaState>,
 }
 
 struct CodeHashResolving<F> {
@@ -266,131 +272,150 @@ impl<F: CodeHashResolveFunc> CodeHashResolving<F> {
 
 impl TxnInfo {
     fn into_processed_txn_info<F: CodeHashResolveFunc>(
-        self,
+        tx_infos: &[Self],
         all_accounts_in_pre_image: &[(HashedAccountAddr, AccountRlp)],
         extra_state_accesses: &[HashedAccountAddr],
         code_hash_resolver: &mut CodeHashResolving<F>,
     ) -> ProcessedTxnInfo {
         let mut nodes_used_by_txn = NodesUsedByTxn::default();
         let mut contract_code_accessed = create_empty_code_access_map();
+        let mut meta = Vec::with_capacity(tx_infos.len());
 
-        for (addr, trace) in self.traces {
-            let hashed_addr = hash(addr.as_bytes());
+        for txn in tx_infos.iter() {
+            for (addr, trace) in txn.traces.iter() {
+                let hashed_addr = hash(addr.as_bytes());
 
-            let storage_writes = trace.storage_written.unwrap_or_default();
+                let storage_writes = trace.storage_written.clone().unwrap_or_default();
 
-            let storage_read_keys = trace
-                .storage_read
-                .into_iter()
-                .flat_map(|reads| reads.into_iter());
+                let storage_read_keys = trace
+                    .storage_read
+                    .clone()
+                    .into_iter()
+                    .flat_map(|reads| reads.into_iter());
 
-            let storage_write_keys = storage_writes.keys();
-            let storage_access_keys = storage_read_keys.chain(storage_write_keys.copied());
+                let storage_write_keys = storage_writes.keys();
+                let storage_access_keys = storage_read_keys.chain(storage_write_keys.copied());
 
-            nodes_used_by_txn.storage_accesses.push((
-                hashed_addr,
-                storage_access_keys
-                    .map(|k| Nibbles::from_h256_be(hash(&k.0)))
-                    .collect(),
-            ));
-
-            let storage_trie_change = !storage_writes.is_empty();
-            let code_change = trace.code_usage.is_some();
-            let state_write_occurred = trace.balance.is_some()
-                || trace.nonce.is_some()
-                || storage_trie_change
-                || code_change;
-
-            if state_write_occurred {
-                let state_trie_writes = StateTrieWrites {
-                    balance: trace.balance,
-                    nonce: trace.nonce,
-                    storage_trie_change,
-                    code_hash: trace.code_usage.as_ref().map(|usage| usage.get_code_hash()),
+                if let Some(storage) = nodes_used_by_txn.storage_accesses.get_mut(&hashed_addr) {
+                    storage.extend(
+                        &storage_access_keys
+                            .map(|k| Nibbles::from_h256_be(hash(&k.0)))
+                            .collect::<Vec<Nibbles>>(),
+                    )
+                } else {
+                    nodes_used_by_txn.storage_accesses.insert(
+                        hashed_addr,
+                        storage_access_keys
+                            .map(|k| Nibbles::from_h256_be(hash(&k.0)))
+                            .collect::<Vec<Nibbles>>(),
+                    );
                 };
 
-                nodes_used_by_txn
-                    .state_writes
-                    .push((hashed_addr, state_trie_writes))
-            }
+                let storage_trie_change = !storage_writes.is_empty();
+                let code_change = trace.code_usage.is_some();
+                let state_write_occurred = trace.balance.is_some()
+                    || trace.nonce.is_some()
+                    || storage_trie_change
+                    || code_change;
 
-            let storage_writes_vec = storage_writes
-                .into_iter()
-                .map(|(k, v)| (Nibbles::from_h256_be(k), rlp::encode(&v).to_vec()))
-                .collect();
+                if state_write_occurred {
+                    let state_trie_writes = StateTrieWrites {
+                        balance: trace.balance,
+                        nonce: trace.nonce,
+                        storage_trie_change,
+                        code_hash: trace.code_usage.as_ref().map(|usage| usage.get_code_hash()),
+                    };
 
-            nodes_used_by_txn
-                .storage_writes
-                .push((hashed_addr, storage_writes_vec));
+                    nodes_used_by_txn
+                        .state_writes
+                        .insert(hashed_addr, state_trie_writes);
+                }
 
-            nodes_used_by_txn.state_accesses.push(hashed_addr);
-
-            if let Some(c_usage) = trace.code_usage {
-                match c_usage {
-                    ContractCodeUsage::Read(c_hash) => {
-                        contract_code_accessed
-                            .entry(c_hash)
-                            .or_insert_with(|| code_hash_resolver.resolve(&c_hash));
+                for (k, v) in storage_writes.into_iter() {
+                    if let Some(storage) = nodes_used_by_txn.storage_writes.get_mut(&hashed_addr) {
+                        storage.insert(Nibbles::from_h256_be(k), rlp::encode(&v).to_vec());
+                    } else {
+                        nodes_used_by_txn.storage_writes.insert(
+                            hashed_addr,
+                            HashMap::from_iter([(
+                                Nibbles::from_h256_be(k),
+                                rlp::encode(&v).to_vec(),
+                            )]),
+                        );
                     }
-                    ContractCodeUsage::Write(c_bytes) => {
-                        let c_hash = hash(&c_bytes);
+                }
 
-                        contract_code_accessed.insert(c_hash, c_bytes.0.clone());
-                        code_hash_resolver.insert_code(c_hash, c_bytes.0);
+                nodes_used_by_txn.state_accesses.insert(hashed_addr);
+
+                if let Some(c_usage) = &trace.code_usage {
+                    match c_usage {
+                        ContractCodeUsage::Read(c_hash) => {
+                            contract_code_accessed
+                                .entry(*c_hash)
+                                .or_insert_with(|| code_hash_resolver.resolve(c_hash));
+                        }
+                        ContractCodeUsage::Write(c_bytes) => {
+                            let c_hash = hash(c_bytes);
+
+                            contract_code_accessed.insert(c_hash, c_bytes.0.clone());
+                            code_hash_resolver.insert_code(c_hash, c_bytes.0.clone());
+                        }
                     }
+                }
+
+                if trace
+                    .self_destructed
+                    .map_or(false, |self_destructed| self_destructed)
+                {
+                    nodes_used_by_txn
+                        .self_destructed_accounts
+                        .insert(hashed_addr);
                 }
             }
 
-            if trace
-                .self_destructed
-                .map_or(false, |self_destructed| self_destructed)
-            {
-                nodes_used_by_txn.self_destructed_accounts.push(hashed_addr);
+            for &hashed_addr in extra_state_accesses {
+                nodes_used_by_txn.state_accesses.insert(hashed_addr);
             }
-        }
 
-        for &hashed_addr in extra_state_accesses {
-            nodes_used_by_txn.state_accesses.push(hashed_addr);
-        }
+            let accounts_with_storage_accesses: HashSet<_> = HashSet::from_iter(
+                nodes_used_by_txn
+                    .storage_accesses
+                    .iter()
+                    .filter(|(_, slots)| !slots.is_empty())
+                    .map(|(addr, _)| *addr),
+            );
 
-        let accounts_with_storage_accesses: HashSet<_> = HashSet::from_iter(
-            nodes_used_by_txn
-                .storage_accesses
+            let all_accounts_with_non_empty_storage = all_accounts_in_pre_image
                 .iter()
-                .filter(|(_, slots)| !slots.is_empty())
-                .map(|(addr, _)| *addr),
-        );
+                .filter(|(_, data)| data.storage_root != EMPTY_TRIE_HASH);
 
-        let all_accounts_with_non_empty_storage = all_accounts_in_pre_image
-            .iter()
-            .filter(|(_, data)| data.storage_root != EMPTY_TRIE_HASH);
+            let accounts_with_storage_but_no_storage_accesses = all_accounts_with_non_empty_storage
+                .filter(|&(addr, _data)| !accounts_with_storage_accesses.contains(addr))
+                .map(|(addr, data)| (*addr, data.storage_root));
 
-        let accounts_with_storage_but_no_storage_accesses = all_accounts_with_non_empty_storage
-            .filter(|&(addr, _data)| !accounts_with_storage_accesses.contains(addr))
-            .map(|(addr, data)| (*addr, data.storage_root));
+            nodes_used_by_txn
+                .state_accounts_with_no_accesses_but_storage_tries
+                .extend(accounts_with_storage_but_no_storage_accesses);
 
-        nodes_used_by_txn
-            .state_accounts_with_no_accesses_but_storage_tries
-            .extend(accounts_with_storage_but_no_storage_accesses);
+            let txn_bytes = match txn.meta.byte_code.is_empty() {
+                false => Some(txn.meta.byte_code.clone()),
+                true => None,
+            };
 
-        let txn_bytes = match self.meta.byte_code.is_empty() {
-            false => Some(self.meta.byte_code),
-            true => None,
-        };
+            let receipt_node_bytes =
+                process_rlped_receipt_node_bytes(txn.meta.new_receipt_trie_node_byte.clone());
 
-        let receipt_node_bytes =
-            process_rlped_receipt_node_bytes(self.meta.new_receipt_trie_node_byte);
-
-        let new_meta_state = TxnMetaState {
-            txn_bytes,
-            receipt_node_bytes,
-            gas_used: self.meta.gas_used,
-        };
+            meta.push(TxnMetaState {
+                txn_bytes,
+                receipt_node_bytes,
+                gas_used: txn.meta.gas_used,
+            });
+        }
 
         ProcessedTxnInfo {
             nodes_used_by_txn,
             contract_code_accessed,
-            meta: new_meta_state,
+            meta,
         }
     }
 }
@@ -410,20 +435,20 @@ fn create_empty_code_access_map() -> HashMap<CodeHash, Vec<u8>> {
 }
 
 pub(crate) type StorageAccess = Vec<HashedStorageAddrNibbles>;
-pub(crate) type StorageWrite = Vec<(HashedStorageAddrNibbles, Vec<u8>)>;
+pub(crate) type StorageWrite = HashMap<HashedStorageAddrNibbles, Vec<u8>>;
 
 /// Note that "*_accesses" includes writes.
 #[derive(Debug, Default)]
 pub(crate) struct NodesUsedByTxn {
-    pub(crate) state_accesses: Vec<HashedNodeAddr>,
-    pub(crate) state_writes: Vec<(HashedAccountAddr, StateTrieWrites)>,
+    pub(crate) state_accesses: HashSet<HashedNodeAddr>,
+    pub(crate) state_writes: HashMap<HashedAccountAddr, StateTrieWrites>,
 
     // Note: All entries in `storage_writes` also appear in `storage_accesses`.
-    pub(crate) storage_accesses: Vec<(HashedAccountAddr, StorageAccess)>,
-    pub(crate) storage_writes: Vec<(HashedAccountAddr, StorageWrite)>,
+    pub(crate) storage_accesses: HashMap<HashedAccountAddr, StorageAccess>,
+    pub(crate) storage_writes: HashMap<HashedAccountAddr, StorageWrite>,
     pub(crate) state_accounts_with_no_accesses_but_storage_tries:
         HashMap<HashedAccountAddr, TrieRootHash>,
-    pub(crate) self_destructed_accounts: Vec<HashedAccountAddr>,
+    pub(crate) self_destructed_accounts: HashSet<HashedAccountAddr>,
 }
 
 #[derive(Debug)]

--- a/trace_decoder/src/processed_block_trace.rs
+++ b/trace_decoder/src/processed_block_trace.rs
@@ -53,7 +53,7 @@ impl BlockTrace {
             batch_size,
         )?;
 
-        processed_block_trace.into_txn_proof_gen_ir(other_data)
+        processed_block_trace.into_txn_proof_gen_ir(other_data, batch_size)
     }
 
     fn into_processed_block_trace<F>(


### PR DESCRIPTION
Supersedes #122 and includes `trace_decoder` related change for customizable batch size.