### PR TITLE
fix: `clippy::doc_lazy_continuation`

### DIFF
--- a/evm_arithmetization/src/arithmetic/addcy.rs
+++ b/evm_arithmetization/src/arithmetic/addcy.rs
@@ -84,8 +84,9 @@ const GOLDILOCKS_INVERSE_65536: u64 = 18446462594437939201;
 ///
 /// If `N_LIMBS = 1`, then this amounts to verifying that either `x_0
 /// + y_0 = z_0` or `x_0 + y_0 == z_0 + cy*2^16` (this is `t` on line
-/// 127ff). Ok. Now assume the constraints are valid for `N_LIMBS =
-/// n-1`. Then by induction,
+/// 127ff). Ok. Now assume the constraints are valid for `N_LIMBS = n-1`.
+///
+/// Then by induction,
 ///
 /// \sum_{i=0}^{n-1} (x_i + y_i) * 2^(16*i) + (x_n + y_n)*2^(16*n) ==
 /// \sum_{i=0}^{n-1} z_i * 2^(16*i) + cy_{n-1}*2^(16*n) + z_n*2^(16*n)

--- a/evm_arithmetization/src/cpu/decode.rs
+++ b/evm_arithmetization/src/cpu/decode.rs
@@ -8,20 +8,24 @@ use starky::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsume
 use crate::cpu::columns::{CpuColumnsView, COL_MAP};
 
 /// List of opcode blocks
-///  Each block corresponds to exactly one flag, and each flag corresponds to
+/// Each block corresponds to exactly one flag, and each flag corresponds to
 /// exactly one block.  Each block of opcodes:
+///
 /// - is contiguous,
 /// - has a length that is a power of 2, and
 /// - its start index is a multiple of its length (it is aligned).
-///  These properties permit us to check if an opcode belongs to a block of
+///
+/// These properties permit us to check if an opcode belongs to a block of
 /// length 2^n by checking its top 8-n bits.
-///  Additionally, each block can be made available only to the user, only to
+///
+/// Additionally, each block can be made available only to the user, only to
 /// the kernel, or to both. This is mainly useful for making some instructions
 /// kernel-only, while still decoding to invalid for the user. We do this by
 /// making one kernel-only block and another user-only block. The exception is
 /// the PANIC instruction which is user-only without a corresponding kernel
 /// block. This makes the proof unverifiable when PANIC is executed in kernel
 /// mode, which is the intended behavior.
+///
 /// Note: invalid opcodes are not represented here. _Any_ opcode is permitted to
 /// decode to `is_invalid`. The kernel then verifies that the opcode was
 /// _actually_ invalid.

--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -312,15 +312,12 @@ where
     /// # Arguments
     ///
     /// - `skip_tables`: a boolean indicating whether to serialize only the
-    ///   upper circuits
-    /// or the entire prover state, including recursive circuits to shrink STARK
-    /// proofs.
+    ///   upper circuits or the entire prover state, including recursive
+    ///   circuits to shrink STARK proofs.
     /// - `gate_serializer`: a custom gate serializer needed to serialize
-    ///   recursive circuits
-    /// common data.
+    ///   recursive circuits common data.
     /// - `generator_serializer`: a custom generator serializer needed to
