### PR TITLE
fix(cancun): dummy payloads and public input retrieval

### DIFF
--- a/evm_arithmetization/src/proof.rs
+++ b/evm_arithmetization/src/proof.rs
@@ -211,12 +211,12 @@ impl BlockMetadata {
             (pis[18].to_canonical_u64() + (pis[19].to_canonical_u64() << 32)).into();
         let block_gas_used = pis[20].to_canonical_u64().into();
         let block_blob_gas_used =
-            (pis[23].to_canonical_u64() + (pis[24].to_canonical_u64() << 32)).into();
+            (pis[21].to_canonical_u64() + (pis[22].to_canonical_u64() << 32)).into();
         let block_excess_blob_gas =
-            (pis[25].to_canonical_u64() + (pis[26].to_canonical_u64() << 32)).into();
-        let parent_beacon_block_root = get_h256(&pis[27..35]);
+            (pis[23].to_canonical_u64() + (pis[24].to_canonical_u64() << 32)).into();
+        let parent_beacon_block_root = get_h256(&pis[25..33]);
         let block_bloom =
-            core::array::from_fn(|i| h2u(get_h256(&pis[35 + 8 * i..35 + 8 * (i + 1)])));
+            core::array::from_fn(|i| h2u(get_h256(&pis[33 + 8 * i..33 + 8 * (i + 1)])));
 
         Self {
             block_beneficiary,

--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -647,7 +647,7 @@ impl ProcessedBlockTrace {
                 withdrawals_with_hashed_addrs_iter().map(|(_, h_addr, _)| h_addr);
 
             let additional_paths = if last_inputs.txn_number_before == 0.into() {
-                // We need to include the beacon roots contract as this is payload is at the
+                // We need to include the beacon roots contract as this payload is at the
                 // start of the block execution.
                 vec![Nibbles::from_h256_be(H256(
                     BEACON_ROOTS_CONTRACT_ADDRESS_HASHED,

--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -256,13 +256,12 @@ impl ProcessedBlockTrace {
         let mut txn_gen_inputs = self
             .txn_info
             .into_iter()
-            .enumerate()
-            .map(|(idx, txn_info)| {
+            .map(|txn_info| {
                 let current_idx = txn_idx;
                 if !txn_info.meta.is_dummy() {
                     txn_idx += 1;
                 }
-                let is_initial_payload = idx == 0;
+                let is_initial_payload = txn_idx == 0;
 
                 Self::process_txn_info(
                     current_idx,
@@ -716,7 +715,7 @@ impl ProcessedBlockTrace {
         );
         // For each non-dummy txn, we increment `txn_number_after` by 1, and
         // update `gas_used_after` accordingly.
-        extra_data.txn_number_after += U256::one();
+        extra_data.txn_number_after += U256::from(!txn_info.meta.is_dummy() as u8);
         extra_data.gas_used_after += txn_info.meta.gas_used.into();
 
         // Because we need to run delta application before creating the minimal
@@ -772,7 +771,7 @@ impl ProcessedBlockTrace {
 
         // After processing a transaction, we update the remaining accumulators
         // for the next transaction.
-        extra_data.txn_number_before += U256::one();
+        extra_data.txn_number_before = extra_data.txn_number_after;
         extra_data.gas_used_before = extra_data.gas_used_after;
 
         Ok(gen_inputs)

--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -257,11 +257,12 @@ impl ProcessedBlockTrace {
             .txn_info
             .into_iter()
             .map(|txn_info| {
+                let is_initial_payload = txn_idx == 0;
+
                 let current_idx = txn_idx;
                 if !txn_info.meta.is_dummy() {
                     txn_idx += 1;
                 }
-                let is_initial_payload = txn_idx == 0;
 
                 Self::process_txn_info(
                     current_idx,


### PR DESCRIPTION
Small fixes for cancun:

- the decoder was only adding the beacon block roots contract to the state trie preimage for the first payload, which was causing a Kernel panic in case of empty blocks (the second dummy payload has txn_nb = 0 and would attempt to access it as well)
- the second dummy payload for an empty block would have a txn counter set to 1 instead of 0
- following `blobbasefee` removal from block metadata, the `from_public_inputs` method hadn't been updated accordingly.