### PR TITLE
fix: limit iterator length when fetching block hashes

### DIFF
--- a/zero_bin/rpc/src/lib.rs
+++ b/zero_bin/rpc/src/lib.rs
@@ -138,6 +138,7 @@ where
         .into_iter()
         .flatten()
         .skip(odd_offset as usize)
+        .take(PREVIOUS_HASHES_COUNT)
         .for_each(|(hash, block_num)| {
             if let (Some(hash), Some(block_num)) = (hash, block_num) {
                 // Most recent previous block hash is expected at the end of the array


### PR DESCRIPTION
Something silly that we missed in #370, is that the iterator length isn't bounded by the fixed, constant size of the target array we're filling up. Instead, we iterate over the whole vector which, following latest fix, is 1 item too long for half the blocks (those with even offset), causing an underflow when indexing.