### PR TITLE
Allow features with macros within macros

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/assembler.rs
+++ b/evm_arithmetization/src/cpu/kernel/assembler.rs
@@ -219,6 +219,9 @@ fn expand_macros(
                     expanded.extend(expand_macros(body.clone(), macros, macro_counter));
                 }
             }
+            Item::ConditionalBlock(_, items) => {
+                expanded.extend(expand_macros(items.clone(), macros, macro_counter));
+            }
             item => {
                 expanded.push(item);
             }

--- a/evm_arithmetization/src/cpu/kernel/parser.rs
+++ b/evm_arithmetization/src/cpu/kernel/parser.rs
@@ -246,6 +246,14 @@ mod tests {
     #[test]
     fn test_feature() {
         let code = r#"
+        %macro bar_foo
+            #[cfg(feature = feature_1)]
+            {
+                %bar
+                PUSH 3
+                ADD
+            }
+        %endmacro
         #[cfg(feature = feature_1)]
         {
             %macro bar
@@ -260,7 +268,7 @@ mod tests {
 
             #[cfg(feature = feature_1)]
             {
-                %bar
+                %bar_foo
                 PUSH 1
             }
             PUSH 3
@@ -291,6 +299,8 @@ mod tests {
         %macro bar
             PUSH 2
             MUL
+            PUSH 3
+            ADD
         %endmacro
 
         global foo_1:
@@ -353,6 +363,8 @@ mod tests {
         %macro bar
             PUSH 2
             MUL
+            PUSH 3
+            ADD
         %endmacro
 
         global foo_1:


### PR DESCRIPTION
With the current implementation of conditional blocks, we cannot have conditional blocks including macros within a macro. This PR aims at allowing such a case scenario.