### PR TITLE
fix(cancun): encode calldata for EIP-4780 as `U256`

### DIFF
--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -311,7 +311,10 @@ impl ProcessedBlockTrace {
         let timestamp = rlp::encode(&block_data.block_timestamp).to_vec();
 
         let root_idx = timestamp_idx + HISTORY_BUFFER_LENGTH_MOD;
-        let calldata = rlp::encode(&block_data.parent_beacon_block_root).to_vec();
+        let calldata = rlp::encode(&U256::from_big_endian(
+            &block_data.parent_beacon_block_root.0,
+        ))
+        .to_vec();
 
         let storage_trie = trie_state
             .storage


### PR DESCRIPTION
`calldata` for initial payload as per EIP-4780 is currently encoded directly from its `H256` value, which may mess the final storage trie root when the hash MSB is 0. Switching its type to a `U256` before RLP encoding (as actual storage slot type is) fixes this edge case.

Detected with [witness-0007.json](https://github.com/0xPolygonZero/zk_evm/files/15462155/witness-0007.json)
