### PR TITLE
Added `Clone` to a few error types in `mpt_trie`

### DIFF
--- a/mpt_trie/src/nibbles.rs
+++ b/mpt_trie/src/nibbles.rs
@@ -72,7 +72,7 @@ pub trait ToNibbles {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 /// Errors encountered when converting from `Bytes` to `Nibbles`.
 pub enum BytesToNibblesError {
     #[error("Tried constructing `Nibbles` from a zero byte slice")]
@@ -97,7 +97,7 @@ pub enum FromHexPrefixError {
 }
 
 /// Error type for conversion.
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 pub enum NibblesToTypeError {
     #[error("Overflow encountered when converting to U256: {0}")]
     /// Overflow encountered.

--- a/mpt_trie/src/trie_ops.rs
+++ b/mpt_trie/src/trie_ops.rs
@@ -19,7 +19,7 @@ use crate::{
 pub type TrieOpResult<T> = Result<T, TrieOpError>;
 
 /// An error type for trie operation.
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 pub enum TrieOpError {
     /// An error that occurs when a hash node is found during an insert
     /// operation.


### PR DESCRIPTION
This change is already in upstream (`develop`), but now `trace_decoder` which relies on `feat/type2` needs this as well, so this is just a simple back-port.