### PR TITLE
fix: properly log final results when due

### DIFF
--- a/zero_bin/leader/src/client.rs
+++ b/zero_bin/leader/src/client.rs
@@ -46,12 +46,6 @@ pub(crate) async fn client_main(
     )
     .await?;
 
-    if cfg!(feature = "test_only") {
-        info!("All proof witnesses have been generated successfully.");
-    } else {
-        info!("All proofs have been generated successfully.");
-    }
-
     // If `keep_intermediate_proofs` is not set we only keep the last block
     // proof from the interval. It contains all the necessary information to
     // verify the whole sequence.
@@ -65,6 +59,12 @@ pub(crate) async fn client_main(
         .await;
     runtime.close().await?;
     let proved_blocks = proved_blocks?;
+
+    if cfg!(feature = "test_only") {
+        info!("All proof witnesses have been generated successfully.");
+    } else {
+        info!("All proofs have been generated successfully.");
+    }
 
     if params.keep_intermediate_proofs {
         if params.proof_output_dir.is_some() {


### PR DESCRIPTION
This was logging "_final_" results before we were actually done with the payload.
Additionally, because `prove_rpc.sh` script was calling `grep` on the logging file and exiting (with success) upon finding this line (`All proof witnesses have been generated successfully.`), this was resulting in the issue mentioned in #351 of skipping fully `trace_decoder` processing + zkCPU simulation for `test_only` runs.

closes #351 