### PR TITLE
chore(cancun): Cleanup and bring back `dead_code` lint for `evm_arithmetization`

### DIFF
--- a/evm_arithmetization/src/arithmetic/addcy.rs
+++ b/evm_arithmetization/src/arithmetic/addcy.rs
@@ -170,7 +170,6 @@ pub(crate) fn eval_packed_generic<P: PackedField>(
     eval_packed_generic_addcy(yield_constr, is_gt, in0, aux, in1, out, false);
 }
 
-#[allow(clippy::needless_collect)]
 pub(crate) fn eval_ext_circuit_addcy<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,

--- a/evm_arithmetization/src/cpu/columns/general.rs
+++ b/evm_arithmetization/src/cpu/columns/general.rs
@@ -78,7 +78,6 @@ impl<T: Copy> CpuGeneralColumnsView<T> {
 }
 
 impl<T: Copy + PartialEq> PartialEq<Self> for CpuGeneralColumnsView<T> {
-    #[allow(clippy::unconditional_recursion)] // false positive
     fn eq(&self, other: &Self) -> bool {
         let self_arr: &[T; NUM_SHARED_COLUMNS] = self.borrow();
         let other_arr: &[T; NUM_SHARED_COLUMNS] = other.borrow();

--- a/evm_arithmetization/src/cpu/kernel/constants/txn_fields.rs
+++ b/evm_arithmetization/src/cpu/kernel/constants/txn_fields.rs
@@ -5,7 +5,6 @@ use crate::memory::segments::Segment;
 ///
 /// Each value is directly scaled by the corresponding `Segment::TxnFields`
 /// value for faster memory access in the kernel.
-#[allow(dead_code)]
 #[allow(clippy::enum_clike_unportable_variant)]
 #[repr(usize)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
@@ -41,6 +40,7 @@ impl NormalizedTxnField {
     pub(crate) const COUNT: usize = 17;
 
     /// Unscales this virtual offset by their respective `Segment` value.
+    #[cfg(test)]
     pub(crate) const fn unscale(&self) -> usize {
         *self as usize - Segment::TxnFields as usize
     }

--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -51,6 +51,7 @@ pub(crate) struct Interpreter<F: Field> {
     /// halt_context
     pub(crate) halt_context: Option<usize>,
     /// Counts the number of appearances of each opcode. For debugging purposes.
+    #[allow(unused)]
     pub(crate) opcode_count: [usize; 0x100],
     jumpdest_table: HashMap<usize, BTreeSet<usize>>,
     /// `true` if the we are currently carrying out a jumpdest analysis.
@@ -616,6 +617,7 @@ impl<F: Field> Transition<F> for Interpreter<F> {
     }
 }
 
+#[cfg(debug_assertions)]
 fn get_mnemonic(opcode: u8) -> &'static str {
     match opcode {
         0x00 => "STOP",

--- a/evm_arithmetization/src/cpu/kernel/mod.rs
+++ b/evm_arithmetization/src/cpu/kernel/mod.rs
@@ -13,6 +13,7 @@ mod utils;
 pub(crate) mod interpreter;
 
 pub use constants::cancun_constants;
+pub use constants::global_exit_root;
 
 #[cfg(test)]
 mod tests;

--- a/evm_arithmetization/src/cpu/kernel/parser.rs
+++ b/evm_arithmetization/src/cpu/kernel/parser.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::empty_docs)]
-
 use std::str::FromStr;
 
 use ethereum_types::U256;

--- a/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
@@ -144,7 +144,7 @@ fn prepare_interpreter<F: Field>(
     );
     let hash = H256::from_uint(&interpreter.stack()[1]);
 
-    state_trie.insert(k, rlp::encode(account).to_vec());
+    state_trie.insert(k, rlp::encode(account).to_vec())?;
     let expected_state_trie_hash = state_trie.hash();
     assert_eq!(hash, expected_state_trie_hash);
 
@@ -201,7 +201,9 @@ fn test_extcodecopy() -> Result<()> {
     // Pre-initialize the accessed addresses list.
     let init_accessed_addresses = KERNEL.global_labels["init_access_lists"];
     interpreter.generation_state.registers.program_counter = init_accessed_addresses;
-    interpreter.push(0xdeadbeefu32.into());
+    interpreter
+        .push(0xdeadbeefu32.into())
+        .expect("The stack should not overflow");
     interpreter.run()?;
 
     let extcodecopy = KERNEL.global_labels["sys_extcodecopy"];
@@ -321,7 +323,7 @@ fn sstore() -> Result<()> {
 
     let mut state_trie_before = HashedPartialTrie::from(Node::Empty);
 
-    state_trie_before.insert(addr_nibbles, rlp::encode(&account_before).to_vec());
+    state_trie_before.insert(addr_nibbles, rlp::encode(&account_before).to_vec())?;
 
     let trie_inputs = TrieInputs {
         state_trie: state_trie_before.clone(),
@@ -336,7 +338,9 @@ fn sstore() -> Result<()> {
     // Pre-initialize the accessed addresses list.
     let init_accessed_addresses = KERNEL.global_labels["init_access_lists"];
     interpreter.generation_state.registers.program_counter = init_accessed_addresses;
-    interpreter.push(0xdeadbeefu32.into());
+    interpreter
+        .push(0xdeadbeefu32.into())
+        .expect("The stack should not overflow");
     interpreter.run()?;
 
     // Prepare the interpreter by inserting the account in the state trie.
@@ -384,7 +388,7 @@ fn sstore() -> Result<()> {
     let hash = H256::from_uint(&interpreter.stack()[1]);
 
     let mut expected_state_trie_after = HashedPartialTrie::from(Node::Empty);
-    expected_state_trie_after.insert(addr_nibbles, rlp::encode(&account_after).to_vec());
+    expected_state_trie_after.insert(addr_nibbles, rlp::encode(&account_after).to_vec())?;
 
     let expected_state_trie_hash = expected_state_trie_after.hash();
     assert_eq!(hash, expected_state_trie_hash);
@@ -417,7 +421,7 @@ fn sload() -> Result<()> {
 
     let mut state_trie_before = HashedPartialTrie::from(Node::Empty);
 
-    state_trie_before.insert(addr_nibbles, rlp::encode(&account_before).to_vec());
+    state_trie_before.insert(addr_nibbles, rlp::encode(&account_before).to_vec())?;
 
     let trie_inputs = TrieInputs {
         state_trie: state_trie_before.clone(),
@@ -432,7 +436,9 @@ fn sload() -> Result<()> {
     // Pre-initialize the accessed addresses list.
     let init_accessed_addresses = KERNEL.global_labels["init_access_lists"];
     interpreter.generation_state.registers.program_counter = init_accessed_addresses;
-    interpreter.push(0xdeadbeefu32.into());
+    interpreter
+        .push(0xdeadbeefu32.into())
+        .expect("The stack should not overflow");
     interpreter.run()?;
 
     // Prepare the interpreter by inserting the account in the state trie.

--- a/evm_arithmetization/src/cpu/kernel/tests/add11.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/add11.rs
@@ -122,26 +122,36 @@ fn test_add11_yml() {
             &mut beacon_roots_account_storage,
             block_metadata.block_timestamp,
             block_metadata.parent_beacon_block_root,
-        );
+        )
+        .unwrap();
         let beacon_roots_account =
             beacon_roots_contract_from_storage(&beacon_roots_account_storage);
 
         let mut expected_state_trie_after = HashedPartialTrie::from(Node::Empty);
-        expected_state_trie_after.insert(
-            beneficiary_nibbles,
-            rlp::encode(&beneficiary_account_after).to_vec(),
-        );
         expected_state_trie_after
-            .insert(sender_nibbles, rlp::encode(&sender_account_after).to_vec());
-        expected_state_trie_after.insert(to_nibbles, rlp::encode(&to_account_after).to_vec());
-        expected_state_trie_after.insert(
-            beacon_roots_account_nibbles(),
-            rlp::encode(&beacon_roots_account).to_vec(),
-        );
-        expected_state_trie_after.insert(
-            ger_account_nibbles(),
-            rlp::encode(&GLOBAL_EXIT_ROOT_ACCOUNT).to_vec(),
-        );
+            .insert(
+                beneficiary_nibbles,
+                rlp::encode(&beneficiary_account_after).to_vec(),
+            )
+            .unwrap();
+        expected_state_trie_after
+            .insert(sender_nibbles, rlp::encode(&sender_account_after).to_vec())
+            .unwrap();
+        expected_state_trie_after
+            .insert(to_nibbles, rlp::encode(&to_account_after).to_vec())
+            .unwrap();
+        expected_state_trie_after
+            .insert(
+                beacon_roots_account_nibbles(),
+                rlp::encode(&beacon_roots_account).to_vec(),
+            )
+            .unwrap();
+        expected_state_trie_after
+            .insert(
+                ger_account_nibbles(),
+                rlp::encode(&GLOBAL_EXIT_ROOT_ACCOUNT).to_vec(),
+            )
+            .unwrap();
         expected_state_trie_after
     };
     let receipt_0 = LegacyReceiptRlp {
@@ -151,10 +161,12 @@ fn test_add11_yml() {
         logs: vec![],
     };
     let mut receipts_trie = HashedPartialTrie::from(Node::Empty);
-    receipts_trie.insert(
-        Nibbles::from_str("0x80").unwrap(),
-        rlp::encode(&receipt_0).to_vec(),
-    );
+    receipts_trie
+        .insert(
+            Nibbles::from_str("0x80").unwrap(),
+            rlp::encode(&receipt_0).to_vec(),
+        )
+        .unwrap();
     let transactions_trie: HashedPartialTrie = Node::Leaf {
         nibbles: Nibbles::from_str("0x80").unwrap(),
         value: txn.to_vec(),
@@ -290,26 +302,36 @@ fn test_add11_yml_with_exception() {
             &mut beacon_roots_account_storage,
             block_metadata.block_timestamp,
             block_metadata.parent_beacon_block_root,
-        );
+        )
+        .unwrap();
         let beacon_roots_account =
             beacon_roots_contract_from_storage(&beacon_roots_account_storage);
 
         let mut expected_state_trie_after = HashedPartialTrie::from(Node::Empty);
-        expected_state_trie_after.insert(
-            beneficiary_nibbles,
-            rlp::encode(&beneficiary_account_after).to_vec(),
-        );
         expected_state_trie_after
-            .insert(sender_nibbles, rlp::encode(&sender_account_after).to_vec());
-        expected_state_trie_after.insert(to_nibbles, rlp::encode(&to_account_after).to_vec());
-        expected_state_trie_after.insert(
-            beacon_roots_account_nibbles(),
-            rlp::encode(&beacon_roots_account).to_vec(),
-        );
-        expected_state_trie_after.insert(
-            ger_account_nibbles(),
-            rlp::encode(&GLOBAL_EXIT_ROOT_ACCOUNT).to_vec(),
-        );
+            .insert(
+                beneficiary_nibbles,
+                rlp::encode(&beneficiary_account_after).to_vec(),
+            )
+            .unwrap();
+        expected_state_trie_after
+            .insert(sender_nibbles, rlp::encode(&sender_account_after).to_vec())
+            .unwrap();
+        expected_state_trie_after
+            .insert(to_nibbles, rlp::encode(&to_account_after).to_vec())
+            .unwrap();
+        expected_state_trie_after
+            .insert(
+                beacon_roots_account_nibbles(),
+                rlp::encode(&beacon_roots_account).to_vec(),
+            )
+            .unwrap();
+        expected_state_trie_after
+            .insert(
+                ger_account_nibbles(),
+                rlp::encode(&GLOBAL_EXIT_ROOT_ACCOUNT).to_vec(),
+            )
+            .unwrap();
         expected_state_trie_after
     };
 
@@ -320,10 +342,12 @@ fn test_add11_yml_with_exception() {
         logs: vec![],
     };
     let mut receipts_trie = HashedPartialTrie::from(Node::Empty);
-    receipts_trie.insert(
-        Nibbles::from_str("0x80").unwrap(),
-        rlp::encode(&receipt_0).to_vec(),
-    );
+    receipts_trie
+        .insert(
+            Nibbles::from_str("0x80").unwrap(),
+            rlp::encode(&receipt_0).to_vec(),
+        )
+        .unwrap();
     let transactions_trie: HashedPartialTrie = Node::Leaf {
         nibbles: Nibbles::from_str("0x80").unwrap(),
         value: txn.to_vec(),

--- a/evm_arithmetization/src/cpu/kernel/tests/balance.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/balance.rs
@@ -96,7 +96,7 @@ fn prepare_interpreter<F: Field>(
     );
     let hash = H256::from_uint(&interpreter.stack()[1]);
 
-    state_trie.insert(k, rlp::encode(account).to_vec());
+    state_trie.insert(k, rlp::encode(account).to_vec())?;
     let expected_state_trie_hash = state_trie.hash();
     assert_eq!(hash, expected_state_trie_hash);
 

--- a/evm_arithmetization/src/cpu/kernel/tests/blobhash.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/blobhash.rs
@@ -31,8 +31,12 @@ fn test_valid_blobhash() -> Result<()> {
 
     interpreter.set_context_metadata_field(1, GasLimit, U256::from(1000000000000u64));
 
-    interpreter.push(index.into()); // target hash index
-    interpreter.push(retdest); // kexit_info
+    interpreter
+        .push(index.into())
+        .expect("The stack should not overflow"); // target hash index
+    interpreter
+        .push(retdest)
+        .expect("The stack should not overflow"); // kexit_info
 
     interpreter.run()?;
 
@@ -68,8 +72,12 @@ fn test_invalid_blobhash() -> Result<()> {
 
     interpreter.set_context_metadata_field(1, GasLimit, U256::from(1000000000000u64));
 
-    interpreter.push(index.into()); // target hash index
-    interpreter.push(retdest); // kexit_info
+    interpreter
+        .push(index.into())
+        .expect("The stack should not overflow"); // target hash index
+    interpreter
+        .push(retdest)
+        .expect("The stack should not overflow"); // kexit_info
 
     interpreter.run()?;
 

--- a/evm_arithmetization/src/cpu/kernel/tests/bls381.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/bls381.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use ethereum_types::U256;
 use hex_literal::hex;
-use keccak_hash::keccak;
 use plonky2::field::goldilocks_field::GoldilocksField as F;
 use rand::Rng;
 
@@ -9,12 +8,10 @@ use super::{run_interpreter_with_memory, InterpreterMemoryInitialization};
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::cancun_constants::POINT_EVALUATION_PRECOMPILE_RETURN_VALUE;
 use crate::cpu::kernel::constants::cancun_constants::KZG_VERSIONED_HASH;
-use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
 use crate::cpu::kernel::interpreter::Interpreter;
 use crate::extension_tower::{Fp2, Stack, BLS381};
-use crate::memory::segments::Segment::{self, KernelGeneral};
+use crate::memory::segments::Segment::KernelGeneral;
 use crate::util::sha2;
-use crate::witness::errors::ProgramError;
 
 #[test]
 fn test_bls_fp2_mul() -> Result<()> {

--- a/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
@@ -102,8 +102,12 @@ fn test_insert_address() -> Result<()> {
 
     assert!(address != H160::zero(), "Cosmic luck or bad RNG?");
 
-    interpreter.push(retaddr);
-    interpreter.push(U256::from(address.0.as_slice()));
+    interpreter
+        .push(retaddr)
+        .expect("The stack should not overflow");
+    interpreter
+        .push(U256::from(address.0.as_slice()))
+        .expect("The stack should not overflow");
     interpreter.generation_state.registers.program_counter = insert_accessed_addresses;
 
     interpreter.run()?;
@@ -146,8 +150,12 @@ fn test_insert_accessed_addresses() -> Result<()> {
     let offset = Segment::AccessedAddresses as usize;
     for i in 0..n {
         let addr = U256::from(addresses[i].0.as_slice());
-        interpreter.push(0xdeadbeefu32.into());
-        interpreter.push(addr);
+        interpreter
+            .push(0xdeadbeefu32.into())
+            .expect("The stack should not overflow");
+        interpreter
+            .push(addr)
+            .expect("The stack should not overflow");
         interpreter.generation_state.registers.program_counter = insert_accessed_addresses;
         interpreter.run()?;
         assert_eq!(interpreter.pop().unwrap(), U256::one());
@@ -156,8 +164,12 @@ fn test_insert_accessed_addresses() -> Result<()> {
     for i in 0..n {
         // Test for address already in list.
         let addr_in_list = addresses[i];
-        interpreter.push(retaddr);
-        interpreter.push(U256::from(addr_in_list.0.as_slice()));
+        interpreter
+            .push(retaddr)
+            .expect("The stack should not overflow");
+        interpreter
+            .push(U256::from(addr_in_list.0.as_slice()))
+            .expect("The stack should not overflow");
         interpreter.generation_state.registers.program_counter = insert_accessed_addresses;
         interpreter.run()?;
         assert_eq!(interpreter.pop().unwrap(), U256::zero());
@@ -170,8 +182,12 @@ fn test_insert_accessed_addresses() -> Result<()> {
     }
 
     // Test for address not in list.
-    interpreter.push(retaddr);
-    interpreter.push(U256::from(addr_not_in_list.0.as_slice()));
+    interpreter
+        .push(retaddr)
+        .expect("The stack should not overflow");
+    interpreter
+        .push(U256::from(addr_not_in_list.0.as_slice()))
+        .expect("The stack should not overflow");
     interpreter.generation_state.registers.program_counter = insert_accessed_addresses;
 
     interpreter.run()?;
@@ -222,9 +238,15 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
     for i in 0..n {
         let addr = U256::from(storage_keys[i].0 .0.as_slice());
         let key = storage_keys[i].1;
-        interpreter.push(retaddr);
-        interpreter.push(key);
-        interpreter.push(addr);
+        interpreter
+            .push(retaddr)
+            .expect("The stack should not overflow");
+        interpreter
+            .push(key)
+            .expect("The stack should not overflow");
+        interpreter
+            .push(addr)
+            .expect("The stack should not overflow");
         interpreter.generation_state.registers.program_counter = insert_accessed_storage_keys;
         interpreter.run()?;
         assert_eq!(interpreter.pop().unwrap(), U256::one());
@@ -234,9 +256,15 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
     for i in 0..10 {
         // Test for storage key already in list.
         let (addr, key) = storage_keys[i];
-        interpreter.push(retaddr);
-        interpreter.push(key);
-        interpreter.push(U256::from(addr.0.as_slice()));
+        interpreter
+            .push(retaddr)
+            .expect("The stack should not overflow");
+        interpreter
+            .push(key)
+            .expect("The stack should not overflow");
+        interpreter
+            .push(U256::from(addr.0.as_slice()))
+            .expect("The stack should not overflow");
         interpreter.generation_state.registers.program_counter = insert_accessed_storage_keys;
         interpreter.run()?;
         assert_eq!(interpreter.pop().unwrap(), U256::zero());
@@ -250,9 +278,15 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
     }
 
     // Test for storage key not in list.
-    interpreter.push(retaddr);
-    interpreter.push(storage_key_not_in_list.1);
-    interpreter.push(U256::from(storage_key_not_in_list.0 .0.as_slice()));
+    interpreter
+        .push(retaddr)
+        .expect("The stack should not overflow");
+    interpreter
+        .push(storage_key_not_in_list.1)
+        .expect("The stack should not overflow");
+    interpreter
+        .push(U256::from(storage_key_not_in_list.0 .0.as_slice()))
+        .expect("The stack should not overflow");
     interpreter.generation_state.registers.program_counter = insert_accessed_storage_keys;
 
     interpreter.run()?;

--- a/evm_arithmetization/src/cpu/kernel/tests/core/jumpdest_analysis.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/jumpdest_analysis.rs
@@ -72,9 +72,15 @@ fn test_jumpdest_analysis() -> Result<()> {
 
     // Run jumpdest analysis with context = 3
     interpreter.generation_state.registers.context = CONTEXT;
-    interpreter.push(0xDEADBEEFu32.into());
-    interpreter.push(code_len.into());
-    interpreter.push(U256::from(CONTEXT) << CONTEXT_SCALING_FACTOR);
+    interpreter
+        .push(0xDEADBEEFu32.into())
+        .expect("The stack should not overflow");
+    interpreter
+        .push(code_len.into())
+        .expect("The stack should not overflow");
+    interpreter
+        .push(U256::from(CONTEXT) << CONTEXT_SCALING_FACTOR)
+        .expect("The stack should not overflow");
 
     // We need to manually pop the jumpdest_table and push its value on the top of
     // the stack
@@ -86,7 +92,9 @@ fn test_jumpdest_analysis() -> Result<()> {
         .get_mut(&CONTEXT)
         .unwrap()
         .pop();
-    interpreter.push(41.into());
+    interpreter
+        .push(41.into())
+        .expect("The stack should not overflow");
 
     interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![]);
@@ -195,14 +203,14 @@ fn test_verify_non_jumpdest() -> Result<()> {
         code[i] -= 1;
 
         // We check that all non jumpdests are indeed non jumpdests
-        for (j, &opcode) in code
-            .iter()
-            .enumerate()
-            .filter(|&(j, _)| j != 1 && j != 5 && j != 7)
-        {
+        for j in (0..code.len()).filter(|&i| i != 1 && i != 5 && i != 7) {
             interpreter.generation_state.registers.program_counter = verify_non_jumpdest;
-            interpreter.push(0xDEADBEEFu32.into());
-            interpreter.push(j.into());
+            interpreter
+                .push(0xDEADBEEFu32.into())
+                .expect("The stack should not overflow");
+            interpreter
+                .push(j.into())
+                .expect("The stack should not overflow");
             interpreter.run()?;
             assert!(interpreter.stack().is_empty());
             assert_eq!(interpreter.get_jumpdest_bit(j), U256::zero());

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/insert.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/insert.rs
@@ -234,7 +234,7 @@ fn test_state_trie(
     );
     let hash = H256::from_uint(&interpreter.stack()[1]);
 
-    state_trie.insert(k, rlp::encode(&account).to_vec());
+    state_trie.insert(k, rlp::encode(&account).to_vec())?;
     let expected_state_trie_hash = state_trie.hash();
     assert_eq!(hash, expected_state_trie_hash);
 

--- a/evm_arithmetization/src/cpu/kernel/tests/transaction_parsing/parse_type_0_txn.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/transaction_parsing/parse_type_0_txn.rs
@@ -15,7 +15,7 @@ fn process_type_0_txn() -> Result<()> {
     let process_normalized_txn = KERNEL.global_labels["process_normalized_txn"];
 
     let retaddr = 0xDEADBEEFu32.into();
-    const INITIAL_TXN_RLP_ADDR: usize = (Segment::RlpRaw as usize + 1);
+    const INITIAL_TXN_RLP_ADDR: usize = Segment::RlpRaw as usize + 1;
     let mut interpreter: Interpreter<F> = Interpreter::new(
         process_type_0_txn,
         vec![retaddr, INITIAL_TXN_RLP_ADDR.into()],

--- a/evm_arithmetization/src/generation/prover_input.rs
+++ b/evm_arithmetization/src/generation/prover_input.rs
@@ -1,4 +1,3 @@
-use core::cmp::min;
 use core::mem::transmute;
 use core::ops::Neg;
 use std::collections::{BTreeSet, HashMap};
@@ -7,7 +6,6 @@ use std::str::FromStr;
 use anyhow::{bail, Error, Result};
 use ethereum_types::{BigEndianHash, H256, U256, U512};
 use itertools::Itertools;
-use keccak_hash::keccak;
 use num_bigint::BigUint;
 use plonky2::field::types::Field;
 use serde::{Deserialize, Serialize};
@@ -29,7 +27,7 @@ use crate::generation::prover_input::FieldOp::{Inverse, Sqrt};
 use crate::generation::state::GenerationState;
 use crate::memory::segments::Segment;
 use crate::memory::segments::Segment::BnPairing;
-use crate::util::{biguint_to_mem_vec, h2u, mem_vec_to_biguint, sha2, u256_to_u8, u256_to_usize};
+use crate::util::{biguint_to_mem_vec, mem_vec_to_biguint, sha2, u256_to_u8, u256_to_usize};
 use crate::witness::errors::ProverInputError::*;
 use crate::witness::errors::{ProgramError, ProverInputError};
 use crate::witness::memory::MemoryAddress;
@@ -304,8 +302,6 @@ impl<F: Field> GenerationState<F> {
             ));
         };
 
-        let jd_len = jumpdest_table.len();
-
         if let Some(ctx_jumpdest_table) = jumpdest_table.get_mut(&context)
             && let Some(next_jumpdest_address) = ctx_jumpdest_table.pop()
         {
@@ -324,8 +320,6 @@ impl<F: Field> GenerationState<F> {
                 ProverInputError::InvalidJumpdestSimulation,
             ));
         };
-
-        let jd_len = jumpdest_table.len();
 
         if let Some(ctx_jumpdest_table) = jumpdest_table.get_mut(&context)
             && let Some(next_jumpdest_proof) = ctx_jumpdest_table.pop()
@@ -526,7 +520,7 @@ impl<F: Field> GenerationState<F> {
         let mut z_bytes = [0u8; 32];
         z.to_big_endian(&mut z_bytes);
         let mut acc = CurveAff::<Fp2<BLS381>>::unit();
-        for (i, &byte) in z_bytes.iter().enumerate() {
+        for byte in z_bytes.into_iter() {
             acc = acc * 256_i32;
             acc = acc + (CurveAff::<Fp2<BLS381>>::GENERATOR * byte as i32);
         }

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -163,7 +163,7 @@ pub(crate) trait State<F: Field> {
                     }
                 } else {
                     #[cfg(not(test))]
-                    self.log_info(format!("CPU halted after {} cycles", self.get_clock()));
+                    log::info!("CPU halted after {} cycles", self.get_clock());
                     return Ok(());
                 }
             }
@@ -260,12 +260,6 @@ pub(crate) trait State<F: Field> {
     #[inline]
     fn log_debug(&self, msg: String) {
         log::debug!("{}", msg);
-    }
-
-    /// Logs `msg` in `info` mode.
-    #[inline]
-    fn log_info(&self, msg: String) {
-        log::info!("{}", msg);
     }
 
     /// Logs `msg` at `level`.

--- a/evm_arithmetization/src/generation/trie_extractor.rs
+++ b/evm_arithmetization/src/generation/trie_extractor.rs
@@ -1,9 +1,7 @@
 //! Code for extracting trie data after witness generation. This is intended
 //! only for debugging.
 
-use std::collections::HashMap;
-
-use ethereum_types::{BigEndianHash, H256, U256, U512};
+use ethereum_types::{BigEndianHash, H256, U256};
 use mpt_trie::nibbles::{Nibbles, NibblesIntern};
 use mpt_trie::partial_trie::{HashedPartialTrie, Node, PartialTrie, WrappedNode};
 
@@ -14,106 +12,8 @@ use crate::util::{u256_to_bool, u256_to_h160, u256_to_u8, u256_to_usize};
 use crate::witness::errors::ProgramError;
 use crate::witness::memory::{MemoryAddress, MemoryState};
 
-/// Account data as it's stored in the state trie, with a pointer to the storage
-/// trie.
-#[derive(Debug)]
-pub(crate) struct AccountTrieRecord {
-    pub(crate) nonce: u64,
-    pub(crate) balance: U256,
-    pub(crate) storage_ptr: usize,
-    pub(crate) code_hash: H256,
-}
-
-pub(crate) fn read_state_trie_value(
-    slice: &[Option<U256>],
-) -> Result<AccountTrieRecord, ProgramError> {
-    Ok(AccountTrieRecord {
-        nonce: slice[0].unwrap_or_default().low_u64(),
-        balance: slice[1].unwrap_or_default(),
-        storage_ptr: u256_to_usize(slice[2].unwrap_or_default())?,
-        code_hash: H256::from_uint(&slice[3].unwrap_or_default()),
-    })
-}
-
 pub(crate) fn read_storage_trie_value(slice: &[Option<U256>]) -> U256 {
     slice[0].unwrap_or_default()
-}
-
-pub(crate) fn read_trie<V>(
-    memory: &MemoryState,
-    ptr: usize,
-    read_value: fn(&[Option<U256>]) -> Result<V, ProgramError>,
-) -> Result<HashMap<Nibbles, V>, ProgramError> {
-    let mut res = HashMap::new();
-    let empty_nibbles = Nibbles {
-        count: 0,
-        packed: NibblesIntern::zero(),
-    };
-    read_trie_helper::<V>(memory, ptr, read_value, empty_nibbles, &mut res)?;
-    Ok(res)
-}
-
-pub(crate) fn read_trie_helper<V>(
-    memory: &MemoryState,
-    ptr: usize,
-    read_value: fn(&[Option<U256>]) -> Result<V, ProgramError>,
-    prefix: Nibbles,
-    res: &mut HashMap<Nibbles, V>,
-) -> Result<(), ProgramError> {
-    let load = |offset| memory.contexts[0].segments[Segment::TrieData as usize].content[offset];
-    let load_slice_from = |init_offset| {
-        &memory.contexts[0].segments[Segment::TrieData.unscale()].content[init_offset..]
-    };
-
-    let trie_type = PartialTrieType::all()[u256_to_usize(load(ptr).unwrap_or_default())?];
-    match trie_type {
-        PartialTrieType::Empty => Ok(()),
-        PartialTrieType::Hash => Ok(()),
-        PartialTrieType::Branch => {
-            let ptr_payload = ptr + 1;
-            for i in 0u8..16 {
-                let child_ptr = u256_to_usize(load(ptr_payload + i as usize).unwrap_or_default())?;
-                read_trie_helper::<V>(memory, child_ptr, read_value, prefix.merge_nibble(i), res)?;
-            }
-            let value_ptr = u256_to_usize(load(ptr_payload + 16).unwrap_or_default())?;
-            if value_ptr != 0 {
-                res.insert(prefix, read_value(load_slice_from(value_ptr))?);
-            };
-
-            Ok(())
-        }
-        PartialTrieType::Extension => {
-            let count = u256_to_usize(load(ptr + 1).unwrap_or_default())?;
-            let packed = load(ptr + 2).unwrap_or_default();
-            let nibbles = Nibbles {
-                count,
-                packed: packed.into(),
-            };
-            let child_ptr = u256_to_usize(load(ptr + 3).unwrap_or_default())?;
-            read_trie_helper::<V>(
-                memory,
-                child_ptr,
-                read_value,
-                prefix.merge_nibbles(&nibbles),
-                res,
-            )
-        }
-        PartialTrieType::Leaf => {
-            let count = u256_to_usize(load(ptr + 1).unwrap_or_default())?;
-            let packed = load(ptr + 2).unwrap_or_default();
-            let nibbles = Nibbles {
-                count,
-                packed: packed.into(),
-            };
-            let value_ptr = u256_to_usize(load(ptr + 3).unwrap_or_default())?;
-            res.insert(
-                prefix.merge_nibbles(&nibbles),
-                read_value(load_slice_from(value_ptr))?,
-            );
-
-            Ok(())
-        }
-    }
 }
 
 pub(crate) fn read_receipt_trie_value(

--- a/evm_arithmetization/src/lib.rs
+++ b/evm_arithmetization/src/lib.rs
@@ -181,7 +181,6 @@
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::field_reassign_with_default)]
-#![allow(unused)]
 #![feature(let_chains)]
 
 // Individual STARK processing units

--- a/evm_arithmetization/src/memory/segments.rs
+++ b/evm_arithmetization/src/memory/segments.rs
@@ -3,7 +3,6 @@ pub(crate) const SEGMENT_SCALING_FACTOR: usize = 32;
 /// This contains all the existing memory segments. The values in the enum are
 /// shifted by 32 bits to allow for convenient address components (context /
 /// segment / virtual) bundling in the kernel.
-#[allow(dead_code)]
 #[allow(clippy::enum_clike_unportable_variant)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
 pub(crate) enum Segment {

--- a/evm_arithmetization/src/testing_utils.rs
+++ b/evm_arithmetization/src/testing_utils.rs
@@ -59,19 +59,6 @@ pub fn create_account_storage(storage_pairs: &[(U256, U256)]) -> anyhow::Result<
     Ok(trie)
 }
 
-/// Creates the storage trie of the beacon roots contract account at the
-/// provided timestamp. Not passing any parent root will consider the parent
-/// root at genesis, i.e. the empty hash.
-fn beacon_roots_contract_storage(
-    timestamp: U256,
-    parent_root: H256,
-) -> anyhow::Result<HashedPartialTrie> {
-    let timestamp_idx = timestamp % HISTORY_BUFFER_LENGTH.1;
-    let root_idx = timestamp_idx + HISTORY_BUFFER_LENGTH.1;
-
-    create_account_storage(&[(timestamp_idx, timestamp), (root_idx, h2u(parent_root))])
-}
-
 /// Updates the beacon roots account storage with the provided timestamp and
 /// block parent root.
 pub fn update_beacon_roots_account_storage(

--- a/evm_arithmetization/src/util.rs
+++ b/evm_arithmetization/src/util.rs
@@ -127,17 +127,6 @@ pub(crate) fn h256_limbs<F: Field>(h256: H256) -> [F; 8] {
         .unwrap()
 }
 
-/// Returns the 32-bit limbs of a `U160`.
-pub(crate) fn h160_limbs<F: Field>(h160: H160) -> [F; 5] {
-    h160.0
-        .chunks(4)
-        .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
-        .map(F::from_canonical_u32)
-        .collect_vec()
-        .try_into()
-        .unwrap()
-}
-
 pub(crate) const fn indices_arr<const N: usize>() -> [usize; N] {
     let mut indices_arr = [0; N];
     let mut i = 0;

--- a/evm_arithmetization/src/verifier.rs
+++ b/evm_arithmetization/src/verifier.rs
@@ -294,6 +294,7 @@ where
     running_sum + challenge.combine(row.iter()).inverse()
 }
 
+#[cfg(debug_assertions)]
 pub(crate) mod debug_utils {
     use super::*;
 


### PR DESCRIPTION
Removes `#![allow(dead_code)]` from `evm_arithmetization`, and perform associated cleanup.

It's targeting `feat/cancun` as some modules weren't used for Shanghai.