### PR TITLE
Make leader work no matter what the CWD is

### DIFF
--- a/zero_bin/.cargo/config.toml
+++ b/zero_bin/.cargo/config.toml
@@ -2,3 +2,7 @@
 # https://github.com/rust-lang/rust/pull/124129
 # https://github.com/dtolnay/linkme/pull/88
 rustflags = ["-Zlinker-features=-lld"]
+
+[env]
+# If we're running in the project workspace, then we should set the workspace env var so we read/write to/from files relative to the workspace.
+CARGO_WORKSPACE_DIR = { value = "", relative = true }

--- a/zero_bin/common/src/prover_state/persistence.rs
+++ b/zero_bin/common/src/prover_state/persistence.rs
@@ -17,9 +17,10 @@ use super::{
     Config, RecursiveCircuitsForTableSize, SIZE,
 };
 
-const CIRCUITS_FOLDER: &str = "./circuits";
+const CIRCUITS_DIR: &str = "circuits/";
 const PROVER_STATE_FILE_PREFIX: &str = "prover_state";
 const VERIFIER_STATE_FILE_PREFIX: &str = "verifier_state";
+const CARGO_WORKSPACE_DIR_ENV: &str = "CARGO_WORKSPACE_DIR";
 
 fn get_serializers() -> (
     DefaultGateSerializer,
@@ -72,9 +73,11 @@ pub(crate) trait DiskResource {
         p: &Self::PathConstrutor,
         r: &Self::Resource,
     ) -> Result<(), DiskResourceError<Self::Error>> {
+        let circuits_dir = relative_circuit_dir_path();
+
         // Create the base folder if non-existent.
-        if std::fs::metadata(CIRCUITS_FOLDER).is_err() {
-            std::fs::create_dir(CIRCUITS_FOLDER).map_err(|_| {
+        if std::fs::metadata(&circuits_dir).is_err() {
+            std::fs::create_dir(&circuits_dir).map_err(|_| {
                 DiskResourceError::IoError::<Self::Error>(std::io::Error::other(
                     "Could not create circuits folder",
                 ))
@@ -104,7 +107,7 @@ impl DiskResource for BaseProverResource {
     fn path(p: &Self::PathConstrutor) -> impl AsRef<Path> {
         format!(
             "{}/{}_base_{}_{}",
-            CIRCUITS_FOLDER,
+            &relative_circuit_dir_path(),
             PROVER_STATE_FILE_PREFIX,
             env::var("EVM_ARITHMETIZATION_PKG_VER").unwrap_or("NA".to_string()),
             p.get_configuration_digest()
@@ -140,7 +143,7 @@ impl DiskResource for MonolithicProverResource {
     fn path(p: &Self::PathConstrutor) -> impl AsRef<Path> {
         format!(
             "{}/{}_monolithic_{}_{}",
-            CIRCUITS_FOLDER,
+            &relative_circuit_dir_path(),
             PROVER_STATE_FILE_PREFIX,
             env::var("EVM_ARITHMETIZATION_PKG_VER").unwrap_or("NA".to_string()),
             p.get_configuration_digest()
@@ -175,7 +178,7 @@ impl DiskResource for RecursiveCircuitResource {
     fn path((circuit_type, size): &Self::PathConstrutor) -> impl AsRef<Path> {
         format!(
             "{}/{}_{}_{}_{}",
-            CIRCUITS_FOLDER,
+            &relative_circuit_dir_path(),
             PROVER_STATE_FILE_PREFIX,
             env::var("EVM_ARITHMETIZATION_PKG_VER").unwrap_or("NA".to_string()),
             circuit_type.as_short_str(),
@@ -219,7 +222,7 @@ impl DiskResource for VerifierResource {
     fn path(p: &Self::PathConstrutor) -> impl AsRef<Path> {
         format!(
             "{}/{}_{}_{}",
-            CIRCUITS_FOLDER,
+            &relative_circuit_dir_path(),
             VERIFIER_STATE_FILE_PREFIX,
             env::var("EVM_ARITHMETIZATION_PKG_VER").unwrap_or("NA".to_string()),
             p.get_configuration_digest()
@@ -272,4 +275,13 @@ fn prover_to_disk(
     }
 
     Ok(())
+}
+
+/// If we're running in the cargo workspace, then always use the `circuits`
+/// directory that lives in `tools/`. Otherwise, just use `circuits` in the
+/// current directory.
+fn relative_circuit_dir_path() -> String {
+    env::var(CARGO_WORKSPACE_DIR_ENV)
+        .map(|p| format!("{}tools/{}", p, CIRCUITS_DIR))
+        .unwrap_or_else(|_| CIRCUITS_DIR.to_string())
 }

--- a/zero_bin/common/src/prover_state/persistence.rs
+++ b/zero_bin/common/src/prover_state/persistence.rs
@@ -282,6 +282,6 @@ fn prover_to_disk(
 /// current directory.
 fn relative_circuit_dir_path() -> String {
     env::var(CARGO_WORKSPACE_DIR_ENV)
-        .map(|p| format!("{}tools/{}", p, CIRCUITS_DIR))
+        .map(|p| format!("{}/{}", p, CIRCUITS_DIR))
         .unwrap_or_else(|_| CIRCUITS_DIR.to_string())
 }

--- a/zero_bin/tools/prove_rpc.sh
+++ b/zero_bin/tools/prove_rpc.sh
@@ -40,6 +40,9 @@ fi
 # Force the working directory to always be the `tools/` directory. 
 TOOLS_DIR=$(dirname $(realpath "$0"))
 
+# Set the environment variable to let the binary know that we're running in the project workspace.
+export CARGO_WORKSPACE_DIR="${TOOLS_DIR}/../"
+
 PROOF_OUTPUT_DIR="${TOOLS_DIR}/proofs"
 OUT_LOG_PATH="${PROOF_OUTPUT_DIR}/b$1_$2.log"
 ALWAYS_WRITE_LOGS=0 # Change this to `1` if you always want logs to be written.

--- a/zero_bin/tools/prove_rpc.sh
+++ b/zero_bin/tools/prove_rpc.sh
@@ -37,7 +37,10 @@ else
   export MEMORY_CIRCUIT_SIZE="17..28"
 fi
 
-PROOF_OUTPUT_DIR="proofs"
+# Force the working directory to always be the `tools/` directory. 
+TOOLS_DIR=$(dirname $(realpath "$0"))
+
+PROOF_OUTPUT_DIR="${TOOLS_DIR}/proofs"
 OUT_LOG_PATH="${PROOF_OUTPUT_DIR}/b$1_$2.log"
 ALWAYS_WRITE_LOGS=0 # Change this to `1` if you always want logs to be written.
 TOT_BLOCKS=$(($2-$1+1))
@@ -56,7 +59,6 @@ OUTPUT_TO_TERMINAL="${OUTPUT_TO_TERMINAL:-false}"
 RUN_VERIFICATION="${RUN_VERIFICATION:-false}"
 
 mkdir -p $PROOF_OUTPUT_DIR
-
 
 if [ $IGNORE_PREVIOUS_PROOFS ]; then
     # Set checkpoint height to previous block number for the first block in range

--- a/zero_bin/tools/prove_stdio.sh
+++ b/zero_bin/tools/prove_stdio.sh
@@ -86,12 +86,12 @@ fi
 cargo build --release --jobs "$num_procs"
 
 start_time=$(date +%s%N)
-"${TOOLS_DIR}/../../target/release/leader" --runtime in-memory --load-strategy on-demand stdio < $INPUT_FILE | tee leader.out
+"${TOOLS_DIR}/../../target/release/leader" --runtime in-memory --load-strategy on-demand stdio < $INPUT_FILE | tee "${TOOLS_DIR}/leader.out"
 end_time=$(date +%s%N)
 
-tail -n 1 leader.out > proofs.json
+tail -n 1 leader.out > "${TOOLS_DIR}/proofs.json"
 
-"${TOOLS_DIR}/../../target/release/verifier" -f proofs.json | tee verify.out
+"${TOOLS_DIR}/../../target/release/verifier" -f proofs.json | tee "${TOOLS_DIR}/verify.out"
 
 if grep -q 'All proofs verified successfully!' verify.out; then
     duration_ns=$((end_time - start_time))

--- a/zero_bin/tools/prove_stdio.sh
+++ b/zero_bin/tools/prove_stdio.sh
@@ -14,6 +14,9 @@ num_procs=$(nproc)
 # Force the working directory to always be the `tools/` directory. 
 TOOLS_DIR=$(dirname $(realpath "$0"))
 
+# Set the environment variable to let the binary know that we're running in the project workspace.
+export CARGO_WORKSPACE_DIR="${TOOLS_DIR}/../"
+
 # Configured Rayon and Tokio with rough defaults
 export RAYON_NUM_THREADS=$num_procs
 export TOKIO_WORKER_THREADS=$num_procs

--- a/zero_bin/tools/prove_stdio.sh
+++ b/zero_bin/tools/prove_stdio.sh
@@ -11,6 +11,9 @@
 # We're going to set the parallelism in line with the total cpu count
 num_procs=$(nproc)
 
+# Force the working directory to always be the `tools/` directory. 
+TOOLS_DIR=$(dirname $(realpath "$0"))
+
 # Configured Rayon and Tokio with rough defaults
 export RAYON_NUM_THREADS=$num_procs
 export TOKIO_WORKER_THREADS=$num_procs
@@ -80,12 +83,12 @@ fi
 cargo build --release --jobs "$num_procs"
 
 start_time=$(date +%s%N)
-../../target/release/leader --runtime in-memory --load-strategy on-demand stdio < $INPUT_FILE | tee leader.out
+"${TOOLS_DIR}/../../target/release/leader" --runtime in-memory --load-strategy on-demand stdio < $INPUT_FILE | tee leader.out
 end_time=$(date +%s%N)
 
 tail -n 1 leader.out > proofs.json
 
-../../target/release/verifier -f proofs.json | tee verify.out
+"${TOOLS_DIR}/../../target/release/verifier" -f proofs.json | tee verify.out
 
 if grep -q 'All proofs verified successfully!' verify.out; then
     duration_ns=$((end_time - start_time))


### PR DESCRIPTION
Resolves #306.

A few notes:
- If we are ever working within the project directory (eg. we haven't just copied the binary to some random directory), it should always look for `circuits` in `zk_evm/zero_bin/tools/`. If we're not in the project workspace, then it should just use the current working directory.
- The cleanest way to get the project directory when working with cargo seems to be setting an environment variable in `.cargo/config.toml`. Let me know if there's a better way.
- The scripts in `tools` now always output to `tools/proofs` no matter what the CWD is.