### PR TITLE
Check for overflow in `context_id` increment

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/util.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/util.asm
@@ -14,6 +14,12 @@
     %add_const(0x10000000000000000) // scale each context by 2^64
     // stack: new_ctx
     DUP1
+    PUSH 0xffffffffffffffffffffffff // 2^96 - 1
+    // stack: max, new_ctx, new_ctx
+    LT
+    %jumpi(fault_exception)
+    // stack: new_ctx
+    DUP1
     %mstore_global_metadata(@GLOBAL_METADATA_LARGEST_CONTEXT)
     // stack: new_ctx
 %endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/core/util.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/util.asm
@@ -14,10 +14,15 @@
     %add_const(0x10000000000000000) // scale each context by 2^64
     // stack: new_ctx
     DUP1
+
+    // Memory addresses are represented as `ctx.2^64 + segment.2^32 + offset`,
+    // each address component expected to fit in a 32-bit limb.
+    // We enforce here that the new context id won't overflow.
     PUSH 0xffffffffffffffffffffffff // 2^96 - 1
     // stack: max, new_ctx, new_ctx
     LT
     %jumpi(fault_exception)
+
     // stack: new_ctx
     DUP1
     %mstore_global_metadata(@GLOBAL_METADATA_LARGEST_CONTEXT)


### PR DESCRIPTION
Addresses Issue J of the audit report, even though as the audit mentions:
> _this Issue [is] unexploitable in practice._