### PR TITLE
Fix txn indexing in error message

### DIFF
--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -91,7 +91,7 @@ pub fn into_txn_proof_gen_ir(
                 &mut extra_data,
                 &other_data,
             )
-            .context(format!("at transaction index {}", txn_idx))
+            .context(format!("at transaction index {}", current_idx))
         })
         .collect::<anyhow::Result<Vec<_>>>()
         .context(format!(


### PR DESCRIPTION
We were picking the already incremented `txn_idx` in the error msg, which was causing discrepancies in error messages between _expected_ and _actual_ failing txn, cf #421 which caused unnecessary headache.