### PR TITLE
fix: Specify conditional attribute properly

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @muursh @Nashtare
-/evm_arithmetization/ @wborgeaud @muursh @Nashtare
+* @muursh @Nashtare @cpubot
+/evm_arithmetization/ @wborgeaud @muursh @Nashtare @cpubot

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,13 @@
+name: Security audit
+on:
+  push:
+    paths: 
+      - '**/Cargo.toml'
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rustsec/audit-check@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Add a few QoL useability functions to the interface ([#169](https://github.com/0xPolygonZero/zk_evm/pull/169))
 
 ## [0.3.1] - 2024-04-22
 

--- a/evm_arithmetization/src/cpu/cpu_stark.rs
+++ b/evm_arithmetization/src/cpu/cpu_stark.rs
@@ -17,7 +17,7 @@ use starky::stark::Stark;
 use super::columns::CpuColumnsView;
 use super::halt;
 use super::kernel::constants::context_metadata::ContextMetadata;
-use super::membus::NUM_GP_CHANNELS;
+use super::membus::{NUM_CHANNELS, NUM_GP_CHANNELS};
 use crate::all_stark::{EvmStarkFrame, Table};
 use crate::cpu::columns::{COL_MAP, NUM_CPU_COLUMNS};
 use crate::cpu::{
@@ -25,7 +25,7 @@ use crate::cpu::{
     modfp254, pc, push0, shift, simple_logic, stack, syscalls_exceptions,
 };
 use crate::memory::segments::Segment;
-use crate::memory::{NUM_CHANNELS, VALUE_LIMBS};
+use crate::memory::VALUE_LIMBS;
 
 /// Creates the vector of `Columns` corresponding to the General Purpose
 /// channels when calling the Keccak sponge: the CPU reads the output of the

--- a/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
@@ -63,17 +63,22 @@ global init_access_lists:
     POP
 %endmacro
 
-// Multiply the ptr at the top of the stack by 2
-// and abort if 2*ptr - @SEGMENT_ACCESSED_ADDRESSES >= @GLOBAL_METADATA_ACCESSED_ADDRESSES_LEN
-// In this way ptr must be pointing to the begining of a node.
+// Multiply the value at the top of the stack, denoted by ptr/2, by 2
+// and abort if ptr/2 >= mem[@GLOBAL_METADATA_ACCESSED_ADDRESSES_LEN]/2
+// In this way 2*ptr/2 must be pointing to the begining of a node.
 %macro get_valid_addr_ptr
-    // stack: ptr
+    // stack: ptr/2
+    DUP1
+    // stack: ptr/2, ptr/2
+    %mload_global_metadata(@GLOBAL_METADATA_ACCESSED_ADDRESSES_LEN)
+    // @GLOBAL_METADATA_ACCESSED_ADDRESSES_LEN must be an even number because
+    // both @SEGMENT_ACCESSED_ADDRESSES and the unscaled access addresses list len
+    // must be even numbers
+    %div_const(2)
+    // stack: scaled_len/2, ptr/2, ptr/2
+    %assert_gt
     %mul_const(2)
-    PUSH @SEGMENT_ACCESSED_ADDRESSES
-    DUP2
-    SUB
-    %assert_lt_const(@GLOBAL_METADATA_ACCESSED_ADDRESSES_LEN)
-    // stack: 2*ptr
+    // stack: ptr
 %endmacro
 
 
@@ -205,17 +210,20 @@ global remove_accessed_addresses:
     // stack: cold_access, value_ptr
 %endmacro
 
-// Multiply the ptr at the top of the stack by 4
-// and abort if 4*ptr - SEGMENT_ACCESSED_STORAGE_KEYS >= @GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN
-// In this way ptr must be pointing to the beginning of a node.
+// Multiply the ptr at the top of the stack, denoted by ptr/4, by 4
+// and abort if ptr/4 >= @GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN/4
+// In this way 4*ptr/4 be pointing to the beginning of a node.
 %macro get_valid_storage_ptr
-    // stack: ptr
+    // stack: ptr/4
+    DUP1
+    %mload_global_metadata(@GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN)
+    // By construction, both @SEGMENT_ACCESSED_STORAGE_KEYS and the unscaled list len
+    // must be multiples of 4
+    %div_const(4)
+    // stack: scaled_len/4, ptr/4, ptr/4
+    %assert_gt
     %mul_const(4)
-    PUSH @SEGMENT_ACCESSED_STORAGE_KEYS
-    DUP2
-    SUB
-    %assert_lt_const(@GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN)
-    // stack: 2*ptr
+    // stack: ptr
 %endmacro
 
 /// Inserts the storage key into the access list if it is not already present.

--- a/evm_arithmetization/src/cpu/kernel/asm/core/call_gas.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/call_gas.asm
@@ -71,7 +71,13 @@ global xfer_cost:
     %jump(after_xfer_cost)
 xfer_cost_nonzero:
     // stack: cost, is_call_or_staticcall, is_call_or_callcode, address, gas, kexit_info, value, retdest
-    %add_const(@GAS_CALLVALUE)
+    SWAP5
+    // stack: kexit_info, is_call_or_staticcall, is_call_or_callcode, address, gas, cost, value, retdest
+    PUSH @GAS_CALLVALUE
+    // stack: call_value_gas, kexit_info, is_call_or_staticcall, is_call_or_callcode, address, gas, cost, value, retdest
+    %charge_gas
+    // stack: kexit_info, is_call_or_staticcall, is_call_or_callcode, address, gas, cost, value, retdest
+    SWAP5
     // stack: cost, is_call_or_staticcall, is_call_or_callcode, address, gas, kexit_info, value, retdest
     %jump(after_xfer_cost)
 

--- a/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
@@ -1,8 +1,6 @@
 // After the transaction data has been parsed into a normalized set of fields
 // (see NormalizedTxnField), this routine processes the transaction.
 
-// TODO: Save checkpoints in @CTX_METADATA_STATE_TRIE_CHECKPOINT_PTR and @SEGMENT_STORAGE_TRIE_CHECKPOINT_PTRS.
-
 // Pre stack: retdest
 // Post stack: success, leftover_gas
 global process_normalized_txn:

--- a/evm_arithmetization/src/cpu/kernel/asm/core/touched_addresses.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/touched_addresses.asm
@@ -47,7 +47,6 @@ insert_touched_addresses_found:
 
 /// Remove the address from the list.
 /// Panics if the address is not in the list.
-/// TODO: Unused?
 global remove_touched_addresses:
     // stack: addr, retdest
     %mload_global_metadata(@GLOBAL_METADATA_TOUCHED_ADDRESSES_LEN)

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/secp256k1/inverse_scalar.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/secp256k1/inverse_scalar.asm
@@ -1,5 +1,4 @@
 /// Division modulo 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141, the Secp256k1 scalar field order
-/// To replace with more efficient method using non-determinism later.
 
 %macro mulmodn_secp_scalar
     // stack: x, y

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/secp256k1/moddiv.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/secp256k1/moddiv.asm
@@ -1,5 +1,4 @@
 /// Division modulo 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f, the Secp256k1 base field order
-/// To replace with more efficient method using non-determinism later.
 
 // Returns y * (x^-1) where the inverse is taken modulo N
 %macro moddiv_secp_base

--- a/evm_arithmetization/src/cpu/kernel/asm/hash/sha2/compression.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/hash/sha2/compression.asm
@@ -65,10 +65,11 @@ compression_loop:
     %mload_kernel_code_u32
     // stack: K[i], W[i], a[i], b[i], c[i], d[i], e[i], f[i], g[i], h[i], num_blocks, scratch_space_addr, message_schedule_addr, i, a[0]..h[0], retdest
     DUP10
-    DUP10
-    DUP10
-    DUP10
-    // stack: e[i], f[i], g[i], h[i], K[i], W[i], a[i], b[i], c[i], d[i], e[i], f[i], g[i], h[i], num_blocks, scratch_space_addr, message_schedule_addr, i, a[0]..h[0], retdest
+    DUP8
+    DUP11
+    DUP11
+    DUP11
+    // stack: e[i], f[i], g[i], e[i], h[i], K[i], W[i], a[i], b[i], c[i], d[i], e[i], f[i], g[i], h[i], num_blocks, scratch_space_addr, message_schedule_addr, i, a[0]..h[0], retdest
     %sha2_temp_word1
     // stack: T1[i], a[i], b[i], c[i], d[i], e[i], f[i], g[i], h[i], num_blocks, scratch_space_addr, message_schedule_addr, i, a[0]..h[0], retdest
     DUP4

--- a/evm_arithmetization/src/cpu/kernel/asm/hash/sha2/ops.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/hash/sha2/ops.asm
@@ -1,14 +1,14 @@
 // 32-bit right rotation
 %macro rotr(rot)
     // stack: value
+    DUP1
+    // stack: value, value
     PUSH $rot
-    // stack: rot, value
-    DUP2
-    DUP2
-    // stack: rot, value, rot, value
+    // stack: rot, value, value
     SHR
-    // stack: value >> rot, rot, value
-    %stack (shifted, rot, value) -> (rot, value, shifted)
+    // stack: value >> rot, value
+    SWAP1
+    PUSH $rot
     // stack: rot, value, value >> rot
     PUSH 32
     SUB
@@ -26,16 +26,14 @@
     // stack: x, x
     %rotr(7)
     // stack: rotr(x, 7), x
-    SWAP1
-    // stack: x, rotr(x, 7)
     DUP1
-    // stack: x, x, rotr(x, 7)
-    %rotr(18)
-    // stack: rotr(x, 18), x, rotr(x, 7)
-    SWAP1
-    // stack: x, rotr(x, 18), rotr(x, 7)
+    // stack: rotr(x, 7), rotr(x, 7), x
+    %rotr(11)
+    // stack: rotr(x, 18), rotr(x, 7), x
+    SWAP2
+    // stack: x, rotr(x, 7), rotr(x, 18)
     %shr_const(3)
-    // stack: shr(x, 3), rotr(x, 18), rotr(x, 7)
+    // stack: shr(x, 3), rotr(x, 7), rotr(x, 18)
     XOR
     XOR
 %endmacro
@@ -46,36 +44,30 @@
     // stack: x, x
     %rotr(17)
     // stack: rotr(x, 17), x
-    SWAP1
-    // stack: x, rotr(x, 17)
     DUP1
-    // stack: x, x, rotr(x, 17)
-    %rotr(19)
-    // stack: rotr(x, 19), x, rotr(x, 17)
-    SWAP1
-    // stack: x, rotr(x, 19), rotr(x, 17)
+    // stack: rotr(x, 17), rotr(x, 17), x
+    %rotr(2)
+    // stack: rotr(x, 19), rotr(x, 17), x
+    SWAP2
+    // stack: x, rotr(x, 17), rotr(x, 19)
     PUSH 10
     SHR
-    // stack: shr(x, 10), rotr(x, 19), rotr(x, 17)
+    // stack: shr(x, 10), rotr(x, 17), rotr(x, 19)
     XOR
     XOR
 %endmacro
 
 %macro sha2_bigsigma_0
     // stack: x
-    DUP1
-    // stack: x, x
     %rotr(2)
-    // stack: rotr(x, 2), x
-    SWAP1
-    // stack: x, rotr(x, 2)
+    // stack: rotr(x, 2)
     DUP1
-    // stack: x, x, rotr(x, 2)
-    %rotr(13)
-    // stack: rotr(x, 13), x, rotr(x, 2)
-    SWAP1
-    // stack: x, rotr(x, 13), rotr(x, 2)
-    %rotr(22)
+    // stack: rotr(x, 2), rotr(x, 2)
+    %rotr(11)
+    // stack: rotr(x, 13), rotr(x, 2)
+    DUP1
+    // stack: rotr(x, 13), rotr(x, 13), rotr(x, 2)
+    %rotr(9)
     // stack: rotr(x, 22), rotr(x, 13), rotr(x, 2)
     XOR
     XOR
@@ -83,19 +75,15 @@
 
 %macro sha2_bigsigma_1
     // stack: x
-    DUP1
-    // stack: x, x
     %rotr(6)
-    // stack: rotr(x, 6), x
-    SWAP1
-    // stack: x, rotr(x, 6)
+    // stack: rotr(x, 6)
     DUP1
-    // stack: x, x, rotr(x, 6)
-    %rotr(11)
-    // stack: rotr(x, 11), x, rotr(x, 6)
-    SWAP1
-    // stack: x, rotr(x, 11), rotr(x, 6)
-    %rotr(25)
+    // stack: rotr(x, 6), rotr(x, 6)
+    %rotr(5)
+    // stack: rotr(x, 11), rotr(x, 6)
+    DUP1
+    // stack: rotr(x, 11), rotr(x, 11), rotr(x, 6)
+    %rotr(14)
     // stack: rotr(x, 25), rotr(x, 11), rotr(x, 6)
     XOR
     XOR
@@ -103,41 +91,31 @@
 
 %macro sha2_choice
     // stack: x, y, z
-    DUP1
-    // stack: x, x, y, z
-    NOT
-    // stack: not x, x, y, z
     SWAP1
-    // stack: x, not x, y, z
-    SWAP3
-    // stack: z, not x, y, x
+    // stack: y, x, z
+    DUP3
+    // stack: z, y, x, z
+    XOR
+    // stack: z xor y, x, z
     AND
-    // stack: (not x) and z, y, x
-    SWAP2
-    // stack: x, y, (not x) and z
-    AND
-    // stack: x and y, (not x) and z
-    OR
+    // stack: (z xor y) and x, z
+    XOR
+    // stack: ((z xor y) and x) xor z == (x and y) xor (not x and z)
 %endmacro
 
 %macro sha2_majority
     // stack: x, y, z
-    DUP1
-    // stack: x, x, y, z
-    DUP3
-    // stack: y, x, x, y, z
-    DUP5
-    // stack: z, y, x, x, y, z
+    DUP2
+    DUP2
     AND
-    // stack: z and y, x, x, y, z
-    SWAP4
-    // stack: z, x, x, y, z and y
-    AND
-    // stack: z and x, x, y, z and y
+    // stack: x and y, x, y, z
     SWAP2
-    // stack: y, x, z and x, z and y
+    // stack: y, x, x and y, z
+    OR
+    // stack: y or x, x and y, z
+    %stack(y_or_x, x_and_y, z) -> (z, y_or_x, x_and_y)
     AND
-    // stack: y and x, z and x, z and y
+    // stack: z and (y or x), x and y
     OR
-    OR
+    // stack: (z and (y or x) or (x and y) == (x and y) or (x and z) or (y and z)
 %endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/hash/sha2/temp_words.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/hash/sha2/temp_words.asm
@@ -1,18 +1,16 @@
 // "T_1" in the SHA-256 spec
 %macro sha2_temp_word1
-    // stack: e, f, g, h, K[i], W[i]
-    DUP1
-    // stack: e, e, f, g, h, K[i], W[i]
-    %sha2_bigsigma_1
-    // stack: Sigma_1(e), e, f, g, h, K[i], W[i]
-    %stack (sig, e, f, g) -> (e, f, g, sig)
-    // stack: e, f, g, Sigma_1(e), h, K[i], W[i]
+    // stack: e, f, g, e, h, K[i], W[i]
     %sha2_choice
-    // stack: Ch(e, f, g), Sigma_1(e), h, K[i], W[i]
-    %add_u32
-    %add_u32
-    %add_u32
-    %add_u32
+    // stack: Ch(e, f, g), e, h, K[i], W[i]
+    SWAP1
+    // stack: e, Ch(e, f, g), h, K[i], W[i]
+    %sha2_bigsigma_1
+    // stack: Sigma_1(e), Ch(e, f, g), h, K[i], W[i]
+    ADD
+    ADD
+    ADD
+    ADD
     // stack: Ch(e, f, g) + Sigma_1(e) + h + K[i] + W[i]
 %endmacro
 
@@ -27,6 +25,6 @@
     // stack: c, a, b, Sigma_0(a)
     %sha2_majority
     // stack: Maj(c, a, b), Sigma_0(a)
-    %add_u32
+    ADD
     // stack: Maj(c, a, b) + Sigma_0(a)
 %endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/hash/sha2/write_length.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/hash/sha2/write_length.asm
@@ -3,14 +3,13 @@
     %build_current_general_address
     SWAP1
     // stack: length, last_addr
-    DUP1
-    // stack: length, length, last_addr
+    DUP2
+    DUP2
+    // stack: length, last_addr, length, last_addr
     %and_const(0xff)
-    // stack: length % (1 << 8), length, last_addr
-    DUP3
-    // stack: last_addr, length % (1 << 8), length, last_addr
-    %swap_mstore
-    
+    // stack: length % (1 << 8), last_addr, length, last_addr
+    MSTORE_GENERAL
+
     %rep 7
         // For i = 0 to 6
         // stack: length >> (8 * i), last_addr - i - 1
@@ -20,14 +19,13 @@
         // stack: length >> (8 * i), last_addr - i - 2
         %shr_const(8)
         // stack: length >> (8 * (i + 1)), last_addr - i - 2
-        PUSH 256
         DUP2
-        // stack: length >> (8 * (i + 1)), 256, length >> (8 * (i + 1)), last_addr - i - 2
-        MOD
-        // stack: (length >> (8 * (i + 1))) % (1 << 8), length >> (8 * (i + 1)), last_addr - i - 2
+        PUSH 256
         DUP3
-        // stack: last_addr - i - 2, (length >> (8 * (i + 1))) % (1 << 8), length >> (8 * (i + 1)), last_addr - i - 2
-        %swap_mstore
+        // stack: length >> (8 * (i + 1)), 256, last_addr - i - 2, length >> (8 * (i + 1)), last_addr - i - 2
+        MOD
+        // stack: (length >> (8 * (i + 1))) % (1 << 8), last_addr - i - 2, length >> (8 * (i + 1)), last_addr - i - 2
+        MSTORE_GENERAL
     %endrep
 
     %pop2

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/delete/delete_branch.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/delete/delete_branch.asm
@@ -6,7 +6,6 @@
 //          - If there are more than one, update the branch node and return it.
 //          - If there is exactly one, transform the branch node into an leaf/extension node and return it.
 // Assumes that `num_nibbles>0` and that the value of the branch node is zero.
-// TODO: May need to revisit these assumptions depending on how the receipt trie is implemented.
 global mpt_delete_branch:
     // stack: node_type, node_payload_ptr, num_nibbles, key, retdest
     POP

--- a/evm_arithmetization/src/cpu/kernel/asm/util/assertions.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/util/assertions.asm
@@ -39,8 +39,8 @@ global panic:
 %endmacro
 
 %macro assert_lt(ret)
-    GE
-    %assert_zero($ret)
+    LT
+    %assert_nonzero($ret)
 %endmacro
 
 %macro assert_le
@@ -56,10 +56,8 @@ global panic:
 %endmacro
 
 %macro assert_gt
-    // %assert_zero is cheaper than %assert_nonzero, so we will leverage the
-    // fact that (x > y) == !(x <= y).
-    LE
-    %assert_zero
+    GT
+    %assert_nonzero
 %endmacro
 
 %macro assert_gt(ret)

--- a/evm_arithmetization/src/cpu/kernel/tests/ecc/ecrecover.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/ecc/ecrecover.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
 use std::str::FromStr;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use ethereum_types::U256;
 use plonky2::field::goldilocks_field::GoldilocksField as F;
 
@@ -32,17 +33,18 @@ fn test_invalid_ecrecover(hash: &str, v: &str, r: &str, s: &str) -> Result<()> {
 #[test]
 fn test_ecrecover_real_block() -> Result<()> {
     let f = include_str!("ecrecover_test_data");
-    let convert_v = |v| match v {
-        // TODO: do this properly.
-        "0" => "0x1b",
-        "1" => "0x1c",
-        "37" => "0x1b",
-        "38" => "0x1c",
-        _ => panic!("Invalid v."),
+    let convert_v = {
+        let mut map = HashMap::new();
+        map.insert("0", "0x1b");
+        map.insert("1", "0x1c");
+        map.insert("37", "0x1b");
+        map.insert("38", "0x1c");
+
+        move |v: &str| map.get(v).copied().ok_or_else(|| anyhow!("Invalid v."))
     };
     for line in f.lines().filter(|s| !s.starts_with("//")) {
         let line = line.split_whitespace().collect::<Vec<_>>();
-        test_valid_ecrecover(line[4], convert_v(line[0]), line[1], line[2], line[3])?;
+        test_valid_ecrecover(line[4], convert_v(line[0])?, line[1], line[2], line[3])?;
     }
     Ok(())
 }

--- a/evm_arithmetization/src/generation/prover_input.rs
+++ b/evm_arithmetization/src/generation/prover_input.rs
@@ -283,7 +283,6 @@ impl<F: RichField> GenerationState<F> {
 
         if self.jumpdest_table.is_none() {
             self.generate_jumpdest_table()?;
-            log::debug!("jdt  = {:?}", self.jumpdest_table);
         }
 
         let Some(jumpdest_table) = &mut self.jumpdest_table else {
@@ -297,11 +296,6 @@ impl<F: RichField> GenerationState<F> {
         if let Some(ctx_jumpdest_table) = jumpdest_table.get_mut(&context)
             && let Some(next_jumpdest_address) = ctx_jumpdest_table.pop()
         {
-            log::debug!(
-                "jumpdest_table_len = {:?}, ctx_jumpdest_table.len = {:?}",
-                jd_len,
-                ctx_jumpdest_table.len()
-            );
             Ok((next_jumpdest_address + 1).into())
         } else {
             jumpdest_table.remove(&context);
@@ -323,11 +317,6 @@ impl<F: RichField> GenerationState<F> {
         if let Some(ctx_jumpdest_table) = jumpdest_table.get_mut(&context)
             && let Some(next_jumpdest_proof) = ctx_jumpdest_table.pop()
         {
-            log::debug!(
-                "jumpdest_table_len = {:?}, ctx_jumpdest_table.len = {:?}",
-                jd_len,
-                ctx_jumpdest_table.len()
-            );
             Ok(next_jumpdest_proof.into())
         } else {
             Err(ProgramError::ProverInputError(

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, bail};
 use ethereum_types::{Address, BigEndianHash, H160, H256, U256};
 use itertools::Itertools;
 use keccak_hash::keccak;
+use log::Level;
 use plonky2::field::types::Field;
 use plonky2::hash::hash_types::RichField;
 use smt_trie::code::{hash_bytecode_u256, hash_contract_bytecode};
@@ -170,7 +171,7 @@ pub(crate) trait State<F: RichField> {
                     }
                 } else {
                     #[cfg(not(test))]
-                    log::info!("CPU halted after {} cycles", self.get_clock());
+                    self.log_info(format!("CPU halted after {} cycles", self.get_clock()));
                     return Ok(());
                 }
             }
@@ -261,6 +262,24 @@ pub(crate) trait State<F: RichField> {
 
         let opcode = read_code_memory(generation_state, &mut row);
         (row, opcode)
+    }
+
+    /// Logs `msg` in `debug` mode.
+    #[inline]
+    fn log_debug(&self, msg: String) {
+        log::debug!("{}", msg);
+    }
+
+    /// Logs `msg` in `info` mode.
+    #[inline]
+    fn log_info(&self, msg: String) {
+        log::info!("{}", msg);
+    }
+
+    /// Logs `msg` at `level`.
+    #[inline]
+    fn log(&self, level: Level, msg: String) {
+        log::log!(level, "{}", msg);
     }
 }
 
@@ -501,7 +520,7 @@ impl<F: RichField> State<F> for GenerationState<F> {
         if registers.is_kernel {
             log_kernel_instruction(self, op);
         } else {
-            log::debug!("User instruction: {:?}", op);
+            self.log_debug(format!("User instruction: {:?}", op));
         }
         fill_op_flag(op, &mut row);
 

--- a/evm_arithmetization/src/lib.rs
+++ b/evm_arithmetization/src/lib.rs
@@ -222,7 +222,7 @@ use mpt_trie::partial_trie::HashedPartialTrie;
 // the time being, it will be able to be disabled with a feature flag
 // (`disable_jemalloc`) in order to allow users to use their own allocator if
 // needed.
-#[cfg(not(any(target_env = "msvc", disable_jemalloc)))]
+#[cfg(not(any(target_env = "msvc", feature = "disable_jemalloc")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/evm_arithmetization/src/memory/mod.rs
+++ b/evm_arithmetization/src/memory/mod.rs
@@ -7,9 +7,6 @@ pub mod columns;
 pub mod memory_stark;
 pub mod segments;
 
-// TODO: Move to CPU module, now that channels have been removed from the memory
-// table.
-pub(crate) const NUM_CHANNELS: usize = crate::cpu::membus::NUM_CHANNELS;
 /// The number of limbs holding the value at a memory address.
 /// Eight limbs of 32 bits can hold a `U256`.
 pub(crate) const VALUE_LIMBS: usize = 8;

--- a/evm_arithmetization/src/witness/transition.rs
+++ b/evm_arithmetization/src/witness/transition.rs
@@ -282,14 +282,16 @@ pub(crate) fn log_kernel_instruction<F: RichField, S: State<F>>(state: &mut S, o
     } else {
         log::Level::Trace
     };
-    log::log!(
+    state.log(
         level,
-        "Cycle {}, ctx={}, pc={}, instruction={:?}, stack={:?}",
-        state.get_clock(),
-        state.get_context(),
-        KERNEL.offset_name(pc),
-        op,
-        state.get_generation_state().stack(),
+        format!(
+            "Cycle {}, ctx={}, pc={}, instruction={:?}, stack={:?}",
+            state.get_clock(),
+            state.get_context(),
+            KERNEL.offset_name(pc),
+            op,
+            state.get_generation_state().stack(),
+        ),
     );
 
     assert!(pc < KERNEL.code.len(), "Kernel PC is out of range: {}", pc);

--- a/mpt_trie/src/debug_tools/diff.rs
+++ b/mpt_trie/src/debug_tools/diff.rs
@@ -113,14 +113,15 @@ impl DiffPoint {
     }
 }
 
-// TODO: Redo display method so this is more readable...
 impl Display for DiffPoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Point Diff {{depth: {}, ", self.depth)?;
-        write!(f, "Path: ({}), ", self.path)?;
-        write!(f, "Key: {:x} ", self.key)?;
-        write!(f, "A info: {} ", self.a_info)?;
-        write!(f, "B info: {}}}", self.b_info)
+        writeln!(f, "Point Diff {{")?;
+        writeln!(f, "    Depth: {},", self.depth)?;
+        writeln!(f, "    Path: ({}),", self.path)?;
+        writeln!(f, "    Key: {:x},", self.key)?;
+        writeln!(f, "    A info: {},", self.a_info)?;
+        writeln!(f, "    B info: {}", self.b_info)?;
+        write!(f, "}}")
     }
 }
 
@@ -136,18 +137,20 @@ pub struct NodeInfo {
     hash: H256,
 }
 
-// TODO: Redo display method so this is more readable...
 impl Display for NodeInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(key: {:x} ", self.key)?;
+        write!(f, "NodeInfo {{ Key: 0x{:x}, ", self.key)?;
 
         match &self.value {
             Some(v) => write!(f, "Value: 0x{}, ", hex::encode(v))?,
             None => write!(f, "Value: N/A, ")?,
         }
 
-        write!(f, "Node type: {} ", self.node_type)?;
-        write!(f, "Trie hash: {:x})", self.hash)
+        write!(
+            f,
+            "Node type: {}, Trie hash: 0x{:x} }}",
+            self.node_type, self.hash
+        )
     }
 }
 

--- a/mpt_trie/src/debug_tools/query.rs
+++ b/mpt_trie/src/debug_tools/query.rs
@@ -206,17 +206,13 @@ impl DebugQueryOutput {
         }
     }
 
-    // TODO: Make the output easier to read...
     fn fmt_query_header(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Query Result {{")?;
-
-        writeln!(f, "Queried Key: {}", self.k)?;
-        writeln!(f, "Node found: {}", self.node_found)?;
-
+        writeln!(f, "    Queried Key: {}", self.k)?;
+        writeln!(f, "    Node Found: {}", self.node_found)?;
         writeln!(f, "}}")
     }
 
-    // TODO: Make the output easier to read...
     fn fmt_node_based_on_debug_params(
         f: &mut fmt::Formatter<'_>,
         seg: &TrieSegment,
@@ -224,30 +220,25 @@ impl DebugQueryOutput {
         params: &DebugQueryParams,
     ) -> fmt::Result {
         let node_type = seg.node_type();
+        let mut components = Vec::new();
 
         if params.include_node_type {
-            write!(f, "{}", node_type)?;
+            components.push(format!("{}", node_type));
         }
-
-        write!(f, "(")?;
 
         if params.include_key_piece_per_node {
             if let Some(k_piece) = seg.get_key_piece_from_seg_if_present() {
-                write!(f, "key: {}", k_piece)?;
+                components.push(format!("Key: {}", k_piece));
             }
         }
 
         if params.include_node_specific_values {
             if let Some(extra_seg_info) = extra_seg_info {
-                if params.include_key_piece_per_node {
-                    write!(f, ", ")?;
-                }
-
-                write!(f, "Extra Seg Info: {}", extra_seg_info)?;
+                components.push(format!("Extra Seg Info: {}", extra_seg_info));
             }
         }
 
-        write!(f, ")")?;
+        write!(f, "({})", components.join(", "))?;
 
         Ok(())
     }

--- a/mpt_trie/src/partial_trie.rs
+++ b/mpt_trie/src/partial_trie.rs
@@ -107,6 +107,11 @@ pub trait PartialTrie:
     /// Returns an iterator over the trie that returns all values for every
     /// `Leaf` and `Hash` node.
     fn values(&self) -> impl Iterator<Item = ValOrHash>;
+
+    /// Returns `true` if the trie contains an element with the given key.
+    fn contains<K>(&self, k: K) -> bool
+    where
+        K: Into<Nibbles>;
 }
 
 /// Part of the trait that is not really part of the public interface but
@@ -261,6 +266,13 @@ impl PartialTrie for StandardTrie {
     fn values(&self) -> impl Iterator<Item = ValOrHash> {
         self.0.trie_values()
     }
+
+    fn contains<K>(&self, k: K) -> bool
+    where
+        K: Into<Nibbles>,
+    {
+        self.0.trie_has_item_by_key(k)
+    }
 }
 
 impl TrieNodeIntern for StandardTrie {
@@ -380,6 +392,13 @@ impl PartialTrie for HashedPartialTrie {
 
     fn values(&self) -> impl Iterator<Item = ValOrHash> {
         self.node.trie_values()
+    }
+
+    fn contains<K>(&self, k: K) -> bool
+    where
+        K: Into<Nibbles>,
+    {
+        self.node.trie_has_item_by_key(k)
     }
 }
 

--- a/mpt_trie/src/trie_ops.rs
+++ b/mpt_trie/src/trie_ops.rs
@@ -364,7 +364,7 @@ impl<T: PartialTrie> Node<T> {
     where
         K: Into<Nibbles>,
     {
-        let k = k.into();
+        let k: Nibbles = k.into();
         trace!("Deleting a leaf node with key {} if it exists", k);
 
         delete_intern(&self.clone(), k)?.map_or(Ok(None), |(updated_root, deleted_val)| {
@@ -390,6 +390,14 @@ impl<T: PartialTrie> Node<T> {
 
     pub(crate) fn trie_values(&self) -> impl Iterator<Item = ValOrHash> {
         self.trie_items().map(|(_, v)| v)
+    }
+
+    pub(crate) fn trie_has_item_by_key<K>(&self, k: K) -> bool
+    where
+        K: Into<Nibbles>,
+    {
+        let k = k.into();
+        self.trie_items().any(|(key, _)| key == k)
     }
 }
 
@@ -1101,6 +1109,28 @@ mod tests {
 
         let res = trie.delete(0x5678)?;
         assert!(res.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn existent_node_key_contains_returns_true() -> TrieOpResult<()> {
+        common_setup();
+
+        let mut trie = StandardTrie::default();
+        trie.insert(0x1234, vec![91])?;
+        assert!(trie.contains(0x1234));
+
+        Ok(())
+    }
+
+    #[test]
+    fn non_existent_node_key_contains_returns_false() -> TrieOpResult<()> {
+        common_setup();
+
+        let mut trie = StandardTrie::default();
+        trie.insert(0x1234, vec![91])?;
+        assert!(!trie.contains(0x5678));
 
         Ok(())
     }

--- a/trace_decoder/src/compact/complex_test_payloads.rs
+++ b/trace_decoder/src/compact/complex_test_payloads.rs
@@ -4,7 +4,7 @@ use mpt_trie::partial_trie::PartialTrie;
 use super::{
     compact_prestate_processing::{
         process_compact_prestate, process_compact_prestate_debug, CompactParsingResult,
-        PartialTriePreImages, ProcessedCompactOutput,
+        ProcessedCompactOutput,
     },
     compact_to_partial_trie::StateTrieExtractionOutput,
 };
@@ -40,6 +40,7 @@ pub(crate) struct TestProtocolInputAndRoot {
 }
 
 impl TestProtocolInputAndRoot {
+    #[allow(dead_code)]
     pub(crate) fn parse_and_check_hash_matches(self) {
         self.parse_and_check_hash_matches_common(process_compact_prestate);
     }

--- a/trace_decoder/src/lib.rs
+++ b/trace_decoder/src/lib.rs
@@ -115,9 +115,6 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
-// TODO: address these lints
-#![allow(unused)]
-#![allow(private_interfaces)]
 
 /// Provides debugging tools and a compact representation of state and storage
 /// tries, used in tests.
@@ -133,6 +130,3 @@ pub mod trace_protocol;
 pub mod types;
 /// Defines useful functions necessary to the other modules.
 pub mod utils;
-
-use trace_protocol::{BlockTrace, TxnInfo};
-use types::OtherBlockData;

--- a/trace_decoder/src/processed_block_trace.rs
+++ b/trace_decoder/src/processed_block_trace.rs
@@ -9,21 +9,21 @@ use mpt_trie::nibbles::Nibbles;
 use mpt_trie::partial_trie::{HashedPartialTrie, PartialTrie};
 
 use crate::compact::compact_prestate_processing::{
-    process_compact_prestate_debug, PartialTriePreImages, ProcessedCompactOutput,
+    process_compact_prestate_debug, CompactParsingError, CompactParsingResult,
+    PartialTriePreImages, ProcessedCompactOutput,
 };
-use crate::decoding::TraceParsingResult;
+use crate::decoding::{TraceParsingError, TraceParsingResult};
 use crate::trace_protocol::{
     BlockTrace, BlockTraceTriePreImages, CombinedPreImages, ContractCodeUsage,
     SeparateStorageTriesPreImage, SeparateTriePreImage, SeparateTriePreImages, TrieCompact,
     TrieUncompressed, TxnInfo,
 };
 use crate::types::{
-    CodeHash, CodeHashResolveFunc, HashedAccountAddr, HashedNodeAddr, HashedStorageAddr,
-    HashedStorageAddrNibbles, OtherBlockData, TrieRootHash, EMPTY_CODE_HASH, EMPTY_TRIE_HASH,
+    CodeHash, CodeHashResolveFunc, HashedAccountAddr, HashedNodeAddr, HashedStorageAddrNibbles,
+    OtherBlockData, TrieRootHash, EMPTY_CODE_HASH, EMPTY_TRIE_HASH,
 };
 use crate::utils::{
-    h_addr_nibs_to_h256, hash, print_value_and_hash_nodes_of_storage_trie,
-    print_value_and_hash_nodes_of_trie,
+    hash, print_value_and_hash_nodes_of_storage_trie, print_value_and_hash_nodes_of_trie,
 };
 
 #[derive(Debug)]
@@ -47,7 +47,7 @@ impl BlockTrace {
         F: CodeHashResolveFunc,
     {
         let processed_block_trace =
-            self.into_processed_block_trace(p_meta, other_data.b_data.withdrawals.clone());
+            self.into_processed_block_trace(p_meta, other_data.b_data.withdrawals.clone())?;
 
         processed_block_trace.into_txn_proof_gen_ir(other_data)
     }
@@ -56,13 +56,13 @@ impl BlockTrace {
         self,
         p_meta: &ProcessingMeta<F>,
         withdrawals: Vec<(Address, U256)>,
-    ) -> ProcessedBlockTrace
+    ) -> TraceParsingResult<ProcessedBlockTrace>
     where
         F: CodeHashResolveFunc,
     {
         // The compact format is able to provide actual code, so if it does, we should
         // take advantage of it.
-        let pre_image_data = process_block_trace_trie_pre_images(self.trie_pre_images);
+        let pre_image_data = process_block_trace_trie_pre_images(self.trie_pre_images)?;
 
         print_value_and_hash_nodes_of_trie(&pre_image_data.tries.state);
 
@@ -75,12 +75,8 @@ impl BlockTrace {
             .state
             .items()
             .filter_map(|(addr, data)| {
-                data.as_val().map(|data| {
-                    (
-                        h_addr_nibs_to_h256(&addr),
-                        rlp::decode::<AccountRlp>(data).unwrap(),
-                    )
-                })
+                data.as_val()
+                    .map(|data| (addr.into(), rlp::decode::<AccountRlp>(data).unwrap()))
             })
             .collect();
 
@@ -115,11 +111,11 @@ impl BlockTrace {
             })
             .collect::<Vec<_>>();
 
-        ProcessedBlockTrace {
+        Ok(ProcessedBlockTrace {
             tries: pre_image_data.tries,
             txn_info,
             withdrawals,
-        }
+        })
     }
 }
 
@@ -146,27 +142,31 @@ impl From<ProcessedCompactOutput> for ProcessedBlockTracePreImages {
 
 fn process_block_trace_trie_pre_images(
     block_trace_pre_images: BlockTraceTriePreImages,
-) -> ProcessedBlockTracePreImages {
+) -> TraceParsingResult<ProcessedBlockTracePreImages> {
     match block_trace_pre_images {
         BlockTraceTriePreImages::Separate(t) => process_separate_trie_pre_images(t),
         BlockTraceTriePreImages::Combined(t) => process_combined_trie_pre_images(t),
     }
 }
 
-fn process_combined_trie_pre_images(tries: CombinedPreImages) -> ProcessedBlockTracePreImages {
-    process_compact_trie(tries.compact)
+fn process_combined_trie_pre_images(
+    tries: CombinedPreImages,
+) -> TraceParsingResult<ProcessedBlockTracePreImages> {
+    Ok(process_compact_trie(tries.compact).map_err(TraceParsingError::from)?)
 }
 
-fn process_separate_trie_pre_images(tries: SeparateTriePreImages) -> ProcessedBlockTracePreImages {
+fn process_separate_trie_pre_images(
+    tries: SeparateTriePreImages,
+) -> TraceParsingResult<ProcessedBlockTracePreImages> {
     let tries = PartialTriePreImages {
         state: process_state_trie(tries.state),
         storage: process_storage_tries(tries.storage),
     };
 
-    ProcessedBlockTracePreImages {
+    Ok(ProcessedBlockTracePreImages {
         tries,
         extra_code_hash_mappings: None,
-    }
+    })
 }
 
 fn process_state_trie(trie: SeparateTriePreImage) -> HashedPartialTrie {
@@ -197,14 +197,17 @@ fn process_multiple_storage_tries(
     todo!()
 }
 
-fn process_compact_trie(trie: TrieCompact) -> ProcessedBlockTracePreImages {
-    // TODO: Wrap in proper result type...
-    let out = process_compact_prestate_debug(trie).unwrap();
+fn process_compact_trie(trie: TrieCompact) -> CompactParsingResult<ProcessedBlockTracePreImages> {
+    let out = process_compact_prestate_debug(trie)?;
 
-    // TODO: Make this into a result...
-    assert!(out.header.version_is_compatible(COMPATIBLE_HEADER_VERSION));
+    if !out.header.version_is_compatible(COMPATIBLE_HEADER_VERSION) {
+        return Err(CompactParsingError::IncompatibleVersion(
+            COMPATIBLE_HEADER_VERSION,
+            out.header.version,
+        ));
+    }
 
-    out.into()
+    Ok(out.into())
 }
 
 /// Structure storing a function turning a `CodeHash` into bytes.

--- a/trace_decoder/src/types.rs
+++ b/trace_decoder/src/types.rs
@@ -1,38 +1,32 @@
 use ethereum_types::{Address, H256, U256};
-use evm_arithmetization::{
-    generation::GenerationInputs,
-    proof::{BlockHashes, BlockMetadata},
-};
-use mpt_trie::{nibbles::Nibbles, partial_trie::HashedPartialTrie};
+use evm_arithmetization::proof::{BlockHashes, BlockMetadata};
+use mpt_trie::nibbles::Nibbles;
 use serde::{Deserialize, Serialize};
 
-// TODO: Make these types in the doc comments point to the actual types...
-/// A type alias for `[U256; 8]` of a bloom filter.
+/// A type alias for `[`[`U256`]`; 8]` of a bloom filter.
 pub type Bloom = [U256; 8];
-/// A type alias for `H256` of a code hash.
+/// A type alias for [`H256`] of a code hash.
 pub type CodeHash = H256;
-/// A type alias for `H256` of an account address's hash.
+/// A type alias for [`H256`] of an account address's hash.
 pub type HashedAccountAddr = H256;
-/// A type alias for `Nibbles` of an account address's hash.
+/// A type alias for [`Nibbles`] of an account address's hash.
 pub type HashedAccountAddrNibbles = Nibbles;
-/// A type alias for `H256` of a node address's hash.
+/// A type alias for [`H256`] of a node address's hash.
 pub type HashedNodeAddr = H256;
-/// A type alias for `H256` of a storage address's hash.
+/// A type alias for [`H256`] of a storage address's hash.
 pub type HashedStorageAddr = H256;
-/// A type alias for `Nibbles` of a hashed storage address's nibbles.
+/// A type alias for [`Nibbles`] of a hashed storage address's nibbles.
 pub type HashedStorageAddrNibbles = Nibbles;
-/// A type alias for `H256` of a storage address.
+/// A type alias for [`H256`] of a storage address.
 pub type StorageAddr = H256;
-/// A type alias for `H256` of a storage address's nibbles.
+/// A type alias for [`H256`] of a storage address's nibbles.
 pub type StorageAddrNibbles = H256;
-/// A type alias for `U256` of a storage value.
+/// A type alias for [`U256`] of a storage value.
 pub type StorageVal = U256;
-/// A type alias for `H256` of a trie root hash.
+/// A type alias for [`H256`] of a trie root hash.
 pub type TrieRootHash = H256;
-/// A type alias for `usize` of a transaction's index within a block.
+/// A type alias for [`usize`] of a transaction's index within a block.
 pub type TxnIdx = usize;
-
-pub(crate) type TriePathIter = mpt_trie::special_query::TriePathIter<HashedPartialTrie>;
 
 /// A function which turns a code hash into bytes.
 pub trait CodeHashResolveFunc = Fn(&CodeHash) -> Vec<u8>;

--- a/trace_decoder/src/utils.rs
+++ b/trace_decoder/src/utils.rs
@@ -1,8 +1,7 @@
 use ethereum_types::H256;
 use keccak_hash::keccak;
-use log::debug;
+use log::trace;
 use mpt_trie::{
-    nibbles::Nibbles,
     partial_trie::{HashedPartialTrie, PartialTrie},
     trie_ops::ValOrHash,
 };
@@ -22,7 +21,7 @@ pub(crate) fn update_val_if_some<T>(target: &mut T, opt: Option<T>) {
 // TODO: Move under a feature flag...
 pub(crate) fn print_value_and_hash_nodes_of_trie(trie: &HashedPartialTrie) {
     let trie_elems = print_value_and_hash_nodes_of_trie_common(trie);
-    println!("State trie {:#?}", trie_elems);
+    trace!("State trie {:#?}", trie_elems);
 }
 
 // TODO: Move under a feature flag...
@@ -31,7 +30,7 @@ pub(crate) fn print_value_and_hash_nodes_of_storage_trie(
     trie: &HashedPartialTrie,
 ) {
     let trie_elems = print_value_and_hash_nodes_of_trie_common(trie);
-    debug!("Storage trie for {:x}: {:#?}", s_trie_addr, trie_elems);
+    trace!("Storage trie for {:x}: {:#?}", s_trie_addr, trie_elems);
 }
 
 // TODO: Move under a feature flag...
@@ -45,18 +44,6 @@ fn print_value_and_hash_nodes_of_trie_common(trie: &HashedPartialTrie) -> Vec<St
             format!("{} - {:x}", v_or_h_char, k)
         })
         .collect()
-}
-
-pub(crate) fn h_addr_nibs_to_h256(h_addr_nibs: &Nibbles) -> H256 {
-    // TODO: HACK! This fix really needs to be in `mpt_trie`...
-    let mut nib_bytes = h_addr_nibs.bytes_be();
-    if nib_bytes.len() < 32 {
-        for _ in nib_bytes.len()..32 {
-            nib_bytes.insert(0, 0);
-        }
-    }
-
-    H256::from_slice(&nib_bytes)
 }
 
 pub(crate) fn optional_field<T: std::fmt::Debug>(label: &str, value: Option<T>) -> String {


### PR DESCRIPTION
The condition `disable_jemalloc` wasn't set properly, hence always evaluating to `false`.
This fixes it.

Note that due to the force-push on `develop`, the history of this PR with the merge commit looks odd, but the only _actual_ diff is on the last commit:

```diff
-      #[cfg(not(any(target_env = "msvc", disable_jemalloc)))]
+      #[cfg(not(any(target_env = "msvc", feature = "disable_jemalloc")))]
#[global_allocator]
static GLOBAL: Jemalloc = Jemalloc;

```