### PR TITLE
`cancun`: cleanup pre-release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ enumn = "0.1.13"
 env_logger = "0.11.3"
 eth_trie = "0.4.0"
 ethereum-types = "0.14.1"
-evm_arithmetization = { path = "evm_arithmetization", version = "0.2.0" }
 futures = "0.3.30"
 hashbrown = "0.14.5"
 hex = "0.4.3"
@@ -72,7 +71,6 @@ itertools = "0.13.0"
 keccak-hash = "0.10.0"
 log = "0.4.21"
 lru = "0.12.3"
-mpt_trie = { path = "mpt_trie", version = "0.3.0" }
 num = "0.4.3"
 num-bigint = "0.4.5"
 num-traits = "0.2.19"
@@ -84,7 +82,6 @@ paste = "1.0.15"
 pest = "2.7.10"
 pest_derive = "2.7.10"
 pretty_env_logger = "0.5.0"
-proof_gen = { path = "proof_gen", version = "0.2.0" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 ripemd = "0.1.3"
@@ -96,20 +93,25 @@ serde_json = "1.0.118"
 serde_path_to_error = "0.1.16"
 serde_with = "3.8.1"
 sha2 = "0.10.8"
-smt_trie = { path = "smt_trie", version = "0.1.0" }
 static_assertions = "1.1.0"
 thiserror = "1.0.61"
 tiny-keccak = "2.0.2"
 tokio = { version = "1.38.0", features = ["full"] }
 toml = "0.8.14"
 tower = "0.4"
-trace_decoder = { path = "trace_decoder", version = "0.4.0" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 u4 = "0.1.0"
 uint = "0.9.5"
 url = "2.5.2"
 winnow = "0.6.13"
+
+# local dependencies
+evm_arithmetization = { path = "evm_arithmetization", version = "0.2.0" }
+mpt_trie = { path = "mpt_trie", version = "0.3.0" }
+proof_gen = { path = "proof_gen", version = "0.2.0" }
+smt_trie = { path = "smt_trie", version = "0.1.0" }
+trace_decoder = { path = "trace_decoder", version = "0.4.0" }
 
 # zero-bin related dependencies
 ops = { path = "zero_bin/ops" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,19 @@
 [workspace]
 members = [
-    "compat",
-    "evm_arithmetization",
-    "mpt_trie",
-    "proc_macro",
-    "proof_gen",
-    "smt_trie",
-    "trace_decoder",
-    "zero_bin/common",
-    "zero_bin/leader",
-    "zero_bin/ops",
-    "zero_bin/prover",
-    "zero_bin/rpc",
-    "zero_bin/verifier",
-    "zero_bin/worker",
+  "compat",
+  "evm_arithmetization",
+  "mpt_trie",
+  "proc_macro",
+  "proof_gen",
+  "smt_trie",
+  "trace_decoder",
+  "zero_bin/common",
+  "zero_bin/leader",
+  "zero_bin/ops",
+  "zero_bin/prover",
+  "zero_bin/rpc",
+  "zero_bin/verifier",
+  "zero_bin/worker",
 ]
 resolver = "2"
 
@@ -28,18 +28,18 @@ categories = ["cryptography::cryptocurrencies"]
 [workspace.dependencies]
 __compat_primitive_types = { version = "0.12.2", package = "primitive-types" }
 alloy = { git = "https://github.com/alloy-rs/alloy", tag = 'v0.1.1', default-features = false, features = [
-    "consensus",
-    "reqwest",
-    "json-rpc",
-    "rlp",
-    "rpc",
-    "rpc-client",
-    "rpc-types-eth",
-    "rpc-types-trace",
-    "providers",
-    "transports",
-    "transport-http",
-    "rpc-types-debug",
+  "consensus",
+  "reqwest",
+  "json-rpc",
+  "rlp",
+  "rpc",
+  "rpc-client",
+  "rpc-types-eth",
+  "rpc-types-trace",
+  "providers",
+  "transports",
+  "transport-http",
+  "rpc-types-debug",
 ] }
 anyhow = "1.0.86"
 async-stream = "0.3.5"

--- a/compat/Cargo.toml
+++ b/compat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compat"
 version = "0.1.0"
-publish = false # TODO(<owner>): https://github.com/0xPolygonZero/zk_evm/issues/314 find a better place for this
+publish = false             # TODO(<owner>): https://github.com/0xPolygonZero/zk_evm/issues/314 find a better place for this
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -10,5 +10,5 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-alloy = {workspace = true }
+alloy = { workspace = true }
 __compat_primitive_types = { workspace = true }

--- a/evm_arithmetization/Cargo.toml
+++ b/evm_arithmetization/Cargo.toml
@@ -3,8 +3,8 @@ name = "evm_arithmetization"
 description = "Implementation of STARKs for the Ethereum Virtual Machine"
 version = "0.2.0"
 authors = [
-    "Daniel Lubarov <daniel@lubarov.com>",
-    "William Borgeaud <williamborgeaud@gmail.com>",
+  "Daniel Lubarov <daniel@lubarov.com>",
+  "William Borgeaud <williamborgeaud@gmail.com>",
 ]
 readme = "README.md"
 categories = ["cryptography"]
@@ -57,9 +57,9 @@ ripemd = { workspace = true }
 default = ["parallel"]
 asmtools = ["hex"]
 parallel = [
-    "plonky2/parallel",
-    "plonky2_maybe_rayon/parallel",
-    "starky/parallel",
+  "plonky2/parallel",
+  "plonky2_maybe_rayon/parallel",
+  "starky/parallel",
 ]
 
 [[bin]]

--- a/evm_arithmetization/src/cpu/columns/general.rs
+++ b/evm_arithmetization/src/cpu/columns/general.rs
@@ -21,7 +21,7 @@ impl<T: Copy> CpuGeneralColumnsView<T> {
     /// View of the columns used for exceptions: they are the exception code
     /// bits. SAFETY: Each view is a valid interpretation of the underlying
     /// array.
-    pub(crate) fn exception(&self) -> &CpuExceptionView<T> {
+    pub(crate) const fn exception(&self) -> &CpuExceptionView<T> {
         unsafe { &self.exception }
     }
 
@@ -34,7 +34,7 @@ impl<T: Copy> CpuGeneralColumnsView<T> {
 
     /// View of the columns required for logic operations.
     /// SAFETY: Each view is a valid interpretation of the underlying array.
-    pub(crate) fn logic(&self) -> &CpuLogicView<T> {
+    pub(crate) const fn logic(&self) -> &CpuLogicView<T> {
         unsafe { &self.logic }
     }
 
@@ -46,7 +46,7 @@ impl<T: Copy> CpuGeneralColumnsView<T> {
 
     /// View of the columns required for jump operations.
     /// SAFETY: Each view is a valid interpretation of the underlying array.
-    pub(crate) fn jumps(&self) -> &CpuJumpsView<T> {
+    pub(crate) const fn jumps(&self) -> &CpuJumpsView<T> {
         unsafe { &self.jumps }
     }
 
@@ -58,7 +58,7 @@ impl<T: Copy> CpuGeneralColumnsView<T> {
 
     /// View of the columns required for shift operations.
     /// SAFETY: Each view is a valid interpretation of the underlying array.
-    pub(crate) fn shift(&self) -> &CpuShiftView<T> {
+    pub(crate) const fn shift(&self) -> &CpuShiftView<T> {
         unsafe { &self.shift }
     }
 
@@ -70,7 +70,7 @@ impl<T: Copy> CpuGeneralColumnsView<T> {
 
     /// View of the columns required for the stack top.
     /// SAFETY: Each view is a valid interpretation of the underlying array.
-    pub(crate) fn stack(&self) -> &CpuStackView<T> {
+    pub(crate) const fn stack(&self) -> &CpuStackView<T> {
         unsafe { &self.stack }
     }
 
@@ -82,7 +82,7 @@ impl<T: Copy> CpuGeneralColumnsView<T> {
 
     /// View of the columns required for the push operation.
     /// SAFETY: Each view is a valid interpretation of the underlying array.
-    pub(crate) fn push(&self) -> &CpuPushView<T> {
+    pub(crate) const fn push(&self) -> &CpuPushView<T> {
         unsafe { &self.push }
     }
 

--- a/evm_arithmetization/src/cpu/kernel/asm/core/create_receipt.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/create_receipt.asm
@@ -129,7 +129,7 @@ process_receipt_logs_loop:
     MLOAD_GENERAL
     %append_to_trie_data
     // stack: addr_ptr, i, num_logs, receipt_ptr, txn_nb, new_cum_gas, txn_nb, num_nibbles, retdest
-    //Write num_topics.
+    // Write num_topics.
     %increment
     // stack: num_topics_ptr, i, num_logs, receipt_ptr, txn_nb, new_cum_gas, txn_nb, num_nibbles, retdest
     DUP1

--- a/evm_arithmetization/src/cpu/kernel/asm/core/jumpdest_analysis.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/jumpdest_analysis.asm
@@ -134,7 +134,7 @@ global write_table_if_jumpdest:
 
     %jump_neq_const(0x5b, return)
 
-    //stack: jumpdest, ctx, proof_prefix_addr, retdest
+    // stack: jumpdest, ctx, proof_prefix_addr, retdest
     SWAP2 DUP1
     // stack: proof_prefix_addr, proof_prefix_addr, ctx, jumpdest
     ISZERO

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/msm.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/msm.asm
@@ -10,7 +10,7 @@ global bn_msm_loop:
     DUP1 %jumpi(bn_msm_loop_add_a_nonzero)
     POP
 msm_loop_add_b:
-    //stack: accx, accy, i, retdest
+    // stack: accx, accy, i, retdest
     DUP3 %bn_mload_wnaf_b
     // stack: w, accx, accy, i, retdest
     DUP1 %jumpi(bn_msm_loop_add_b_nonzero)
@@ -20,7 +20,7 @@ msm_loop_contd:
     // TODO: the GLV scalars for the BN curve are 127-bit, so could use 127 here. But this would require modifying `wnaf.asm`. Not sure it's worth it...
     %eq_const(129) %jumpi(msm_end)
     %increment
-    //stack: i+1, accx, accy, retdest
+    // stack: i+1, accx, accy, retdest
     %stack (i, accx, accy, retdest) -> (accx, accy, bn_msm_loop, i, retdest)
     %jump(bn_double)
 
@@ -54,9 +54,9 @@ bn_msm_loop_add_b_nonzero:
     // stack: w
     DUP1
     %mload_current(@SEGMENT_BN_TABLE_Q)
-    //stack: Gy, w
+    // stack: Gy, w
     SWAP1 %decrement %mload_current(@SEGMENT_BN_TABLE_Q)
-    //stack: Gx, Gy
+    // stack: Gx, Gy
 %endmacro
 
 %macro bn_mload_point_b
@@ -67,7 +67,7 @@ bn_msm_loop_add_b_nonzero:
     %stack (bneg, Gy, w) -> (@BN_BASE, Gy, bneg, bneg, Gy, w)
     SUB SWAP1 ISZERO MUL SWAP2 MUL ADD
     SWAP1 %decrement %mload_current(@SEGMENT_BN_TABLE_Q)
-    //stack: Gx, Gy
+    // stack: Gx, Gy
     PUSH @BN_GLV_BETA
     MULFP254
 %endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/insert/insert.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/insert/insert.asm
@@ -42,7 +42,7 @@ global mpt_insert_branch:
     // stack: node_type, node_payload_ptr, num_nibbles, key, value_ptr, retdest
     POP
 
-    //stack: node_payload_ptr, num_nibbles, key, value_ptr, retdest
+    // stack: node_payload_ptr, num_nibbles, key, value_ptr, retdest
 
     // At this point, we branch based on whether the key terminates with this branch node.
     // stack: node_payload_ptr, num_nibbles, key, value_ptr, retdest

--- a/evm_arithmetization/src/witness/traces.rs
+++ b/evm_arithmetization/src/witness/traces.rs
@@ -37,7 +37,7 @@ pub(crate) struct Traces<T: Copy> {
 }
 
 impl<T: Copy> Traces<T> {
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Traces {
             arithmetic_ops: vec![],
             byte_packing_ops: vec![],

--- a/mpt_trie/Cargo.toml
+++ b/mpt_trie/Cargo.toml
@@ -9,9 +9,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
-exclude = [
-    "test_data/*"
-]
+exclude = ["test_data/*"]
 
 [dependencies]
 bytes = { workspace = true }

--- a/mpt_trie/src/builder.rs
+++ b/mpt_trie/src/builder.rs
@@ -28,7 +28,7 @@ pub struct PartialTrieBuilder<T> {
 
 impl<T: PartialTrie> PartialTrieBuilder<T> {
     /// Creates a new `PartialTrieBuilder` with the given root and nodes.
-    pub fn new(root: H256, nodes: HashMap<H256, Vec<u8>>) -> Self {
+    pub const fn new(root: H256, nodes: HashMap<H256, Vec<u8>>) -> Self {
         PartialTrieBuilder {
             root,
             nodes,

--- a/mpt_trie/src/nibbles.rs
+++ b/mpt_trie/src/nibbles.rs
@@ -912,7 +912,7 @@ impl Nibbles {
 
     /// Returns a slice of the internal bytes of packed nibbles.
     /// Only the relevant bytes (up to `count` nibbles) are considered valid.
-    pub fn as_byte_slice(&self) -> &[u8] {
+    pub const fn as_byte_slice(&self) -> &[u8] {
         // Calculate the number of full bytes needed to cover 'count' nibbles
         let bytes_needed = (self.count + 1) / 2; // each nibble is half a byte
 

--- a/smt_trie/src/bits.rs
+++ b/smt_trie/src/bits.rs
@@ -44,14 +44,14 @@ impl Add for Bits {
 }
 
 impl Bits {
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Bits {
             count: 0,
             packed: U256::zero(),
         }
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.count == 0
     }
 

--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -89,7 +89,7 @@ impl std::error::Error for TraceParsingError {}
 
 impl TraceParsingError {
     /// Function to create a new TraceParsingError with mandatory fields
-    fn new(reason: TraceParsingErrorReason) -> Self {
+    const fn new(reason: TraceParsingErrorReason) -> Self {
         Self {
             block_num: None,
             block_chain_id: None,

--- a/zero_bin/common/src/prover_state/circuit.rs
+++ b/zero_bin/common/src/prover_state/circuit.rs
@@ -200,7 +200,7 @@ impl CircuitConfig {
     }
 
     /// Get all circuits specified in the config.
-    pub fn as_degree_bits_ranges(&self) -> &[Range<usize>; NUM_TABLES] {
+    pub const fn as_degree_bits_ranges(&self) -> &[Range<usize>; NUM_TABLES] {
         &self.circuits
     }
 

--- a/zero_bin/common/src/prover_state/cli.rs
+++ b/zero_bin/common/src/prover_state/cli.rs
@@ -33,7 +33,10 @@ pub enum CircuitPersistence {
 }
 
 impl CircuitPersistence {
-    pub fn with_load_strategy(self, load_strategy: TableLoadStrategy) -> super::CircuitPersistence {
+    pub const fn with_load_strategy(
+        self,
+        load_strategy: TableLoadStrategy,
+    ) -> super::CircuitPersistence {
         match self {
             CircuitPersistence::None => super::CircuitPersistence::None,
             CircuitPersistence::Disk => super::CircuitPersistence::Disk(load_strategy),

--- a/zero_bin/common/src/prover_state/mod.rs
+++ b/zero_bin/common/src/prover_state/mod.rs
@@ -125,7 +125,7 @@ pub struct ProverStateManager {
 }
 
 impl ProverStateManager {
-    pub fn with_load_strategy(self, load_strategy: TableLoadStrategy) -> Self {
+    pub const fn with_load_strategy(self, load_strategy: TableLoadStrategy) -> Self {
         match self.persistence {
             CircuitPersistence::None => self,
             CircuitPersistence::Disk(_) => Self {

--- a/zero_bin/ops/Cargo.toml
+++ b/zero_bin/ops/Cargo.toml
@@ -16,7 +16,7 @@ proof_gen = { workspace = true }
 tracing = { workspace = true }
 keccak-hash = { workspace = true }
 
-zero_bin_common ={ path = "../common" }
+zero_bin_common = { path = "../common" }
 
 [features]
 default = []

--- a/zero_bin/prover/Cargo.toml
+++ b/zero_bin/prover/Cargo.toml
@@ -17,11 +17,11 @@ paladin-core = { workspace = true }
 anyhow = { workspace = true }
 futures = { workspace = true }
 alloy.workspace = true
-tokio = {workspace = true}
-serde_json = {workspace = true}
+tokio = { workspace = true }
+serde_json = { workspace = true }
 ruint = { workspace = true, features = ["num-traits", "primitive-types"] }
 ops = { workspace = true }
-zero_bin_common ={ workspace = true }
+zero_bin_common = { workspace = true }
 num-traits = { workspace = true }
 
 [features]

--- a/zero_bin/rpc/src/native/txn.rs
+++ b/zero_bin/rpc/src/native/txn.rs
@@ -278,7 +278,7 @@ async fn process_code(
 }
 
 /// Processes the self destruct for the given account state.
-fn process_self_destruct(
+const fn process_self_destruct(
     post_state: Option<&AccountState>,
     pre_state: Option<&AccountState>,
 ) -> Option<bool> {

--- a/zero_bin/rpc/src/provider.rs
+++ b/zero_bin/rpc/src/provider.rs
@@ -39,7 +39,7 @@ where
         &mut self.provider
     }
 
-    pub fn as_provider(&self) -> &ProviderT {
+    pub const fn as_provider(&self) -> &ProviderT {
         &self.provider
     }
 

--- a/zero_bin/rpc/src/retry.rs
+++ b/zero_bin/rpc/src/retry.rs
@@ -32,7 +32,7 @@ impl Clone for RetryPolicy {
 }
 
 impl RetryPolicy {
-    pub fn new(backoff: tokio::time::Duration, max_retries: u32) -> Self {
+    pub const fn new(backoff: tokio::time::Duration, max_retries: u32) -> Self {
         Self {
             backoff,
             retries: 0,

--- a/zero_bin/verifier/Cargo.toml
+++ b/zero_bin/verifier/Cargo.toml
@@ -15,4 +15,4 @@ serde_path_to_error = { workspace = true }
 proof_gen = { workspace = true }
 
 # Local dependencies
-zero_bin_common ={ path = "../common" }
+zero_bin_common = { path = "../common" }


### PR DESCRIPTION
Just a couple tweaks. Includes

- `clippy::missing_const_fn`
- `taplo fmt`
- some stack comments fixes in the Kernel assembly code