### PR TITLE
ci: add cargo audit job

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,13 @@
+name: Security audit
+on:
+  push:
+    paths: 
+      - '**/Cargo.toml'
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rustsec/audit-check@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See usage at [rustsec/audit-check/usage](https://github.com/rustsec/audit-check?tab=readme-ov-file#usage).