### PR TITLE
fix: tweak fetching of previous block hashes

### DIFF
--- a/zero_bin/rpc/src/lib.rs
+++ b/zero_bin/rpc/src/lib.rs
@@ -100,7 +100,7 @@ where
         std::iter::successors(Some(target_block_number as i128 - 1 + odd_offset), |&it| {
             Some(it - 1)
         })
-        .take(PREVIOUS_HASHES_COUNT)
+        .take(PREVIOUS_HASHES_COUNT + 1)
         .filter(|i| *i >= 0)
         .collect::<Vec<_>>();
     let concurrency = previous_block_numbers.len();


### PR DESCRIPTION
Oversight of #346: the witness fetching step for the previous hashes was missing the update on the most distant block hash from the current block (i.e. index 0 in the `b_hashes.prev_hashes` array).