### PR TITLE
Parse embedded short nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5716,6 +5716,6 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "trybuild",
 ]


### PR DESCRIPTION
This PR modifies the logic for inserting short node variants into the trie builder. The updated logic also parses branch nodes as in some instances (when a short node is less than 32 bytes) short nodes are embedded directly into the branch node.

closes: #344 