### PR TITLE
Refactor `zero_bin` leader cli

### DIFF
--- a/zero_bin/leader/src/cli.rs
+++ b/zero_bin/leader/src/cli.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use alloy::transports::http::reqwest::Url;
 use clap::{Parser, Subcommand, ValueHint};
+use rpc::RpcType;
 use zero_bin_common::prover_state::cli::CliProverStateConfig;
 
 /// zero-bin leader config
@@ -19,7 +20,7 @@ pub(crate) struct Cli {
     pub(crate) prover_state_config: CliProverStateConfig,
 }
 
-#[derive(Subcommand, Clone)]
+#[derive(Subcommand)]
 pub(crate) enum Command {
     /// Reads input from stdin and writes output to stdout.
     Stdio {
@@ -30,52 +31,14 @@ pub(crate) enum Command {
         #[arg(short, long, default_value_t = false)]
         save_inputs_on_error: bool,
     },
-    /// Reads input from a Jerigon node and writes output to stdout.
-    Jerigon {
-        // The Jerigon RPC URL.
+    /// Reads input from a node rpc and writes output to stdout.
+    Rpc {
+        // The node RPC URL.
         #[arg(long, short = 'u', value_hint = ValueHint::Url)]
         rpc_url: Url,
-        /// The block interval for which to generate a proof.
-        #[arg(long, short = 'i')]
-        block_interval: String,
-        /// The checkpoint block number.
-        #[arg(short, long, default_value_t = 0)]
-        checkpoint_block_number: u64,
-        /// The previous proof output.
-        #[arg(long, short = 'f', value_hint = ValueHint::FilePath)]
-        previous_proof: Option<PathBuf>,
-        /// If provided, write the generated proofs to this directory instead of
-        /// stdout.
-        #[arg(long, short = 'o', value_hint = ValueHint::FilePath)]
-        proof_output_dir: Option<PathBuf>,
-        /// If true, save the public inputs to disk on error.
-        #[arg(short, long, default_value_t = false)]
-        save_inputs_on_error: bool,
-        /// Network block time in milliseconds. This value is used
-        /// to determine the blockchain node polling interval.
-        #[arg(short, long, env = "ZERO_BIN_BLOCK_TIME", default_value_t = 2000)]
-        block_time: u64,
-        /// Keep intermediate proofs. Default action is to
-        /// delete them after the final proof is generated.
-        #[arg(
-            short,
-            long,
-            env = "ZERO_BIN_KEEP_INTERMEDIATE_PROOFS",
-            default_value_t = false
-        )]
-        keep_intermediate_proofs: bool,
-        /// Backoff in milliseconds for request retries
-        #[arg(long, default_value_t = 0)]
-        backoff: u64,
-        /// The maximum number of retries
-        #[arg(long, default_value_t = 0)]
-        max_retries: u32,
-    },
-    /// Reads input from a native node and writes output to stdout.
-    Native {
-        // The native RPC URL.
-        #[arg(long, short = 'u', value_hint = ValueHint::Url)]
-        rpc_url: Url,
+        // The node RPC type (jerigon / native).
+        #[arg(long, short = 't', default_value = "jerigon")]
+        rpc_type: RpcType,
         /// The block interval for which to generate a proof.
         #[arg(long, short = 'i')]
         block_interval: String,

--- a/zero_bin/leader/src/client.rs
+++ b/zero_bin/leader/src/client.rs
@@ -106,13 +106,3 @@ pub(crate) async fn client_main(
 
     Ok(())
 }
-
-impl From<super::cli::Command> for RpcType {
-    fn from(command: super::cli::Command) -> Self {
-        match command {
-            super::cli::Command::Native { .. } => RpcType::Native,
-            super::cli::Command::Jerigon { .. } => RpcType::Jerigon,
-            _ => panic!("Unsupported command type"),
-        }
-    }
-}

--- a/zero_bin/leader/src/main.rs
+++ b/zero_bin/leader/src/main.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
 
     let runtime = Runtime::from_config(&args.paladin, register()).await?;
 
-    match args.command.clone() {
+    match args.command {
         Command::Stdio {
             previous_proof,
             save_inputs_on_error,
@@ -93,20 +93,9 @@ async fn main() -> Result<()> {
 
             http::http_main(runtime, port, output_dir, save_inputs_on_error).await?;
         }
-        Command::Jerigon {
+        Command::Rpc {
             rpc_url,
-            block_interval,
-            checkpoint_block_number,
-            previous_proof,
-            proof_output_dir,
-            save_inputs_on_error,
-            block_time,
-            keep_intermediate_proofs,
-            backoff,
-            max_retries,
-        }
-        | Command::Native {
-            rpc_url,
+            rpc_type,
             block_interval,
             checkpoint_block_number,
             previous_proof,
@@ -133,7 +122,7 @@ async fn main() -> Result<()> {
                 runtime,
                 RpcParams {
                     rpc_url,
-                    rpc_type: args.command.into(),
+                    rpc_type,
                     backoff,
                     max_retries,
                 },

--- a/zero_bin/tools/prove_rpc.sh
+++ b/zero_bin/tools/prove_rpc.sh
@@ -87,7 +87,7 @@ fi
 if [[ $8 == "test_only" ]]; then
     # test only run
     echo "Proving blocks ${BLOCK_INTERVAL} in a test_only mode now... (Total: ${TOT_BLOCKS})"
-    cargo r --release --features test_only --bin leader -- --runtime in-memory --load-strategy on-demand "$NODE_RPC_TYPE" --rpc-url "$NODE_RPC_URL" --block-interval $BLOCK_INTERVAL --proof-output-dir $PROOF_OUTPUT_DIR $PREV_PROOF_EXTRA_ARG --backoff "$BACKOFF" --max-retries "$RETRIES" > $OUT_LOG_PATH 2>&1
+    cargo r --release --features test_only --bin leader -- --runtime in-memory --load-strategy on-demand rpc --rpc-type "$NODE_RPC_TYPE" --rpc-url "$NODE_RPC_URL" --block-interval $BLOCK_INTERVAL --proof-output-dir $PROOF_OUTPUT_DIR $PREV_PROOF_EXTRA_ARG --backoff "$BACKOFF" --max-retries "$RETRIES" > $OUT_LOG_PATH 2>&1
     if grep -q 'All proof witnesses have been generated successfully.' $OUT_LOG_PATH; then
         echo -e "Success - Note this was just a test, not a proof"
         # Remove the log on success if we don't want to keep it.
@@ -102,7 +102,7 @@ if [[ $8 == "test_only" ]]; then
 else
     # normal run
     echo "Proving blocks ${BLOCK_INTERVAL} now... (Total: ${TOT_BLOCKS})"
-    cargo r --release --bin leader -- --runtime in-memory --load-strategy on-demand "$NODE_RPC_TYPE" --rpc-url "$3" --block-interval $BLOCK_INTERVAL --proof-output-dir $PROOF_OUTPUT_DIR $PREV_PROOF_EXTRA_ARG --backoff "$BACKOFF" --max-retries "$RETRIES" > $OUT_LOG_PATH 2>&1
+    cargo r --release --bin leader -- --runtime in-memory --load-strategy on-demand rpc --rpc-type "$NODE_RPC_TYPE" --rpc-url "$3" --block-interval $BLOCK_INTERVAL --proof-output-dir $PROOF_OUTPUT_DIR $PREV_PROOF_EXTRA_ARG --backoff "$BACKOFF" --max-retries "$RETRIES" > $OUT_LOG_PATH 2>&1
 
     retVal=$?
     if [ $retVal -ne 0 ]; then


### PR DESCRIPTION
This PR proposes that we refactor the leader CLI such that instead of having one command per rpc type, we have a single rpc command with an argument for the rpc type. This reduces redundancy and makes the cli more extensible as more rpc types are added (e.g. reth).