### PR TITLE
fix(cancun): `mcopy` check offsets

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/memory/metadata.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/metadata.asm
@@ -433,6 +433,15 @@ zero_hash:
     // stack: (empty)
 %endmacro
 
+// Faults if the given offset is "out of range", i.e. does not fit in a single memory limb.
+%macro ensure_offset_in_range
+    // stack: offset
+    %gt_const(0xffffffff)
+    // stack: is_overflow
+    %jumpi(fault_exception)
+    // stack: (empty)
+%endmacro
+
 // Convenience macro for checking if the current context is static.
 // Called before state-changing opcodes.
 %macro check_static

--- a/evm_arithmetization/src/cpu/kernel/asm/memory/metadata.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/metadata.asm
@@ -433,15 +433,6 @@ zero_hash:
     // stack: (empty)
 %endmacro
 
-// Faults if the given offset is "out of range", i.e. does not fit in a single memory limb.
-%macro ensure_offset_in_range
-    // stack: offset
-    %gt_const(0xffffffff)
-    // stack: is_overflow
-    %jumpi(fault_exception)
-    // stack: (empty)
-%endmacro
-
 // Convenience macro for checking if the current context is static.
 // Called before state-changing opcodes.
 %macro check_static

--- a/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
@@ -225,15 +225,14 @@ global sys_mcopy:
     // stack: kexit_info, dest_offset, offset, size
     %wcopy_charge_gas
 
-    // stack: kexit_info, dest_offset, offset, size
-    DUP2
-    %ensure_offset_in_range
-    DUP3
-    %ensure_offset_in_range
-
     %stack (kexit_info, dest_offset, offset, size) -> (dest_offset, size, kexit_info, dest_offset, offset, size)
     %add_or_fault
     // stack: expanded_num_bytes, kexit_info, dest_offset, offset, size, kexit_info
+    DUP1 %ensure_reasonable_offset
+    %update_mem_bytes
+
+    %stack (kexit_info, dest_offset, offset, size) -> (offset, size, kexit_info, dest_offset, offset, size)
+    %add_or_fault
     DUP1 %ensure_reasonable_offset
     %update_mem_bytes
 

--- a/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
@@ -112,7 +112,7 @@ calldataload_large_offset:
 codecopy_within_bounds:
     // stack: total_size, segment, src_ctx, kexit_info, dest_offset, offset, size
     POP
-global wcopy_within_bounds:
+wcopy_within_bounds:
     // TODO: rework address creation to have less stack manipulation overhead
     // stack: segment, src_ctx, kexit_info, dest_offset, offset, size
     GET_CONTEXT
@@ -123,17 +123,17 @@ global wcopy_within_bounds:
     // stack: DST, SRC, size, wcopy_after, kexit_info
     %jump(memcpy_bytes)
 
-global wcopy_empty:
+wcopy_empty:
     // stack: Gverylow, kexit_info, dest_offset, offset, size
     %charge_gas
     %stack (kexit_info, dest_offset, offset, size) -> (kexit_info)
     EXIT_KERNEL
 
 
-global codecopy_large_offset:
+codecopy_large_offset:
     // stack: total_size, src_ctx, kexit_info, dest_offset, offset, size
     %pop2
-global wcopy_large_offset:
+wcopy_large_offset:
     // offset is larger than the size of the {CALLDATA,CODE,RETURNDATA}. So we just have to write zeros.
     // stack: kexit_info, dest_offset, offset, size
     GET_CONTEXT
@@ -142,7 +142,7 @@ global wcopy_large_offset:
     %build_address
     %jump(memset)
 
-global wcopy_after:
+wcopy_after:
     // stack: kexit_info
     EXIT_KERNEL
 
@@ -260,7 +260,7 @@ global sys_mcopy:
     // stack: segment, context, kexit_info, dest_offset, offset, size
     %jump(wcopy_within_bounds)
 