-    ///   serialize recursive
-    /// circuits proving data.
+    ///   serialize recursive circuits proving data.
     pub fn to_bytes(
         &self,
         skip_tables: bool,
@@ -351,15 +348,12 @@ where
     ///
     /// - `bytes`: a slice of bytes to deserialize this prover state from.
     /// - `skip_tables`: a boolean indicating whether to deserialize only the
-    ///   upper circuits
-    /// or the entire prover state, including recursive circuits to shrink STARK
-    /// proofs.
+    ///   upper circuits or the entire prover state, including recursive
+    ///   circuits to shrink STARK proofs.
     /// - `gate_serializer`: a custom gate serializer needed to serialize
-    ///   recursive circuits
-    /// common data.
+    ///   recursive circuits common data.
     /// - `generator_serializer`: a custom generator serializer needed to
-    ///   serialize recursive
-    /// circuits proving data.
+    ///   serialize recursive circuits proving data.
     pub fn from_bytes(
         bytes: &[u8],
         skip_tables: bool,
@@ -420,10 +414,10 @@ where
     /// # Arguments
     ///
     /// - `all_stark`: a structure defining the logic of all STARK modules and
-    ///   their associated
-    /// cross-table lookups.
+    ///   their associated cross-table lookups.
     /// - `degree_bits_ranges`: the logarithmic ranges to be supported for the
     ///   recursive tables.
+    ///
     /// Transactions may yield arbitrary trace lengths for each STARK module
     /// (within some bounds), unknown prior generating the witness to create
     /// a proof. Thus, for each STARK module, we construct a map from
@@ -432,8 +426,7 @@ where
     /// for this STARK module. Specifying a wide enough range allows a
     /// prover to cover all possible scenarios.
     /// - `stark_config`: the configuration to be used for the STARK prover. It
-    ///   will usually be a fast
-    /// one yielding large proofs.
+    ///   will usually be a fast one yielding large proofs.
     pub fn new(
         all_stark: &AllStark<F, D>,
         degree_bits_ranges: &[Range<usize>; NUM_TABLES],
@@ -1002,20 +995,16 @@ where
     /// # Arguments
     ///
     /// - `all_stark`: a structure defining the logic of all STARK modules and
-    ///   their associated
-    /// cross-table lookups.
+    ///   their associated cross-table lookups.
     /// - `config`: the configuration to be used for the STARK prover. It will
-    ///   usually be a fast
-    /// one yielding large proofs.
+    ///   usually be a fast one yielding large proofs.
     /// - `generation_inputs`: a transaction and auxiliary data needed to
-    ///   generate a proof, provided
-    /// in Intermediary Representation.
+    ///   generate a proof, provided in Intermediary Representation.
     /// - `timing`: a profiler defining a scope hierarchy and the time consumed
     ///   by each one.
     /// - `abort_signal`: an optional [`AtomicBool`] wrapped behind an [`Arc`],
-    ///   to send a kill signal
-    /// early. This is only necessary in a distributed setting where a worker
-    /// may be blocking the entire queue.
+    ///   to send a kill signal early. This is only necessary in a distributed
+    ///   setting where a worker may be blocking the entire queue.
     ///
     /// # Outputs
     ///
@@ -1199,14 +1188,12 @@ where
     /// # Arguments
     ///
     /// - `lhs_is_agg`: a boolean indicating whether the left child proof is an
-    ///   aggregation proof or
-    /// a regular transaction proof.
+    ///   aggregation proof or a regular transaction proof.
     /// - `lhs_proof`: the left child proof.
     /// - `lhs_public_values`: the public values associated to the right child
     ///   proof.
     /// - `rhs_is_agg`: a boolean indicating whether the right child proof is an
-    ///   aggregation proof or
-    /// a regular transaction proof.
+    ///   aggregation proof or a regular transaction proof.
     /// - `rhs_proof`: the right child proof.
     /// - `rhs_public_values`: the public values associated to the right child
     ///   proof.
@@ -1293,9 +1280,8 @@ where
     /// # Arguments
     ///
     /// - `opt_parent_block_proof`: an optional parent block proof. Passing one
-    ///   will generate a proof of
-    /// validity for both the block range covered by the previous proof and the
-    /// current block.
+    ///   will generate a proof of validity for both the block range covered by
+    ///   the previous proof and the current block.
     /// - `agg_root_proof`: the final aggregation proof containing all
     ///   transactions within the current block.
     /// - `public_values`: the public values associated to the aggregation

--- a/evm_arithmetization/src/prover.rs
+++ b/evm_arithmetization/src/prover.rs
@@ -177,6 +177,7 @@ where
 /// - `trace_poly_values` are the trace values for each STARK.
 /// - `trace_commitments` are the trace polynomials commitments for each STARK.
 /// - `ctl_data_per_table` group all the cross-table lookup data for each STARK.
+///
 /// Each STARK uses its associated data to generate a proof.
 fn prove_with_commitments<F, C, const D: usize>(
     all_stark: &AllStark<F, D>,


### PR DESCRIPTION
Triggered since 1.80.
No concrete changes, just documentation indentation tweaks.