### PR TITLE
fix: Revert interpreter stack display

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -333,31 +333,14 @@ impl<F: Field> Interpreter<F> {
         }
     }
 
+    // As this relies on the underlying `GenerationState` method, stacks containing
+    // more than 10 elements will be truncated. As such, new tests that would need
+    // to access more elements would require special handling.
     pub(crate) fn stack(&self) -> Vec<U256> {
-        match self.stack_len().cmp(&1) {
-            Ordering::Greater => {
-                let mut stack = self.generation_state.memory.contexts[self.context()].segments
-                    [Segment::Stack.unscale()]
-                .content
-                .iter()
-                .filter_map(|&opt_elt| opt_elt)
-                .collect::<Vec<_>>();
-                stack.truncate(self.stack_len() - 1);
-                stack.push(
-                    self.stack_top()
-                        .expect("The stack is checked to be nonempty"),
-                );
-                stack
-            }
-            Ordering::Equal => {
-                vec![self
-                    .stack_top()
-                    .expect("The stack is checked to be nonempty")]
-            }
-            Ordering::Less => {
-                vec![]
-            }
-        }
+        let mut stack = self.generation_state.stack();
+        stack.reverse();
+
+        stack
     }
 
     fn stack_segment_mut(&mut self) -> &mut Vec<Option<U256>> {
@@ -509,7 +492,10 @@ impl<F: Field> State<F> for Interpreter<F> {
     }
 
     fn get_stack(&self) -> Vec<U256> {
-        self.stack()
+        let mut stack = self.stack();
+        stack.reverse();
+
+        stack
     }
 
     fn get_halt_offsets(&self) -> Vec<usize> {


### PR DESCRIPTION
Encountering an error while running the CPU in `simulation` mode (i.e. through the interpreter) would display a reverted stack, which can be confusing. Additionally, the interpreter was re-implementing stack reconstruction in a bloated way while we could reuse the implementation from the underlying generation state (assuming the stack is less than 10 elements long in unit tests, which is currently always the case).

The only downside is that the `interpreter`'s implementation of the `State` trait method `get_stack` requires a double call to `stack.reverse()`, although this method is only used upon CPU erroring, so this isn't an issue.