-global mcopy_with_overlap:
+mcopy_with_overlap:
     // We do have an overlap between the SRC and DST ranges. We will first copy the overlapping segment
     // (i.e. end of the copy portion), then copy the remaining (i.e. beginning) portion. 
 

--- a/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
@@ -112,7 +112,7 @@ calldataload_large_offset:
 codecopy_within_bounds:
     // stack: total_size, segment, src_ctx, kexit_info, dest_offset, offset, size
     POP
-wcopy_within_bounds:
+global wcopy_within_bounds:
     // TODO: rework address creation to have less stack manipulation overhead
     // stack: segment, src_ctx, kexit_info, dest_offset, offset, size
     GET_CONTEXT
@@ -123,17 +123,17 @@ wcopy_within_bounds:
     // stack: DST, SRC, size, wcopy_after, kexit_info
     %jump(memcpy_bytes)
 
-wcopy_empty:
+global wcopy_empty:
     // stack: Gverylow, kexit_info, dest_offset, offset, size
     %charge_gas
     %stack (kexit_info, dest_offset, offset, size) -> (kexit_info)
     EXIT_KERNEL
 
 
-codecopy_large_offset:
+global codecopy_large_offset:
     // stack: total_size, src_ctx, kexit_info, dest_offset, offset, size
     %pop2
-wcopy_large_offset:
+global wcopy_large_offset:
     // offset is larger than the size of the {CALLDATA,CODE,RETURNDATA}. So we just have to write zeros.
     // stack: kexit_info, dest_offset, offset, size
     GET_CONTEXT
@@ -142,7 +142,7 @@ wcopy_large_offset:
     %build_address
     %jump(memset)
 
-wcopy_after:
+global wcopy_after:
     // stack: kexit_info
     EXIT_KERNEL
 
@@ -225,6 +225,12 @@ global sys_mcopy:
     // stack: kexit_info, dest_offset, offset, size
     %wcopy_charge_gas
 
+    // stack: kexit_info, dest_offset, offset, size
+    DUP2
+    %ensure_offset_in_range
+    DUP3
+    %ensure_offset_in_range
+
     %stack (kexit_info, dest_offset, offset, size) -> (dest_offset, size, kexit_info, dest_offset, offset, size)
     %add_or_fault
     // stack: expanded_num_bytes, kexit_info, dest_offset, offset, size, kexit_info
@@ -255,7 +261,7 @@ global sys_mcopy:
     // stack: segment, context, kexit_info, dest_offset, offset, size
     %jump(wcopy_within_bounds)
 
-mcopy_with_overlap:
+global mcopy_with_overlap:
     // We do have an overlap between the SRC and DST ranges. We will first copy the overlapping segment
     // (i.e. end of the copy portion), then copy the remaining (i.e. beginning) portion. 
 

