### PR TITLE
Revert "Fix `SELFDESTRUCT`"

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/create_contract_account.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/create_contract_account.asm
@@ -4,6 +4,7 @@
 %macro create_contract_account
     // stack: address
     DUP1 %insert_touched_addresses
+    DUP1 %append_created_contracts
     DUP1 %mpt_read_state_trie
     // stack: existing_account_ptr, address
     // If the account doesn't exist, there's no need to check its balance or nonce,
@@ -27,7 +28,6 @@
 
 %%add_account:
     // stack: existing_balance, address
-    DUP2 %append_created_contracts
     DUP2 PUSH 1
     // stack: is_contract, address, existing_balance, address
     %journal_add_account_created


### PR DESCRIPTION
This was an erroneous fix, where the issue actually lied in the parsing of the Jerigon payload that didn't carry the actual account deletion information. More on this in #475.

The gist of it (from EIP-6780)

> A contract is considered created at the beginning of a create transaction or when a CREATE series operation begins execution (CREATE, CREATE2, and other operations that deploy contracts in the future). **_`If a balance exists at the contract’s new address it is still considered to be a contract creation`_**.

