### PR TITLE
Do not propagate zero values

### DIFF
--- a/evm_arithmetization/src/memory/columns.rs
+++ b/evm_arithmetization/src/memory/columns.rs
@@ -67,8 +67,13 @@ pub(crate) const STALE_CONTEXTS_FREQUENCIES: usize = IS_PRUNED + 1;
 // `ADDR_CONTEXT` + 1 is in `STALE_CONTEXTS`.
 pub(crate) const IS_STALE: usize = STALE_CONTEXTS_FREQUENCIES + 1;
 
-// Filter for the `MemAfter` CTL.
-pub(crate) const MEM_AFTER_FILTER: usize = IS_STALE + 1;
+// Flag indicating that a value can potentially be propagated.
+// Contains `filter * address_changed * is_not_stale`.
+pub(crate) const MAYBE_IN_MEM_AFTER: usize = IS_STALE + 1;
+
+// Filter for the `MemAfter` CTL. Is equal to `MAYBE_IN_MEM_AFTER` if segment is
+// preinitialized or the value is non-zero, is 0 otherwise.
+pub(crate) const MEM_AFTER_FILTER: usize = MAYBE_IN_MEM_AFTER + 1;
 
 // We use a range check to enforce the ordering.
 pub(crate) const RANGE_CHECK: usize = MEM_AFTER_FILTER + 1;

--- a/evm_arithmetization/src/memory/memory_stark.rs
+++ b/evm_arithmetization/src/memory/memory_stark.rs
@@ -260,13 +260,11 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
             {
                 // `maybe_in_mem_after = filter * address_changed * (1 - is_stale)`
                 trace_col_vecs[MAYBE_IN_MEM_AFTER][i] = F::ONE;
-                // For efficiency, `mem_after_filter` is forcefully left to 0 if:
-                // - value is zero AND
-                // - segment is not preinitialized.
-                // Else, it's set to `maybe_in_mem_after`, which is 1 only in the current case.
+
                 let addr_segment = trace_col_vecs[ADDR_SEGMENT][i];
                 let is_non_zero_value =
                     (0..VALUE_LIMBS).any(|limb| trace_col_vecs[value_limb(limb)][i].is_nonzero());
+                // We filter out zero values in non-preinitialized segments.
                 if is_non_zero_value
                     || PREINITIALIZED_SEGMENTS_INDICES
                         .contains(&(addr_segment.to_canonical_u64() as usize))

--- a/evm_arithmetization/src/memory/segments.rs
+++ b/evm_arithmetization/src/memory/segments.rs
@@ -82,6 +82,14 @@ pub(crate) enum Segment {
     StorageLinkedList = 35 << SEGMENT_SCALING_FACTOR,
 }
 
+// These segments are not zero-initialized.
+pub(crate) const PREINITIALIZED_SEGMENTS_INDICES: [usize; 4] = [
+    Segment::Code.unscale(),
+    Segment::TrieData.unscale(),
+    Segment::AccountsLinkedList.unscale(),
+    Segment::StorageLinkedList.unscale(),
+];
+
 impl Segment {
     pub(crate) const COUNT: usize = 36;
 

--- a/evm_arithmetization/src/witness/memory.rs
+++ b/evm_arithmetization/src/witness/memory.rs
@@ -17,7 +17,7 @@ use MemoryChannel::{Code, GeneralPurpose, PartialChannel};
 
 use super::operation::CONTEXT_SCALING_FACTOR;
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
-use crate::memory::segments::{Segment, SEGMENT_SCALING_FACTOR};
+use crate::memory::segments::{Segment, PREINITIALIZED_SEGMENTS_INDICES, SEGMENT_SCALING_FACTOR};
 use crate::witness::errors::MemoryError::{ContextTooLarge, SegmentTooLarge, VirtTooLarge};
 use crate::witness::errors::ProgramError;
 use crate::witness::errors::ProgramError::MemoryError;
@@ -225,11 +225,7 @@ impl MemoryState {
     /// need a specific behaviour here, since the values can be stored either in
     /// `preinitialized_segments` or in the memory itself.
     pub(crate) fn get_preinit_memory(&self, segment: Segment) -> Vec<Option<U256>> {
-        assert!(
-            segment == Segment::AccountsLinkedList
-                || segment == Segment::StorageLinkedList
-                || segment == Segment::TrieData
-        );
+        assert!(PREINITIALIZED_SEGMENTS_INDICES.contains(&segment.unscale()));
         let len = self
             .preinitialized_segments
             .get(&segment)
@@ -301,6 +297,7 @@ impl MemoryState {
         segment: Segment,
         values: MemorySegmentState,
     ) {
+        assert!(PREINITIALIZED_SEGMENTS_INDICES.contains(&segment.unscale()));
         self.preinitialized_segments.insert(segment, values);
     }
 


### PR DESCRIPTION
Addresses https://github.com/0xPolygonZero/zk_evm/issues/441.

Testing on some Ethereum blocks indicate an average gain in trace lengths of:
- 1.7% for Memory
- 9.2% for MemBefore
- 9.4% for MemAfter