### PR TITLE
fix: `StorageTrie`, `ReceiptTrie` and `TransactionTrie` shouldn't use `TypedMpt`

### DIFF
--- a/trace_decoder/src/type1.rs
+++ b/trace_decoder/src/type1.rs
@@ -132,7 +132,7 @@ fn node2storagetrie(node: Node) -> anyhow::Result<StorageTrie> {
                 match value {
                     Either::Left(Value { raw_value }) => mpt.insert(
                         TriePath::new(path.iter().copied().chain(key))?,
-                        raw_value.into_vec(),
+                        rlp::encode(&raw_value.as_slice()).to_vec(),
                     )?,
                     Either::Right(_) => bail!("unexpected account node in storage trie"),
                 };

--- a/trace_decoder/src/typed_mpt.rs
+++ b/trace_decoder/src/typed_mpt.rs
@@ -63,22 +63,6 @@ impl<T> TypedMpt<T> {
             and only encoded `T`s are ever inserted",
         ))
     }
-    /// # Panics
-    /// - If [`rlp::decode`]-ing for `T` doesn't round-trip.
-    fn remove(&mut self, path: TriePath) -> Result<Option<T>, Error>
-    where
-        T: rlp::Decodable,
-    {
-        match self.inner.delete(path.into_nibbles()) {
-            Ok(None) => Ok(None),
-            Ok(Some(bytes)) => Ok(Some(rlp::decode(&bytes).expect(
-                "T encoding/decoding should round-trip,\
-                    and only encoded `T`s are ever inserted",
-            ))),
-            // TODO(0xaatif): why is this fallible if `get` isn't?
-            Err(source) => Err(Error { source }),
-        }
-    }
     fn as_hashed_partial_trie(&self) -> &HashedPartialTrie {
         &self.inner
     }
@@ -328,15 +312,4 @@ impl StorageTrie {
     pub fn as_mut_hashed_partial_trie_unchecked(&mut self) -> &mut HashedPartialTrie {
         &mut self.untyped
     }
-}
-
-#[test]
-fn test() {
-    let hash = H256(std::array::from_fn(|ix| ix as _));
-    let mut ours = StorageTrie::default();
-    ours.insert_hash(TriePath::default(), hash).unwrap();
-    assert_eq!(
-        ours.as_hashed_partial_trie(),
-        &HashedPartialTrie::new(Node::Hash(hash))
-    );
 }


### PR DESCRIPTION
#413 

Snippets from `0xaatif/typed-backend2` that fix the bug.
The basic change is
```diff,rust
struct FooTrie {
-    typed: TypedMpt<Vec<u8>>,
+    untyped: HashedPartialTrie,
}
```

The following oracle passes

```bash
cargo build --release 

RUST_LOG=info ./target/release/leader \
    --runtime in-memory \
    --load-strategy on-demand rpc \
    --rpc-type native \
    --rpc-url "$RPC_URL" \
    --block-interval 19807080..19807081 \
    --backoff 1000 \
    --max-retries 1000
```