### PR TITLE
misc(zero-bin): fix logging filename for test script

### DIFF
--- a/zero_bin/tools/prove_rpc.sh
+++ b/zero_bin/tools/prove_rpc.sh
@@ -38,7 +38,7 @@ else
 fi
 
 PROOF_OUTPUT_DIR="proofs"
-OUT_LOG_PATH="${PROOF_OUTPUT_DIR}/b${i}.log"
+OUT_LOG_PATH="${PROOF_OUTPUT_DIR}/b$1_$2.log"
 ALWAYS_WRITE_LOGS=0 # Change this to `1` if you always want logs to be written.
 TOT_BLOCKS=$(($2-$1+1))
 


### PR DESCRIPTION
Previous version is probably a leftover from latest refactorings, yielding an empty filename `b.log` which isn't carrying much information on its own.