### PR TITLE
perf(evm_arithmetization): Check for zero amount early in `add_eth`

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/transfer.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/transfer.asm
@@ -64,6 +64,8 @@ global deduct_eth_insufficient_balance:
 // Post stack: (empty)
 global add_eth:
     // stack: addr, amount, retdest
+    DUP2 ISZERO %jumpi(add_eth_zero_amount)
+    // stack: addr, amount, retdest
     DUP1 %insert_touched_addresses
     DUP1 %mpt_read_state_trie
     // stack: account_ptr, addr, amount, retdest
@@ -84,7 +86,6 @@ global add_eth_new_account:
     // stack: null_account_ptr, addr, amount, retdest
     POP
     // stack: addr, amount, retdest
-    DUP2 ISZERO %jumpi(add_eth_new_account_zero)
     DUP1 %journal_add_account_created
     %get_trie_data_size // pointer to new account we're about to create
     // stack: new_account_ptr, addr, amount, retdest
@@ -100,7 +101,7 @@ global add_eth_new_account:
     // stack: key, new_account_ptr, retdest
     %jump(mpt_insert_state_trie)
 
-add_eth_new_account_zero:
+add_eth_zero_amount:
     // stack: addr, amount, retdest
     %pop2 JUMP
 


### PR DESCRIPTION
When calling `add_eth`, regardless if the target account already exists in the trie or not, sending a 0 amount will end-up being a no-op.
As such, we can skip trie access and journaling entries and exit early in such cases. 