### PR TITLE
fix: Add beacon roots touched slots into `state_access` with native tracer

### DIFF
--- a/zero_bin/rpc/src/native/state.rs
+++ b/zero_bin/rpc/src/native/state.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use alloy::{
-    primitives::{keccak256, Address, StorageKey, B256, B64, U256},
+    primitives::{keccak256, Address, StorageKey, B256, U256},
     providers::Provider,
     rpc::types::eth::{Block, BlockTransactionsKind, EIP1186AccountProofResponse},
     transports::Transport,
@@ -105,14 +105,11 @@ fn insert_beacon_roots_update(
     let timestamp = block.header.timestamp;
 
     const MODULUS: u64 = HISTORY_BUFFER_LENGTH.1;
-    let slots = [timestamp % MODULUS, (timestamp % MODULUS) + MODULUS];
 
-    let mut keys = HashSet::new();
-    for slot in slots {
-        // let mut bytes = [0; 32];
-        // U256::from(slot).to_big_endian(&mut bytes);
-        keys.insert(U256::from(slot).into());
-    }
+    let keys = HashSet::from_iter([
+        U256::from(timestamp % MODULUS).into(), // timestamp_idx
+        U256::from((timestamp % MODULUS) + MODULUS).into(), // root_idx
+    ]);
     state_access.insert(BEACON_ROOTS_CONTRACT_STATE_KEY.1.into(), keys);
 
     Ok(())

--- a/zero_bin/rpc/src/native/state.rs
+++ b/zero_bin/rpc/src/native/state.rs
@@ -1,8 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
-use __compat_primitive_types::U256;
 use alloy::{
-    primitives::{keccak256, Address, StorageKey, B256},
+    primitives::{keccak256, Address, StorageKey, B256, B64, U256},
     providers::Provider,
     rpc::types::eth::{Block, BlockTransactionsKind, EIP1186AccountProofResponse},
     transports::Transport,
@@ -110,9 +109,9 @@ fn insert_beacon_roots_update(
 
     let mut keys = HashSet::new();
     for slot in slots {
-        let mut bytes = [0; 32];
-        U256::from(slot).to_big_endian(&mut bytes);
-        keys.insert(keccak256(bytes));
+        // let mut bytes = [0; 32];
+        // U256::from(slot).to_big_endian(&mut bytes);
+        keys.insert(U256::from(slot).into());
     }
     state_access.insert(BEACON_ROOTS_CONTRACT_STATE_KEY.1.into(), keys);
 


### PR DESCRIPTION
Tested against blocks 20175000 through 201750010.

closes #350 