### PR TITLE
perf: reduce overhead in final iteration of `memset`

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/memory/memset.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/memset.asm
@@ -32,13 +32,12 @@ memset_finish:
     %jumpi(memset_bytes_empty)
 
     // stack: DST, final_count, retdest
-    DUP2
     PUSH 0
-    DUP3
-    // stack: DST, 0, final_count, DST, final_count, retdest
+    SWAP1
+    // stack: DST, 0, final_count, retdest
     %mstore_unpacking
-    // stack: DST, final_count, retdest
-    %pop3
+    // stack: DST', retdest
+    POP
     // stack: retdest
     JUMP
 


### PR DESCRIPTION
Fairly minor, initially aiming at targeting the wrong stack descriptions highlighted by auditors (i.e. `// stack: DST, final_count, retdest` after the `%mstore_unpacking` call that should have been `// stack: DST', DST, final_count, retdest`, but realized we could also just reduce the overhead when calling `memset` on the last chunk.