### PR TITLE
Serialize flaky inputs as 'json' files

### DIFF
--- a/zero_bin/ops/src/lib.rs
+++ b/zero_bin/ops/src/lib.rs
@@ -34,7 +34,7 @@ impl Operation for TxProof {
                 .map_err(|err| {
                     if let Err(write_err) = save_inputs_to_disk(
                         format!(
-                            "b{}_txn_{}_input.log",
+                            "b{}_txn_{}_input.json",
                             input.block_metadata.block_number, input.txn_number_before
                         ),
                         input,
@@ -69,7 +69,7 @@ impl Operation for TxProof {
             .map_err(|err| {
                 if let Err(write_err) = save_inputs_to_disk(
                     format!(
-                        "b{}_txn_{}_input.log",
+                        "b{}_txn_{}_input.json",
                         input.block_metadata.block_number, input.txn_number_before
                     ),
                     input,
@@ -171,7 +171,7 @@ impl Monoid for AggProof {
                 ];
                 if let Err(write_err) = save_inputs_to_disk(
                     format!(
-                        "b{}_agg_lhs_rhs_inputs.log",
+                        "b{}_agg_lhs_rhs_inputs.json",
                         pv[0].block_metadata.block_number
                     ),
                     pv,
@@ -208,7 +208,7 @@ impl Operation for BlockProof {
                 if self.save_inputs_on_error {
                     if let Err(write_err) = save_inputs_to_disk(
                         format!(
-                            "b{}_block_input.log",
+                            "b{}_block_input.json",
                             input.p_vals.block_metadata.block_number
                         ),
                         input.p_vals,


### PR DESCRIPTION
When passing `--save-inputs-on-error` flag, we automatically write to disk the `GenerationInputs` that caused the proof generation to fail. The current extension is `.log` which is a bit confusing, especially as we serialize them into a pretty JSON string.