### PR TITLE
Fix: `zero-bin` is now able again to accesses `evm_arithmetization` for circuit versions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,7 @@
 # https://github.com/rust-lang/rust/pull/124129
 # https://github.com/dtolnay/linkme/pull/88
 rustflags = ["-Z", "linker-features=-lld"]
+
+[env]
+# If we're running in the project workspace, then we should set the workspace env var so we read/write to/from files relative to the workspace.
+CARGO_WORKSPACE_DIR = { value = "", relative = true }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,4 +5,4 @@ rustflags = ["-Z", "linker-features=-lld"]
 
 [env]
 # If we're running in the project workspace, then we should set the workspace env var so we read/write to/from files relative to the workspace.
-CARGO_WORKSPACE_DIR = { value = "", relative = true }
+ZK_EVM_WORKSPACE_DIR = { value = "", relative = true }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,3 @@
 # https://github.com/rust-lang/rust/pull/124129
 # https://github.com/dtolnay/linkme/pull/88
 rustflags = ["-Z", "linker-features=-lld"]
-
-[env]
-# If we're running in the project workspace, then we should set the workspace env var so we read/write to/from files relative to the workspace.
-ZK_EVM_WORKSPACE_DIR = { value = "", relative = true }

--- a/zero_bin/common/src/prover_state/persistence.rs
+++ b/zero_bin/common/src/prover_state/persistence.rs
@@ -35,7 +35,7 @@ const NUM_HASH_NIBS_TO_USE_IN_CIRCUIT_VERSION: usize = 8;
 /// the kernel hash of the circuit that we are loading in from disk differs,
 /// then using these circuits could potentially lead to incorrect results (but
 /// most likely just a crash).
