### PR TITLE
migrate compat to trace_decoder crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,6 +1337,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "compat"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "primitive-types 0.12.2",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4058,6 +4066,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "clap",
+ "compat",
  "evm_arithmetization",
  "futures",
  "mpt_trie",
@@ -5716,6 +5725,6 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "trybuild",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ members = ["mpt_trie",
     "zero_bin/ops",
     "zero_bin/verifier",
     "zero_bin/rpc",
-    "zero_bin/prover"]
+    "zero_bin/prover", 
+    "compat"]
 resolver = "2"
 
 [workspace.package]
@@ -44,6 +45,8 @@ bytes = "1.6.0"
 ciborium = "0.2.2"
 ciborium-io = "0.2.2"
 clap = { version = "4.5.7", features = ["derive", "env"] }
+compat = { path = "compat" }
+__compat_primitive_types = { version = "0.12.2", package = "primitive-types" }
 criterion = "0.5.1"
 dotenvy = "0.15.7"
 enum-as-inner = "0.6.0"

--- a/compat/Cargo.toml
+++ b/compat/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "compat"
+version = "0.1.0"
+publish = false # TODO(<owner>): https://github.com/0xPolygonZero/zk_evm/issues/314 find a better place for this
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+alloy = {workspace = true }
+__compat_primitive_types = { workspace = true }

--- a/compat/src/lib.rs
+++ b/compat/src/lib.rs
@@ -1,4 +1,6 @@
+/// A trait to convert between alloy and ethereum types.
 pub trait Compat<Out> {
+    /// Convert the type to another type
     fn compat(self) -> Out;
 }
 

--- a/zero_bin/rpc/Cargo.toml
+++ b/zero_bin/rpc/Cargo.toml
@@ -21,10 +21,11 @@ mpt_trie = { workspace = true }
 alloy.workspace = true
 futures = { workspace = true }
 url = { workspace = true }
-__compat_primitive_types = { version = "0.12.2", package = "primitive-types" }
+__compat_primitive_types = { workspace = true }
 tower = { workspace = true, features = ["retry"] }
 
 # Local dependencies
-zero_bin_common ={ workspace = true }
+compat = { workspace = true }
+zero_bin_common = { workspace = true }
 prover = { workspace = true }
 

--- a/zero_bin/rpc/src/lib.rs
+++ b/zero_bin/rpc/src/lib.rs
@@ -6,18 +6,16 @@ use alloy::{
 };
 use anyhow::Context as _;
 use clap::ValueEnum;
+use compat::Compat;
 use evm_arithmetization::proof::{BlockHashes, BlockMetadata};
 use futures::{StreamExt as _, TryStreamExt as _};
 use prover::ProverInput;
 use trace_decoder::types::{BlockLevelData, OtherBlockData};
 use zero_bin_common::block_interval::BlockInterval;
 
-mod compat;
 pub mod jerigon;
 pub mod native;
 pub mod retry;
-
-use compat::Compat;
 
 const PREVIOUS_HASHES_COUNT: usize = 256;
 

--- a/zero_bin/rpc/src/native/state.rs
+++ b/zero_bin/rpc/src/native/state.rs
@@ -14,7 +14,7 @@ use trace_decoder::trace_protocol::{
     SeparateTriePreImages, TrieDirect, TxnInfo,
 };
 
-use crate::compat::Compat;
+use crate::Compat;
 
 /// Processes the state witness for the given block.
 pub async fn process_state_witness<ProviderT, TransportT>(

--- a/zero_bin/rpc/src/native/txn.rs
+++ b/zero_bin/rpc/src/native/txn.rs
@@ -24,7 +24,7 @@ use futures::stream::{FuturesOrdered, TryStreamExt};
 use trace_decoder::trace_protocol::{ContractCodeUsage, TxnInfo, TxnMeta, TxnTrace};
 
 use super::CodeDb;
-use crate::compat::Compat;
+use crate::Compat;
 
 /// Processes the transactions in the given block and updates the code db.
 pub(super) async fn process_transactions<ProviderT, TransportT>(


### PR DESCRIPTION
This PR proposes that we migrate the `Compat` trait to `trace_decoder::types`. The rationale behind this migration is such that if there are clients that alloy based which want to integrate with the trace protocol they should not have to import the `rpc` crate to get access to the `Compat` trait and associated conversions. A concrete example of this is the integration of `reth` which is `alloy` based. 