### PR TITLE
fix(cancun): correct search loop in transient storage

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/journal/transient_storage_change.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/journal/transient_storage_change.asm
@@ -9,13 +9,15 @@ global revert_transient_storage_change:
     POP
     %journal_load_3
     // We will always write 0 for deletions as it makes no difference.
-    // stack: address, slot, prev_value, retdest
+    // stack: addr, slot, prev_value, retdest
     %search_transient_storage
+    // stack: found, pos, addr, value, slot, prev_value, retdest
     // The value must have been stored
     %assert_nonzero
-    // stack: pos, addr, value, key, prev_value, retdest
+    // stack: pos, addr, value, slot, prev_value, retdest
     %add_const(2)
     DUP5
+    // stack: prev_value, pos+2, addr, value, slot, prev_value, retdest
     MSTORE_GENERAL
     %pop4
     JUMP

--- a/evm_arithmetization/src/cpu/kernel/asm/main.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/main.asm
@@ -15,6 +15,9 @@ global main:
     // Initialize accessed addresses and storage keys lists
     %init_access_lists
 
+    // Initialize transient storage length
+    %init_transient_storage_len
+
     // Initialize the RLP DATA pointer to its initial position, 
     // skipping over the preinitialized empty node.
     PUSH @INITIAL_TXN_RLP_ADDR


### PR DESCRIPTION
The condition `If pos'' > @GLOBAL_METADATA_TRANSIENT_STORAGE_LEN we need to update the length` was always satisfied, because we were comparing the scaled `pos` with the unscaled `len`.

This PR also changes the length to be stored to be always scaled to reduce overhead in the loop, as well as fixes some stack comments / adds some more.