### PR TITLE
fix: do not add selfdestruct journal entry for skipped accounts

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/terminate.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/terminate.asm
@@ -111,8 +111,22 @@ global sys_selfdestruct:
 
 sys_selfdestruct_journal_add:
     // stack: address, recipient, balance, kexit_info
-    %journal_add_account_destroyed
+    DUP3 ISZERO
 
+    // If balance is 0, we didn't perform any transfer, hence shouldn't
+    // add a new journal entry.
+
+    // stack: balance=0, address, recipient, balance, kexit_info
+    %jumpi(skip_journal_entry)
+    // stack: address, recipient, balance, kexit_info
+    %journal_add_account_destroyed
+    %jump(sys_selfdestruct_exit)
+
+skip_journal_entry:
+    // stack: address, recipient, balance, kexit_info
+    %pop3
+
+sys_selfdestruct_exit:
     // stack: kexit_info
     %leftover_gas
     // stack: leftover_gas

--- a/evm_arithmetization/src/cpu/kernel/asm/core/terminate.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/terminate.asm
@@ -111,10 +111,10 @@ global sys_selfdestruct:
 
 sys_selfdestruct_journal_add:
     // stack: address, recipient, balance, kexit_info
-    DUP3 ISZERO
+    DUP2 %is_non_existent
 
-    // If balance is 0, we didn't perform any transfer, hence shouldn't
-    // add a new journal entry.
+    // If balance is 0, we didn't perform any transfer. Hence, if the recipient
+    // didn't exist before we shouldn't add a new journal entry.
 
     // stack: balance=0, address, recipient, balance, kexit_info
     %jumpi(skip_journal_entry)


### PR DESCRIPTION
Fix a potential issue with selfdestruct, which may try accessing an address that doesn't exist if its creation has been skipped following an `%add_eth` call with amount 0 when refunding.

What we do now during a selfdestruct refund process is:

- after `%add_eth`, check the amount sent
- if it is zero, check for account existence
  - if it exists, add a journal entry
  - otherwise, skip
- if it is non-zero, add a journal entry

Noticed while debugging linked list refactoring of mpt_trie_data with @4l0n50 and @LindaGuiga.