### PR TITLE
fix: set min stack length for transient opcodes

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/exception.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/exception.asm
@@ -256,8 +256,8 @@ min_stack_len_for_opcode:
     BYTES 0  // 0x59, MSIZE
     BYTES 0  // 0x5a, GAS
     BYTES 0  // 0x5b, JUMPDEST
-    BYTES 0  // 0x5c, invalid
-    BYTES 0  // 0x5d, invalid
+    BYTES 1  // 0x5c, TLOAD
+    BYTES 2  // 0x5d, TSTORE
     BYTES 3  // 0x5e, MCOPY
 
     %rep 33 // 0x5f-0x7f, PUSH0-PUSH32


### PR DESCRIPTION
The minimum stack length requirement was not properly set for `TLOAD` / `TSTORE` opcodes.