### PR TITLE
fix: add recipient to `touched_addresses` even when skipping empty transfer

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/transfer.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/transfer.asm
@@ -64,9 +64,10 @@ global deduct_eth_insufficient_balance:
 // Post stack: (empty)
 global add_eth:
     // stack: addr, amount, retdest
+    DUP1 %insert_touched_addresses
+    // stack: addr, amount, retdest
     DUP2 ISZERO %jumpi(add_eth_zero_amount)
     // stack: addr, amount, retdest
-    DUP1 %insert_touched_addresses
     DUP1 %mpt_read_state_trie
     // stack: account_ptr, addr, amount, retdest
     DUP1 ISZERO %jumpi(add_eth_new_account) // If the account pointer is null, we need to create the account.


### PR DESCRIPTION
fix from #322 

We still need to flag `recipients` of `add_eth` as touched addresses, even though we skip an empty transfer for efficiency, otherwise we _may_ not search for them during final empty account deletion. 