### PR TITLE
Now warns if file descriptor limit is too small for native mode

### DIFF
--- a/zero_bin/tools/prove_rpc.sh
+++ b/zero_bin/tools/prove_rpc.sh
@@ -61,7 +61,7 @@ OUTPUT_TO_TERMINAL="${OUTPUT_TO_TERMINAL:-false}"
 RUN_VERIFICATION="${RUN_VERIFICATION:-false}"
 
 # Recommended soft file handle limit. Will warn if it is set lower.
-RECOMMENDED_FILE_HANDLE_LIMIT=4096
+RECOMMENDED_FILE_HANDLE_LIMIT=8192
 
 mkdir -p $PROOF_OUTPUT_DIR
 
@@ -101,7 +101,7 @@ then
         echo "WARNING: Maximum file descriptor limit may be too low to run native mode (current: $file_desc_limit, Recommended: ${RECOMMENDED_FILE_HANDLE_LIMIT}).
         Consider increasing it with:
 
-        ulimit -s ${RECOMMENDED_FILE_HANDLE_LIMIT}"
+        ulimit -n ${RECOMMENDED_FILE_HANDLE_LIMIT}"
     fi
 fi
 


### PR DESCRIPTION
Just prints out a warning in `prove_rpc.sh` if the user has a file descriptor limit that is deemed too small when they are running in native mode. Does not attempt to change the limit (should we? We don't need root for this).

If the limit is too small, then there's a good chance that we'll get various IO errors related to this with `native` mode. (#354 )