### PR TITLE
ci: add labeler flag for new `zero-bin` crate + update `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @muursh @Nashtare @cpubot
-/evm_arithmetization/ @wborgeaud @muursh @Nashtare @cpubot
+* @muursh @Nashtare
+/evm_arithmetization/ @wborgeaud @muursh @Nashtare

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,6 +18,11 @@
 - changed-files:
   - any-glob-to-any-file: proof_gen/**
 
+# Add 'crate: zero_bin' label to any changes within 'zero_bin' folder.
+'crate: zero_bin':
+- changed-files:
+  - any-glob-to-any-file: zero_bin/**
+
 # Add 'specs' label to any changes within 'docs' folder.
 'specs':
 - changed-files:


### PR DESCRIPTION
I'll be also migrating all issues from `zero-bin` shortly.