### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2024-06-12
+
 ### Changed
+- Some cleanup ([#190](https://github.com/0xPolygonZero/zk_evm/pull/190))
+- Silence jumpdest analysis logs ([#193](https://github.com/0xPolygonZero/zk_evm/pull/193))
+- Charge call value gas prior to call ([#199](https://github.com/0xPolygonZero/zk_evm/pull/199))
+- refactor: fix todos ([#162](https://github.com/0xPolygonZero/zk_evm/pull/162))
+- Remove print call in trace_decoder ([#208](https://github.com/0xPolygonZero/zk_evm/pull/208))
+- Update CODEOWNERS ([#224](https://github.com/0xPolygonZero/zk_evm/pull/224))
+- Fix access lists pointers check ([#217](https://github.com/0xPolygonZero/zk_evm/pull/217))
 - Add a few QoL useability functions to the interface ([#169](https://github.com/0xPolygonZero/zk_evm/pull/169))
+- Amortize `sha2` compression loop ([#231](https://github.com/0xPolygonZero/zk_evm/pull/231))
+- ci: add cargo audit job ([#236](https://github.com/0xPolygonZero/zk_evm/pull/236))
+- fix: Revert interpreter stack display ([#238](https://github.com/0xPolygonZero/zk_evm/pull/238))
+- Fix clippy `doc_lazy_continuation` ([#247](https://github.com/0xPolygonZero/zk_evm/pull/247))
+- perf: Improve `blake2` precompile ([#239](https://github.com/0xPolygonZero/zk_evm/pull/239))
+- fix: rustdoc and tests ([#255](https://github.com/0xPolygonZero/zk_evm/pull/255))
+- Native trace processing support ([#246](https://github.com/0xPolygonZero/zk_evm/pull/246))
+- Added `Clone` to a few error types in `mpt_trie` ([#259](https://github.com/0xPolygonZero/zk_evm/pull/259))
+- cleanup: remove outdated segment ([#262](https://github.com/0xPolygonZero/zk_evm/pull/262))
+- fix: add G2 subgroup check for `ECPAIRING` ([#268](https://github.com/0xPolygonZero/zk_evm/pull/268))
+- add partial trie builder ([#258](https://github.com/0xPolygonZero/zk_evm/pull/258))
 
 ## [0.3.1] - 2024-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.2] - 2024-06-12
+## [0.4.0] - 2024-06-12
 
 ### Changed
 - Some cleanup ([#190](https://github.com/0xPolygonZero/zk_evm/pull/190))

--- a/evm_arithmetization/Cargo.toml
+++ b/evm_arithmetization/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "evm_arithmetization"
 description = "Implementation of STARKs for the Ethereum Virtual Machine"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Daniel Lubarov <daniel@lubarov.com>", "William Borgeaud <williamborgeaud@gmail.com>"]
 readme = "README.md"
 categories = ["cryptography"]
@@ -41,7 +41,7 @@ tiny-keccak = "2.0.2"
 serde_json = { workspace = true }
 
 # Local dependencies
-mpt_trie = { version = "0.2.1", path = "../mpt_trie" }
+mpt_trie = { version = "0.3.0", path = "../mpt_trie" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.5.0"

--- a/mpt_trie/Cargo.toml
+++ b/mpt_trie/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mpt_trie"
 description = "Types and utility functions for building/working with partial Ethereum tries."
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Polygon Zero <bgluth@polygon.technology>"]
 readme = "README.md"
 edition.workspace = true

--- a/proof_gen/Cargo.toml
+++ b/proof_gen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "proof_gen"
 description = "Generates block proofs from zero proof IR."
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Polygon Zero <bgluth@polygon.technology>"]
 edition.workspace = true
 license.workspace = true
@@ -17,4 +17,4 @@ plonky2 = { workspace = true }
 serde = { workspace = true }
 
 # Local dependencies
-evm_arithmetization = { version = "0.1.3", path = "../evm_arithmetization" }
+evm_arithmetization = { version = "0.2.0", path = "../evm_arithmetization" }

--- a/trace_decoder/Cargo.toml
+++ b/trace_decoder/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trace_decoder"
 description = "Processes trace payloads into Intermediate Representation (IR) format."
 authors = ["Polygon Zero <bgluth@polygon.technology>"]
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -27,8 +27,8 @@ serde_with = "3.4.0"
 thiserror = { workspace = true }
 
 # Local dependencies
-mpt_trie = { version = "0.2.1", path = "../mpt_trie" }
-evm_arithmetization = { version = "0.1.3", path = "../evm_arithmetization" }
+mpt_trie = { version = "0.3.0", path = "../mpt_trie" }
+evm_arithmetization = { version = "0.2.0", path = "../evm_arithmetization" }
 
 [dev-dependencies]
 pretty_env_logger = "0.5.0"


### PR DESCRIPTION
Supersedes #269, without including `plonky2` related dependencies bump.