### PR TITLE
 Fix jump_to

### DIFF
--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -350,13 +350,16 @@ impl<F: Field> GenerationState<F> {
     /// we're jumping to a special location.
     pub(crate) fn jump_to(&mut self, dst: usize) -> Result<(), ProgramError> {
         self.registers.program_counter = dst;
-        if dst == KERNEL.global_labels["observe_new_address"] {
-            let tip_u256 = stack_peek(self, 0)?;
+        if dst == KERNEL.global_labels["observe_new_address"] && self.get_registers().stack_len > 0
+        {
+            let tip_u256 = stack_peek(self, 0).expect("There cannot be a stack underflow");
             let tip_h256 = H256::from_uint(&tip_u256);
             let tip_h160 = H160::from(tip_h256);
             self.observe_address(tip_h160);
-        } else if dst == KERNEL.global_labels["observe_new_contract"] {
-            let tip_u256 = stack_peek(self, 0)?;
+        } else if dst == KERNEL.global_labels["observe_new_contract"]
+            && self.get_registers().stack_len > 0
+        {
+            let tip_u256 = stack_peek(self, 0).expect("There cannot be a stack underflow");
             let tip_h256 = H256::from_uint(&tip_u256);
             self.observe_contract(tip_h256)?;
         }

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -350,16 +350,17 @@ impl<F: Field> GenerationState<F> {
     /// we're jumping to a special location.
     pub(crate) fn jump_to(&mut self, dst: usize) -> Result<(), ProgramError> {
         self.registers.program_counter = dst;
-        if dst == KERNEL.global_labels["observe_new_address"] && self.get_registers().stack_len > 0
-        {
-            let tip_u256 = stack_peek(self, 0).expect("There cannot be a stack underflow");
+        if self.stack().is_empty() {
+            // We cannot observe anything as the stack is empty.
+            return Ok(());
+        }
+        if dst == KERNEL.global_labels["observe_new_address"] {
+            let tip_u256 = stack_peek(self, 0)?;
             let tip_h256 = H256::from_uint(&tip_u256);
             let tip_h160 = H160::from(tip_h256);
             self.observe_address(tip_h160);
-        } else if dst == KERNEL.global_labels["observe_new_contract"]
-            && self.get_registers().stack_len > 0
-        {
-            let tip_u256 = stack_peek(self, 0).expect("There cannot be a stack underflow");
+        } else if dst == KERNEL.global_labels["observe_new_contract"] {
+            let tip_u256 = stack_peek(self, 0)?;
             let tip_h256 = H256::from_uint(&tip_u256);
             self.observe_contract(tip_h256)?;
         }


### PR DESCRIPTION
`stack_peek` throws an exception if the stack is too small. But we also use `stack_peek` for debugging purposes, which might throw unwanted exceptions. This PR fixes this by ensuring the stack is not empty before carrying out the debugging operations.