### PR TITLE
Added derives to `pub` types where possible for `mpt_trie`

### DIFF
--- a/mpt_trie/src/builder.rs
+++ b/mpt_trie/src/builder.rs
@@ -18,7 +18,7 @@ const EMPTY_TRIE_HASH: H256 = H256([
     0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0, 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21,
 ]);
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 /// A builder for constructing a partial trie from a collection of nodes.
 pub struct PartialTrieBuilder<T> {
     root: H256,

--- a/mpt_trie/src/debug_tools/diff.rs
+++ b/mpt_trie/src/debug_tools/diff.rs
@@ -46,7 +46,7 @@ fn get_key_piece_from_node<T: PartialTrie>(n: &Node<T>) -> Nibbles {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 /// The difference between two Tries, represented as the highest
 /// point of a structural divergence.
 pub struct TrieDiff {

--- a/mpt_trie/src/debug_tools/query.rs
+++ b/mpt_trie/src/debug_tools/query.rs
@@ -34,7 +34,7 @@ fn get_key_piece_from_node_pulling_from_key_for_branches<T: PartialTrie>(
 /// By default, the node type along with its key piece is printed out per node
 /// (eg. "Leaf(0x1234)"). Additional node specific information can be printed
 /// out by enabling `include_node_specific_values`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash)]
 pub struct DebugQueryParams {
     /// Include (if applicable) the piece of the key that is contained by the
     /// node (eg. ("0x1234")).
@@ -58,7 +58,7 @@ impl Default for DebugQueryParams {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, Hash)]
 /// A wrapper for `DebugQueryParams`.
 pub struct DebugQueryParamsBuilder {
     params: DebugQueryParams,
@@ -93,7 +93,7 @@ impl DebugQueryParamsBuilder {
 }
 
 /// The payload to give to the query function. Construct this from the builder.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 pub struct DebugQuery {
     k: Nibbles,
     params: DebugQueryParams,
@@ -110,7 +110,7 @@ impl From<Nibbles> for DebugQuery {
 
 /// Extra data that is associated with a node. Only used if
 /// `include_node_specific_values` is `true`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash)]
 enum ExtraNodeSegmentInfo {
     Hash(H256),
     Branch { child_mask: u16 },
@@ -169,7 +169,7 @@ fn count_non_empty_branch_children_from_mask(mask: u16) -> usize {
     num_children
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash)]
 /// The result of a debug query contains information
 /// of the path used for searching for a key in the trie.
 pub struct DebugQueryOutput {

--- a/mpt_trie/src/debug_tools/stats.rs
+++ b/mpt_trie/src/debug_tools/stats.rs
@@ -9,7 +9,7 @@ use num_traits::ToPrimitive;
 
 use crate::partial_trie::{Node, PartialTrie};
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 /// Statistics for a given trie, consisting of node count aggregated
 /// by time, lowest depth and average depth of leaf and hash nodes.
 pub struct TrieStats {
@@ -43,7 +43,7 @@ impl TrieStats {
 }
 
 /// Total node counts for a trie.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, Hash)]
 struct NodeCounts {
     empty: usize,
     hash: usize,
@@ -106,7 +106,7 @@ impl NodeCounts {
 }
 
 /// Information on the comparison between two tries.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TrieComparison {
     node_comp: NodeComparison,
     depth_comp: DepthComparison,
@@ -120,7 +120,7 @@ impl Display for TrieComparison {
 }
 
 // TODO: Consider computing these values lazily?
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 struct NodeComparison {
     tot_node_rat: RatioStat<usize>,
     non_empty_rat: RatioStat<usize>,
@@ -145,7 +145,7 @@ impl Display for NodeComparison {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct DepthComparison {
     lowest_depth_rat: RatioStat<usize>,
     avg_leaf_depth_rat: RatioStat<f32>,
@@ -160,8 +160,8 @@ impl Display for DepthComparison {
     }
 }
 
-/// Type to hold (and compare) a given variable from two different tries.s
-#[derive(Debug)]
+/// Type to hold (and compare) a given variable from two different tries.
+#[derive(Clone, Debug, Hash)]
 struct RatioStat<T> {
     a: T,
     b: T,

--- a/mpt_trie/src/nibbles.rs
+++ b/mpt_trie/src/nibbles.rs
@@ -72,7 +72,7 @@ pub trait ToNibbles {
     }
 }
 
-#[derive(Clone, Debug, Error)]
+#[derive(Clone, Debug, Eq, Error, PartialEq, Hash)]
 /// Errors encountered when converting from `Bytes` to `Nibbles`.
 pub enum BytesToNibblesError {
     #[error("Tried constructing `Nibbles` from a zero byte slice")]
@@ -84,7 +84,7 @@ pub enum BytesToNibblesError {
     TooManyBytes(usize),
 }
 
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Eq, Error, PartialEq, Hash)]
 /// Errors encountered when converting to hex prefix encoding to nibbles.
 pub enum FromHexPrefixError {
     #[error("Tried to convert a hex prefix byte string into `Nibbles` with invalid flags at the start: {0:#04b}")]
@@ -97,7 +97,7 @@ pub enum FromHexPrefixError {
 }
 
 /// Error type for conversion.
-#[derive(Clone, Debug, Error)]
+#[derive(Clone, Debug, Eq, Error, PartialEq, Hash)]
 pub enum NibblesToTypeError {
     #[error("Overflow encountered when converting to U256: {0}")]
     /// Overflow encountered.

--- a/mpt_trie/src/special_query.rs
+++ b/mpt_trie/src/special_query.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// An iterator for a trie query. Note that this iterator is lazy.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 pub struct TriePathIter<N: PartialTrie> {
     /// The next node in the trie to query with the remaining key.
     curr_node: WrappedNode<N>,

--- a/mpt_trie/src/trie_hashing.rs
+++ b/mpt_trie/src/trie_hashing.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// The node type used for calculating the hash of a trie.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 pub enum EncodedNode {
     /// Node that is RLPed but not hashed.
     Raw(Bytes),

--- a/mpt_trie/src/trie_ops.rs
+++ b/mpt_trie/src/trie_ops.rs
@@ -19,7 +19,7 @@ use crate::{
 pub type TrieOpResult<T> = Result<T, TrieOpError>;
 
 /// An error type for trie operation.
-#[derive(Clone, Debug, Error)]
+#[derive(Clone, Debug, Eq, Error, Hash, PartialEq)]
 pub enum TrieOpError {
     /// An error that occurs when a hash node is found during an insert
     /// operation.
@@ -165,21 +165,21 @@ enum ExistingOrNewBranchValuePlacement<N> {
     BothBranchChildren((Nibble, WrappedNode<N>), (Nibble, WrappedNode<N>)),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 enum IterStackEntry<N> {
     Root(WrappedNode<N>),
     Extension(usize),
     Branch(BranchStackEntry<N>),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 struct BranchStackEntry<N> {
     children: [WrappedNode<N>; 16],
     value: Vec<u8>,
     curr_nib: Nibble,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash)]
 /// An iterator that ranges over all the leafs and hash nodes
 /// of the trie, in lexicographic order.
 pub struct PartialTrieIter<N> {

--- a/mpt_trie/src/trie_subsets.rs
+++ b/mpt_trie/src/trie_subsets.rs
@@ -22,7 +22,7 @@ use crate::{
 pub type SubsetTrieResult<T> = Result<T, SubsetTrieError>;
 
 /// Errors that may occur when creating a subset [`PartialTrie`].
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error, Hash)]
 pub enum SubsetTrieError {
     #[error("Tried to mark nodes in a tracked trie for a key that does not exist! (Key: {0}, trie: {1})")]
     /// The key does not exist in the trie.

--- a/mpt_trie/src/utils.rs
+++ b/mpt_trie/src/utils.rs
@@ -16,7 +16,7 @@ use crate::{
     trie_ops::TrieOpResult,
 };
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 /// Simplified trie node type to make logging cleaner.
 pub enum TrieNodeType {
     /// Empty node.


### PR DESCRIPTION
- I think for public libraries it's generally a good idea to add as many derives as possible to public types since we want to make these types as easy to use as possible for the user.
- This PR just goes through and adds derives where possible (for all of the cases where we don't need to add any manual trait impls).