-static CIRCUIT_VERSION: Lazy<String> =
+pub static CIRCUIT_VERSION: Lazy<String> =
     Lazy::new(|| hex::encode(KERNEL.hash())[..NUM_HASH_NIBS_TO_USE_IN_CIRCUIT_VERSION].to_string());
 
 fn get_serializers() -> (

--- a/zero_bin/common/src/prover_state/persistence.rs
+++ b/zero_bin/common/src/prover_state/persistence.rs
@@ -33,8 +33,7 @@ const KERNEL_HASH_PREFIX: usize = 8;
 /// When we serialize/deserialize circuits, we rely on the hash of the plonky
 /// kernel to determine if the circuit is compatible with our current binary. If
 /// the kernel hash of the circuit that we are loading in from disk differs,
-/// then using these circuits could potentially lead to incorrect results (but
-/// most likely just a crash).
+/// then using these circuits would cause failures during proof generation
 pub static CIRCUIT_VERSION: Lazy<String> =
     Lazy::new(|| hex::encode(KERNEL.hash())[..KERNEL_HASH_PREFIX].to_string());
 

--- a/zero_bin/common/src/prover_state/persistence.rs
+++ b/zero_bin/common/src/prover_state/persistence.rs
@@ -80,8 +80,8 @@ pub(crate) trait DiskResource {
         if std::fs::metadata(&circuits_dir).is_err() {
             std::fs::create_dir(&circuits_dir).map_err(|err| {
                 DiskResourceError::IoError::<Self::Error>(std::io::Error::other(format!(
-                    "Could not create circuits folder at {} with error: {:?}",
-                    circuits_dir, err
+                    "Could not create circuits folder at {} (err: {})",
+                    err, circuits_dir
                 )))
             })?;
         }

--- a/zero_bin/common/src/prover_state/persistence.rs
+++ b/zero_bin/common/src/prover_state/persistence.rs
@@ -93,7 +93,7 @@ pub(crate) trait DiskResource {
 
         // Create the base folder if non-existent.
         if std::fs::metadata(&circuits_dir).is_err() {
-            std::fs::create_dir(&circuits_dir).map_err(|err| {
+            std::fs::create_dir_all(&circuits_dir).map_err(|err| {
                 DiskResourceError::IoError::<Self::Error>(std::io::Error::other(format!(
                     "Could not create circuits folder at {} (err: {})",
                     err, circuits_dir

--- a/zero_bin/common/src/prover_state/persistence.rs
+++ b/zero_bin/common/src/prover_state/persistence.rs
@@ -28,7 +28,7 @@ const ZK_EVM_CACHE_DIR_ENV: &str = "ZK_EVM_CACHE_DIR";
 /// We version serialized circuits by the kernel hash they were serialized with,
 /// but we really only need a few of the starting hex nibbles to reliably
 /// differentiate.
-const NUM_HASH_NIBS_TO_USE_IN_CIRCUIT_VERSION: usize = 8;
+const KERNEL_HASH_PREFIX: usize = 8;
 
 /// When we serialize/deserialize circuits, we rely on the hash of the plonky
 /// kernel to determine if the circuit is compatible with our current binary. If
@@ -36,7 +36,7 @@ const NUM_HASH_NIBS_TO_USE_IN_CIRCUIT_VERSION: usize = 8;
 /// then using these circuits could potentially lead to incorrect results (but
 /// most likely just a crash).
 pub static CIRCUIT_VERSION: Lazy<String> =
-    Lazy::new(|| hex::encode(KERNEL.hash())[..NUM_HASH_NIBS_TO_USE_IN_CIRCUIT_VERSION].to_string());
+    Lazy::new(|| hex::encode(KERNEL.hash())[..KERNEL_HASH_PREFIX].to_string());
 
 fn get_serializers() -> (
     DefaultGateSerializer,

--- a/zero_bin/common/src/prover_state/persistence.rs
+++ b/zero_bin/common/src/prover_state/persistence.rs
@@ -78,10 +78,10 @@ pub(crate) trait DiskResource {
 
         // Create the base folder if non-existent.
         if std::fs::metadata(&circuits_dir).is_err() {
-            std::fs::create_dir_all(&circuits_dir).map_err(|err| {
+            std::fs::create_dir(&circuits_dir).map_err(|err| {
                 DiskResourceError::IoError::<Self::Error>(std::io::Error::other(format!(
-                    "Could not create circuits folder with error \"{:?}\"",
-                    err
+                    "Could not create circuits folder at {} with error: {:?}",
+                    circuits_dir, err
                 )))
             })?;
         }

--- a/zero_bin/common/src/version.rs
+++ b/zero_bin/common/src/version.rs
@@ -1,10 +1,10 @@
 pub fn print_version(
-    evm_arithmetization_package_version: &str,
+    evm_arithmetization_kernel_version: &str,
     rustc_commit_hash: &str,
     rustc_timestamp: &str,
 ) {
     println!(
-        "evm_arithmetization Package Version: {}\nBuild Commit Hash: {}\nBuild Timestamp: {}",
-        evm_arithmetization_package_version, rustc_commit_hash, rustc_timestamp
+        "evm_arithmetization Kernel Version: {}\nBuild Commit Hash: {}\nBuild Timestamp: {}",
+        evm_arithmetization_kernel_version, rustc_commit_hash, rustc_timestamp
     )
 }

--- a/zero_bin/leader/src/main.rs
+++ b/zero_bin/leader/src/main.rs
@@ -10,10 +10,10 @@ use ops::register;
 use paladin::runtime::Runtime;
 use proof_gen::proof_types::GeneratedBlockProof;
 use tracing::{info, warn};
-use zero_bin_common::version;
 use zero_bin_common::{
     block_interval::BlockInterval, prover_state::persistence::set_circuit_cache_dir_env_if_not_set,
 };
+use zero_bin_common::{prover_state::persistence::CIRCUIT_VERSION, version};
 
 use crate::client::{client_main, ProofParams};
 
@@ -22,8 +22,6 @@ mod client;
 mod http;
 mod init;
 mod stdio;
-
-const EVM_ARITHMETIZATION_PKG_VER: &str = "EVM_ARITHMETIZATION_PKG_VER";
 
 fn get_previous_proof(path: Option<PathBuf>) -> Result<Option<GeneratedBlockProof>> {
     if path.is_none() {
@@ -43,22 +41,11 @@ async fn main() -> Result<()> {
     set_circuit_cache_dir_env_if_not_set()?;
     init::tracing();
 
-    if env::var_os(EVM_ARITHMETIZATION_PKG_VER).is_none() {
-        // Safety:
-        // - we're early enough in main that nothing else should race
-        unsafe {
-            env::set_var(
-                EVM_ARITHMETIZATION_PKG_VER,
-                env!("EVM_ARITHMETIZATION_PKG_VER"),
-            );
-        }
-    }
-
     let args: Vec<String> = env::args().collect();
 
     if args.contains(&"--version".to_string()) {
         version::print_version(
-            env!("EVM_ARITHMETIZATION_PKG_VER"),
+            CIRCUIT_VERSION.as_str(),
             env!("VERGEN_RUSTC_COMMIT_HASH"),
             env!("VERGEN_BUILD_TIMESTAMP"),
         );

--- a/zero_bin/leader/src/main.rs
+++ b/zero_bin/leader/src/main.rs
@@ -1,4 +1,4 @@
-use std::{env, io};
+use std::io;
 use std::{fs::File, path::PathBuf};
 
 use anyhow::Result;

--- a/zero_bin/leader/src/main.rs
+++ b/zero_bin/leader/src/main.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{env, io};
 use std::{fs::File, path::PathBuf};
 
 use anyhow::Result;

--- a/zero_bin/rpc/src/main.rs
+++ b/zero_bin/rpc/src/main.rs
@@ -6,8 +6,8 @@ use rpc::provider::CachedProvider;
 use rpc::{retry::build_http_retry_provider, RpcType};
 use tracing_subscriber::{prelude::*, EnvFilter};
 use url::Url;
-use zero_bin_common::block_interval::BlockInterval;
 use zero_bin_common::version;
+use zero_bin_common::{block_interval::BlockInterval, prover_state::persistence::CIRCUIT_VERSION};
 
 #[derive(Parser)]
 pub enum Cli {
@@ -82,7 +82,7 @@ async fn main() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.contains(&"--version".to_string()) {
         version::print_version(
-            env!("EVM_ARITHMETIZATION_PKG_VER"),
+            CIRCUIT_VERSION.as_str(),
             env!("VERGEN_RUSTC_COMMIT_HASH"),
             env!("VERGEN_BUILD_TIMESTAMP"),
         );

--- a/zero_bin/tools/prove_rpc.sh
+++ b/zero_bin/tools/prove_rpc.sh
@@ -40,7 +40,7 @@ fi
 TOOLS_DIR=$(dirname $(realpath "$0"))
 
 # Set the environment variable to let the binary know that we're running in the project workspace.
-export CARGO_WORKSPACE_DIR="${TOOLS_DIR}/../"
+export CARGO_WORKSPACE_DIR="${TOOLS_DIR}/../../"
 
 PROOF_OUTPUT_DIR="${TOOLS_DIR}/proofs"
 OUT_LOG_PATH="${PROOF_OUTPUT_DIR}/b$1_$2.log"

--- a/zero_bin/tools/prove_rpc.sh
+++ b/zero_bin/tools/prove_rpc.sh
@@ -39,9 +39,6 @@ fi
 # Force the working directory to always be the `tools/` directory. 
 TOOLS_DIR=$(dirname $(realpath "$0"))
 
-# Set the environment variable to let the binary know that we're running in the project workspace.
-export CARGO_WORKSPACE_DIR="${TOOLS_DIR}/../../"
-
 PROOF_OUTPUT_DIR="${TOOLS_DIR}/proofs"
 OUT_LOG_PATH="${PROOF_OUTPUT_DIR}/b$1_$2.log"
 ALWAYS_WRITE_LOGS=0 # Change this to `1` if you always want logs to be written.

--- a/zero_bin/tools/prove_stdio.sh
+++ b/zero_bin/tools/prove_stdio.sh
@@ -26,7 +26,7 @@ VERIFY_OUT_PATH="${TOOLS_DIR}/verify.out"
 TEST_OUT_PATH="${TOOLS_DIR}/test.out"
 
 # Set the environment variable to let the binary know that we're running in the project workspace.
-export ZK_EVM_WORKSPACE_DIR="${TOOLS_DIR}/../"
+export ZK_EVM_WORKSPACE_DIR="${TOOLS_DIR}/../../"
 
 # Configured Rayon and Tokio with rough defaults
 export RAYON_NUM_THREADS=$num_procs

--- a/zero_bin/tools/prove_stdio.sh
+++ b/zero_bin/tools/prove_stdio.sh
@@ -25,9 +25,6 @@ PROOFS_JSON_PATH="${TOOLS_DIR}/proofs.json"
 VERIFY_OUT_PATH="${TOOLS_DIR}/verify.out"
 TEST_OUT_PATH="${TOOLS_DIR}/test.out"
 
-# Set the environment variable to let the binary know that we're running in the project workspace.
-export ZK_EVM_WORKSPACE_DIR="${TOOLS_DIR}/../../"
-
 # Configured Rayon and Tokio with rough defaults
 export RAYON_NUM_THREADS=$num_procs
 export TOKIO_WORKER_THREADS=$num_procs

--- a/zero_bin/tools/prove_stdio.sh
+++ b/zero_bin/tools/prove_stdio.sh
@@ -26,7 +26,7 @@ VERIFY_OUT_PATH="${TOOLS_DIR}/verify.out"
 TEST_OUT_PATH="${TOOLS_DIR}/test.out"
 
 # Set the environment variable to let the binary know that we're running in the project workspace.
-export CARGO_WORKSPACE_DIR="${TOOLS_DIR}/../"
+export ZK_EVM_WORKSPACE_DIR="${TOOLS_DIR}/../"
 
 # Configured Rayon and Tokio with rough defaults
 export RAYON_NUM_THREADS=$num_procs

--- a/zero_bin/verifier/src/main.rs
+++ b/zero_bin/verifier/src/main.rs
@@ -7,7 +7,10 @@ use dotenvy::dotenv;
 use proof_gen::proof_types::GeneratedBlockProof;
 use serde_json::Deserializer;
 use tracing::info;
-use zero_bin_common::{prover_state::persistence::set_circuit_cache_dir_env_if_not_set, version};
+use zero_bin_common::{
+    prover_state::persistence::{set_circuit_cache_dir_env_if_not_set, CIRCUIT_VERSION},
+    version,
+};
 
 mod cli;
 mod init;
@@ -20,7 +23,7 @@ fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.contains(&"--version".to_string()) {
         version::print_version(
-            env!("EVM_ARITHMETIZATION_PKG_VER"),
+            CIRCUIT_VERSION.as_str(),
             env!("VERGEN_RUSTC_COMMIT_HASH"),
             env!("VERGEN_BUILD_TIMESTAMP"),
         );

--- a/zero_bin/worker/src/main.rs
+++ b/zero_bin/worker/src/main.rs
@@ -6,7 +6,8 @@ use dotenvy::dotenv;
 use ops::register;
 use paladin::runtime::WorkerRuntime;
 use zero_bin_common::prover_state::{
-    cli::CliProverStateConfig, persistence::set_circuit_cache_dir_env_if_not_set,
+    cli::CliProverStateConfig,
+    persistence::{set_circuit_cache_dir_env_if_not_set, CIRCUIT_VERSION},
 };
 use zero_bin_common::version;
 
@@ -31,7 +32,7 @@ async fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.contains(&"--version".to_string()) {
         version::print_version(
-            env!("EVM_ARITHMETIZATION_PKG_VER"),
+            CIRCUIT_VERSION.as_str(),
             env!("VERGEN_RUSTC_COMMIT_HASH"),
             env!("VERGEN_BUILD_TIMESTAMP"),
         );


### PR DESCRIPTION
Resolves #304.

Note however that the issue was actually something separate from what is mentioned in the issue. `zero-bin` was actually getting the version of `evm_arithmetization` from `Cargo.lock` and was not using tags. The issue was `zero-bin` was one directory deeper from `Cargo.lock` after it got migrated into `zk_evm`. 