### PR TITLE
perf: Charge gas before `tload` search

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/memory/transient_storage.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/transient_storage.asm
@@ -96,12 +96,13 @@ tload_found:
 // Post stack: value
 global sys_tload:
     // stack: kexit_info, slot
+    %charge_gas_const(@GAS_WARMACCESS)
+    // stack: kexit_info, slot
     SWAP1
     // stack: slot, kexit_info
     %tload_current
     SWAP1
 
-    %charge_gas_const(@GAS_WARMACCESS)
     // stack: kexit_info, value
     EXIT_KERNEL
 


### PR DESCRIPTION
Fairly minor PR, but should help a bit for transient storage heavy contracts.