### PR TITLE
fix: scale withdrawals amount to gwei

### DIFF
--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -30,7 +30,7 @@ use crate::{
         OtherBlockData, TrieRootHash, TxnIdx, EMPTY_ACCOUNT_BYTES_RLPED,
         ZERO_STORAGE_SLOT_VAL_RLPED,
     },
-    utils::{hash, optional_field, optional_field_hex, update_val_if_some},
+    utils::{eth_to_gwei, hash, optional_field, optional_field_hex, update_val_if_some},
 };
 
 /// Stores the result of parsing tries. Returns a [TraceParsingError] upon
@@ -617,7 +617,7 @@ impl ProcessedBlockTrace {
             })?;
             let mut acc_data = account_from_rlped_bytes(acc_bytes)?;
 
-            acc_data.balance += amt;
+            acc_data.balance += eth_to_gwei(amt);
 
             state
                 .insert(h_addr_nibs, rlp::encode(&acc_data).to_vec())

--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -563,8 +563,13 @@ impl ProcessedBlockTrace {
     fn add_withdrawals_to_txns(
         txn_ir: &mut [GenerationInputs],
         final_trie_state: &mut PartialTrieState,
-        withdrawals: Vec<(Address, U256)>,
+        mut withdrawals: Vec<(Address, U256)>,
     ) -> TraceParsingResult<()> {
+        // Scale withdrawals amounts.
+        for (_addr, amt) in withdrawals.iter_mut() {
+            *amt = eth_to_gwei(*amt)
+        }
+
         let withdrawals_with_hashed_addrs_iter = || {
             withdrawals
                 .iter()
@@ -617,7 +622,7 @@ impl ProcessedBlockTrace {
             })?;
             let mut acc_data = account_from_rlped_bytes(acc_bytes)?;
 
-            acc_data.balance += eth_to_gwei(amt);
+            acc_data.balance += amt;
 
             state
                 .insert(h_addr_nibs, rlp::encode(&acc_data).to_vec())

--- a/trace_decoder/src/utils.rs
+++ b/trace_decoder/src/utils.rs
@@ -1,4 +1,4 @@
-use ethereum_types::H256;
+use ethereum_types::{H256, U256};
 use keccak_hash::keccak;
 use log::trace;
 use mpt_trie::{
@@ -7,6 +7,11 @@ use mpt_trie::{
 };
 
 use crate::types::HashedStorageAddr;
+
+pub(crate) fn eth_to_gwei(eth: U256) -> U256 {
+    // 1 ether = 10^9 gwei.
+    eth * U256::from(10).pow(9.into())
+}
 
 pub(crate) fn hash(bytes: &[u8]) -> H256 {
     H256::from(keccak(bytes).0)


### PR DESCRIPTION
Withdrawals amounts that are written in blocks are in `gwei` unit (cf [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895#new-field-in-the-execution-payload-withdrawals)). We were currently processing them as `wei`, causing invalid balances on the targets and yielding invalid final state root. This hasn't been caught beforehand because:

- we've tested block contiguity only on John's test chains (which contained no withdrawals)
- benchmarks were targeting single blocks, hence we didn't need to connect the "_invalid_" final state root with the initial state root of the next block
- we don't check the `withdrawals_root` in the statement, hence no discrepancy noticed

We'd need to add some sanity checks to compare with the block header, but the response we keep post RPC requests does not currently contain the header's state root. Will add a tracking issue for it.