--- a/evm_arithmetization/src/cpu/kernel/tests/mcopy.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mcopy.rs
@@ -1,0 +1,114 @@
+use anyhow::Result;
+use ethereum_types::U256;
+use hex_literal::hex;
+use itertools::Itertools;
+use plonky2::field::goldilocks_field::GoldilocksField as F;
+
+use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
+use crate::cpu::kernel::interpreter::Interpreter;
+use crate::memory::segments::Segment;
+use crate::testing_utils::init_logger;
+
+fn test_mcopy(
+    dest_offset: usize,
+    offset: usize,
+    size: usize,
+    pre_memory: &[u8],
+    post_memory: &[u8],
+) -> Result<()> {
+    init_logger();
+
+    let sys_mcopy = crate::cpu::kernel::aggregator::KERNEL.global_labels["sys_mcopy"];
+    let kexit_info = U256::from(0xdeadbeefu32) + (U256::from(u64::from(true)) << 32);
+    let initial_stack = vec![size.into(), offset.into(), dest_offset.into(), kexit_info];
+
+    let mut interpreter: Interpreter<F> = Interpreter::new(sys_mcopy, initial_stack);
+    interpreter.set_context_metadata_field(
+        0,
+        ContextMetadata::GasLimit,
+        U256::from(1000000000000u64),
+    );
+
+    let pre_memory: Vec<U256> = pre_memory.iter().map(|&b| b.into()).collect_vec();
+    let post_memory: Vec<U256> = post_memory.iter().map(|&b| b.into()).collect_vec();
+
+    interpreter.set_memory_segment(Segment::MainMemory, pre_memory);
+    interpreter.run()?;
+
+    let main_memory_data = interpreter.get_memory_segment(Segment::MainMemory);
+    assert_eq!(&main_memory_data, &post_memory);
+
+    Ok(())
+}
+
+#[test]
+fn test_mcopy_0_32_32() {
+    let dest_offset = 0;
+    let offset = 32;
+    let size = 32;
+    let pre_memory = hex!("0000000000000000000000000000000000000000000000000000000000000000000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+    let post_memory = hex!("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+
+    assert!(test_mcopy(dest_offset, offset, size, &pre_memory, &post_memory).is_ok())
+}
+
+#[test]
+fn test_mcopy_0_0_32() {
+    let dest_offset = 0;
+    let offset = 0;
+    let size = 32;
+    let pre_memory = hex!("0101010101010101010101010101010101010101010101010101010101010101");
+    let post_memory = hex!("0101010101010101010101010101010101010101010101010101010101010101");
+
+    assert!(test_mcopy(dest_offset, offset, size, &pre_memory, &post_memory).is_ok())
+}
+
+#[test]
+fn test_mcopy_0_1_8() {
+    let dest_offset = 0;
+    let offset = 1;
+    let size = 8;
+    let pre_memory = hex!("0001020304050607080000000000000000000000000000000000000000000000");
+    let post_memory = hex!("0102030405060708080000000000000000000000000000000000000000000000");
+
+    assert!(test_mcopy(dest_offset, offset, size, &pre_memory, &post_memory).is_ok())
+}
+
+#[test]
+fn test_mcopy_1_0_8() {
+    let dest_offset = 1;
+    let offset = 0;
+    let size = 8;
+    let pre_memory = hex!("0001020304050607080000000000000000000000000000000000000000000000");
+    let post_memory = hex!("0000010203040506070000000000000000000000000000000000000000000000");
+
+    assert!(test_mcopy(dest_offset, offset, size, &pre_memory, &post_memory).is_ok())
+}
+
+#[test]
+fn test_mcopy_1_0_33() {
+    init_logger();
+    let dest_offset = 1;
+    let offset = 0;
+    let size = 33;
+    let pre_memory =
+        hex!("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f2021222324252627");
+    let post_memory =
+        hex!("00000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20222324252627");
+
+    assert!(test_mcopy(dest_offset, offset, size, &pre_memory, &post_memory).is_ok())
+}
+
+#[test]
+fn test_mcopy_1_2_33() {
+    init_logger();
+    let dest_offset = 1;
+    let offset = 2;
+    let size = 33;
+    let pre_memory =
+        hex!("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728");
+    let post_memory =
+        hex!("0002030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20212222232425262728");
+
+    assert!(test_mcopy(dest_offset, offset, size, &pre_memory, &post_memory).is_ok())
+}

--- a/evm_arithmetization/src/cpu/kernel/tests/mod.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mod.rs
@@ -13,6 +13,7 @@ mod exp;
 mod hash;
 mod kernel_consistency;
 mod log;
+mod mcopy;
 mod mpt;
 mod packing;
 mod receipt;


### PR DESCRIPTION
Noticed while working with John's edge case txns.
We aren't checking for valid memory offsets, which would then cause the prover to panic and abort when performing the mem_cpy.

@wborgeaud I noticed we aren't performing this check for the other syscalls of the `wcopy` family. Don't you think we should?

Makes 4th txn of [witness-0233.json](https://github.com/0xPolygonZero/zk_evm/files/15458369/witness-0233.json) pass.
