### PR TITLE
Ensure proper `offset + size` bounds in `wcopy`

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/memory/metadata.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/metadata.asm
@@ -453,6 +453,19 @@ zero_hash:
     // stack: sum
 %endmacro
 
+// Adds the two top elements of the stack, and faults in case of overflow modulo 2^32.
+%macro add_u32_or_fault
+    // stack: x, y
+    %add_or_fault
+    DUP1
+    // stack: sum, sum
+    PUSH 0xffffffff // 2^32 - 1
+    LT
+    // stack: is_overflow, sum
+    %jumpi(fault_exception)
+    // stack: sum
+%endmacro
+
 %macro call_depth
     %mload_global_metadata(@GLOBAL_METADATA_CALL_STACK_DEPTH)
 %endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
@@ -79,7 +79,14 @@ calldataload_large_offset:
     // stack: kexit_info, dest_offset, offset, size
     %wcopy_charge_gas
 
-    %stack (kexit_info, dest_offset, offset, size) -> (dest_offset, size, kexit_info, dest_offset, offset, size)
+    // Ensure that `offset + size` won't overflow the reserved 32-bit limb
+    // of the `virtual` component of the source memory address.
+    DUP4 DUP4
+    // stack: offset, size, kexit_info, dest_offset, offset, size
+    %add_u32_or_fault
+
+    %stack (offset_plus_size, kexit_info, dest_offset, offset, size) ->
+        (dest_offset, size, kexit_info, dest_offset, offset, size)
     %add_or_fault
     // stack: expanded_num_bytes, kexit_info, dest_offset, offset, size, kexit_info
     DUP1 %ensure_reasonable_offset


### PR DESCRIPTION
Addresses Issue H of the audit report.