### PR TITLE
fix(evm_arithmetization): Adjust layout of `CpuGeneralColumnsView`

### DIFF
--- a/evm_arithmetization/src/cpu/columns/general.rs
+++ b/evm_arithmetization/src/cpu/columns/general.rs
@@ -165,7 +165,10 @@ pub(crate) struct CpuShiftView<T: Copy> {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub(crate) struct CpuStackView<T: Copy> {
-    _unused: [T; 4],
+    /// Reserve the unused columns at the beginning. This allows `Self` to
+    /// coexist with any view that uses only the first four columns (i.e. all
+    /// except `CpuLogicView`).
+    _unused: [T; NUM_UNION_COLUMNS - 4],
     /// Pseudoinverse of `stack_len - num_pops`.
     pub(crate) stack_inv: T,
     /// stack_inv * stack_len.
@@ -175,8 +178,6 @@ pub(crate) struct CpuStackView<T: Copy> {
     /// Pseudoinverse of `nv.stack_len - (MAX_USER_STACK_SIZE + 1)` to check for
     /// stack overflow.
     pub(crate) stack_len_bounds_aux: T,
-    /// Reserve the unused columns.
-    _padding_columns: [T; NUM_UNION_COLUMNS - 8],
 }
 
 /// Number of columns shared by all the views of `CpuGeneralColumnsView`.

--- a/evm_arithmetization/src/cpu/columns/general.rs
+++ b/evm_arithmetization/src/cpu/columns/general.rs
@@ -2,8 +2,11 @@ use core::borrow::{Borrow, BorrowMut};
 use core::fmt::{Debug, Formatter};
 use core::mem::{size_of, transmute};
 
+use static_assertions::const_assert;
+
 /// General purpose columns, which can have different meanings depending on what
 /// CTL or other operation is occurring at this row.
+#[repr(C)]
 #[derive(Clone, Copy)]
 pub(crate) union CpuGeneralColumnsView<T: Copy> {
     exception: CpuExceptionView<T>,
@@ -108,14 +111,21 @@ impl<T: Copy> BorrowMut<[T; NUM_SHARED_COLUMNS]> for CpuGeneralColumnsView<T> {
 }
 
 /// View of the first three `CpuGeneralColumns` containing exception code bits.
+#[repr(C)]
 #[derive(Copy, Clone)]
 pub(crate) struct CpuExceptionView<T: Copy> {
     /// Exception code as little-endian bits.
     pub(crate) exc_code_bits: [T; 3],
+    /// Reserve the unused columns.
+    _padding_columns: [T; UNION_FIELD_SIZE - 3],
 }
 
 /// View of the `CpuGeneralColumns` storing pseudo-inverses used to prove logic
 /// operations.
+///
+/// Because this is the largest field of the [`CpuGeneralColumnsView`] union,
+/// we don't add any padding columns.
+#[repr(C)]
 #[derive(Copy, Clone)]
 pub(crate) struct CpuLogicView<T: Copy> {
     /// Pseudoinverse of `(input0 - input1)`. Used prove that they are unequal.
@@ -125,27 +135,34 @@ pub(crate) struct CpuLogicView<T: Copy> {
 
 /// View of the first two `CpuGeneralColumns` storing a flag and a pseudoinverse
 /// used to prove jumps.
+#[repr(C)]
 #[derive(Copy, Clone)]
 pub(crate) struct CpuJumpsView<T: Copy> {
     /// A flag indicating whether a jump should occur.
     pub(crate) should_jump: T,
     /// Pseudoinverse of `cond.iter().sum()`. Used to check `should_jump`.
     pub(crate) cond_sum_pinv: T,
+    /// Reserve the unused columns.
+    _padding_columns: [T; UNION_FIELD_SIZE - 2],
 }
 
 /// View of the first `CpuGeneralColumns` storing a pseudoinverse used to prove
 /// shift operations.
+#[repr(C)]
 #[derive(Copy, Clone)]
 pub(crate) struct CpuShiftView<T: Copy> {
     /// For a shift amount of displacement: [T], this is the inverse of
     /// sum(displacement[1..]) or zero if the sum is zero.
     pub(crate) high_limb_sum_inv: T,
+    /// Reserve the unused columns.
+    _padding_columns: [T; UNION_FIELD_SIZE - 1],
 }
 
 /// View of the last four `CpuGeneralColumns` storing stack-related variables.
 /// The first three are used for conditionally enabling and disabling channels
 /// when reading the next `stack_top`, and the fourth one is used to check for
 /// stack overflow.
+#[repr(C)]
 #[derive(Copy, Clone)]
 pub(crate) struct CpuStackView<T: Copy> {
     _unused: [T; 4],
@@ -158,8 +175,25 @@ pub(crate) struct CpuStackView<T: Copy> {
     /// Pseudoinverse of `nv.stack_len - (MAX_USER_STACK_SIZE + 1)` to check for
     /// stack overflow.
     pub(crate) stack_len_bounds_aux: T,
+    /// Reserve the unused columns.
+    _padding_columns: [T; UNION_FIELD_SIZE - 8],
 }
 
 /// Number of columns shared by all the views of `CpuGeneralColumnsView`.
 /// `u8` is guaranteed to have a `size_of` of 1.
 pub(crate) const NUM_SHARED_COLUMNS: usize = size_of::<CpuGeneralColumnsView<u8>>();
+
+/// The number of columns in the largest field of [`CpuGeneralColumnsView`].
+/// We assert that this is the same as [`NUM_SHARED_COLUMNS`], but we define
+/// it in order to determine the number of padding columns to add to each field
+/// without creating a cycle for rustc.
+const UNION_FIELD_SIZE: usize = size_of::<CpuLogicView<u8>>();
+const_assert!(UNION_FIELD_SIZE == NUM_SHARED_COLUMNS);
+
+/// Assert that each field of the [`CpuGeneralColumnsView`] union contains the
+/// correct number of columns.
+const_assert!(size_of::<CpuExceptionView<u8>>() == NUM_SHARED_COLUMNS);
+const_assert!(size_of::<CpuLogicView<u8>>() == NUM_SHARED_COLUMNS);
+const_assert!(size_of::<CpuJumpsView<u8>>() == NUM_SHARED_COLUMNS);
+const_assert!(size_of::<CpuShiftView<u8>>() == NUM_SHARED_COLUMNS);
+const_assert!(size_of::<CpuStackView<u8>>() == NUM_SHARED_COLUMNS);

--- a/evm_arithmetization/src/cpu/columns/general.rs
+++ b/evm_arithmetization/src/cpu/columns/general.rs
@@ -117,7 +117,7 @@ pub(crate) struct CpuExceptionView<T: Copy> {
     /// Exception code as little-endian bits.
     pub(crate) exc_code_bits: [T; 3],
     /// Reserve the unused columns.
-    _padding_columns: [T; UNION_FIELD_SIZE - 3],
+    _padding_columns: [T; NUM_UNION_COLUMNS - 3],
 }
 
 /// View of the `CpuGeneralColumns` storing pseudo-inverses used to prove logic
@@ -143,7 +143,7 @@ pub(crate) struct CpuJumpsView<T: Copy> {
     /// Pseudoinverse of `cond.iter().sum()`. Used to check `should_jump`.
     pub(crate) cond_sum_pinv: T,
     /// Reserve the unused columns.
-    _padding_columns: [T; UNION_FIELD_SIZE - 2],
+    _padding_columns: [T; NUM_UNION_COLUMNS - 2],
 }
 
 /// View of the first `CpuGeneralColumns` storing a pseudoinverse used to prove
@@ -155,7 +155,7 @@ pub(crate) struct CpuShiftView<T: Copy> {
     /// sum(displacement[1..]) or zero if the sum is zero.
     pub(crate) high_limb_sum_inv: T,
     /// Reserve the unused columns.
-    _padding_columns: [T; UNION_FIELD_SIZE - 1],
+    _padding_columns: [T; NUM_UNION_COLUMNS - 1],
 }
 
 /// View of the last four `CpuGeneralColumns` storing stack-related variables.
@@ -176,7 +176,7 @@ pub(crate) struct CpuStackView<T: Copy> {
     /// stack overflow.
     pub(crate) stack_len_bounds_aux: T,
     /// Reserve the unused columns.
-    _padding_columns: [T; UNION_FIELD_SIZE - 8],
+    _padding_columns: [T; NUM_UNION_COLUMNS - 8],
 }
 
 /// Number of columns shared by all the views of `CpuGeneralColumnsView`.
@@ -187,8 +187,8 @@ pub(crate) const NUM_SHARED_COLUMNS: usize = size_of::<CpuGeneralColumnsView<u8>
 /// We assert that this is the same as [`NUM_SHARED_COLUMNS`], but we define
 /// it in order to determine the number of padding columns to add to each field
 /// without creating a cycle for rustc.
-const UNION_FIELD_SIZE: usize = size_of::<CpuLogicView<u8>>();
-const_assert!(UNION_FIELD_SIZE == NUM_SHARED_COLUMNS);
+const NUM_UNION_COLUMNS: usize = size_of::<CpuLogicView<u8>>();
+const_assert!(NUM_UNION_COLUMNS == NUM_SHARED_COLUMNS);
 
 /// Assert that each field of the [`CpuGeneralColumnsView`] union contains the
 /// correct number of columns.

--- a/evm_arithmetization/src/cpu/columns/general.rs
+++ b/evm_arithmetization/src/cpu/columns/general.rs
@@ -117,7 +117,7 @@ pub(crate) struct CpuExceptionView<T: Copy> {
     /// Exception code as little-endian bits.
     pub(crate) exc_code_bits: [T; 3],
     /// Reserve the unused columns.
-    _padding_columns: [T; NUM_UNION_COLUMNS - 3],
+    _padding_columns: [T; NUM_SHARED_COLUMNS - 3],
 }
 
 /// View of the `CpuGeneralColumns` storing pseudo-inverses used to prove logic
@@ -143,7 +143,7 @@ pub(crate) struct CpuJumpsView<T: Copy> {
     /// Pseudoinverse of `cond.iter().sum()`. Used to check `should_jump`.
     pub(crate) cond_sum_pinv: T,
     /// Reserve the unused columns.
-    _padding_columns: [T; NUM_UNION_COLUMNS - 2],
+    _padding_columns: [T; NUM_SHARED_COLUMNS - 2],
 }
 
 /// View of the first `CpuGeneralColumns` storing a pseudoinverse used to prove
@@ -155,7 +155,7 @@ pub(crate) struct CpuShiftView<T: Copy> {
     /// sum(displacement[1..]) or zero if the sum is zero.
     pub(crate) high_limb_sum_inv: T,
     /// Reserve the unused columns.
-    _padding_columns: [T; NUM_UNION_COLUMNS - 1],
+    _padding_columns: [T; NUM_SHARED_COLUMNS - 1],
 }
 
 /// View of the last four `CpuGeneralColumns` storing stack-related variables.
@@ -168,7 +168,7 @@ pub(crate) struct CpuStackView<T: Copy> {
     /// Reserve the unused columns at the beginning. This allows `Self` to
     /// coexist with any view that uses only the first four columns (i.e. all
     /// except `CpuLogicView`).
-    _unused: [T; NUM_UNION_COLUMNS - 4],
+    _unused: [T; NUM_SHARED_COLUMNS - 4],
     /// Pseudoinverse of `stack_len - num_pops`.
     pub(crate) stack_inv: T,
     /// stack_inv * stack_len.
@@ -180,16 +180,13 @@ pub(crate) struct CpuStackView<T: Copy> {
     pub(crate) stack_len_bounds_aux: T,
 }
 
-/// Number of columns shared by all the views of `CpuGeneralColumnsView`.
-/// `u8` is guaranteed to have a `size_of` of 1.
-pub(crate) const NUM_SHARED_COLUMNS: usize = size_of::<CpuGeneralColumnsView<u8>>();
-
-/// The number of columns in the largest field of [`CpuGeneralColumnsView`].
-/// We assert that this is the same as [`NUM_SHARED_COLUMNS`], but we define
-/// it in order to determine the number of padding columns to add to each field
-/// without creating a cycle for rustc.
-const NUM_UNION_COLUMNS: usize = size_of::<CpuLogicView<u8>>();
-const_assert!(NUM_UNION_COLUMNS == NUM_SHARED_COLUMNS);
+/// The number of columns shared by all views of [`CpuGeneralColumnsView`].
+/// This is defined in terms of the largest view in order to determine the
+/// number of padding columns to add to each field without creating a cycle
+/// for rustc.
+/// NB: `u8` is guaranteed to have a `size_of` of 1.
+pub(crate) const NUM_SHARED_COLUMNS: usize = size_of::<CpuLogicView<u8>>();
+const_assert!(NUM_SHARED_COLUMNS == size_of::<CpuGeneralColumnsView<u8>>());
 
 /// Assert that each field of the [`CpuGeneralColumnsView`] union contains the
 /// correct number of columns.


### PR DESCRIPTION
Addresses #340.

I'm very open to suggestions if there is a way to make this less cumbersome.

It could be nice to add some [miri](https://github.com/rust-lang/miri) tests for this and other conversions, but I can't think of a clean way to run them in the CI. Miri doesn't support inline assembly, so we would need a way to avoid running any test that touches assembly in plonky2. Adding cfg attributes to every other test seems prohibitive. Maybe a naming scheme for miri tests and a `cargo test` filter would be good enough?