### PR TITLE
Removed non-existing public dep `__compat_primitive_types`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ bytes = "1.5.0"
 ciborium = "0.2.1"
 ciborium-io = "0.2.1"
 clap = { version = "4.4.6", features = ["derive", "env"] }
-__compat_primitive_types = "0.12.2"
 criterion = "0.5.1"
 dotenvy = "0.15.7"
 enum-as-inner = "0.6.0"


### PR DESCRIPTION
Something happened in the merge `zero_bin` PR (#279) where a local-renamed dep (something that is not on `crates.io`) got set just with a semver. Somehow `Cargo` is still able to build fine (not sure how...), but `rust-analyzer` (at least on my end) fails to make it past parsing the root `Cargo.toml`. This PR fixes this issue.