### PR TITLE
Add collapse strategy to `PartialTrie` variants

### DIFF
--- a/mpt_trie/src/partial_trie.rs
+++ b/mpt_trie/src/partial_trie.rs
@@ -215,8 +215,6 @@ impl PartialTrie for StandardTrie {
         Self(n)
     }
 
-    // TODO(Robin): Do we ever want to use `StandardTrie` within the other crates?
-    // In which case we may want to include the strategy as part of the struct.
     fn new_with_strategy(n: Node<Self>, _strategy: OnOrphanedHashNode) -> Self {
         Self(n)
     }

--- a/mpt_trie/src/partial_trie.rs
+++ b/mpt_trie/src/partial_trie.rs
@@ -51,7 +51,7 @@ pub trait PartialTrie:
 
     /// Creates a new partial trie from a node with a provided collapse
     /// strategy.
-    fn new_with_strategy(n: Node<Self>, orphaned_hash_node_strategy: OnOrphanedHashNode) -> Self;
+    fn new_with_strategy(n: Node<Self>, strategy: OnOrphanedHashNode) -> Self;
 
     /// Inserts a node into the trie.
     fn insert<K, V>(&mut self, k: K, v: V) -> TrieOpResult<()>
@@ -217,7 +217,7 @@ impl PartialTrie for StandardTrie {
 
     // TODO(Robin): Do we ever want to use `StandardTrie` within the other crates?
     // In which case we may want to include the strategy as part of the struct.
-    fn new_with_strategy(n: Node<Self>, _collapse_strategy: OnOrphanedHashNode) -> Self {
+    fn new_with_strategy(n: Node<Self>, _strategy: OnOrphanedHashNode) -> Self {
         Self(n)
     }
 
@@ -315,7 +315,7 @@ pub struct HashedPartialTrie {
     pub(crate) node: Node<HashedPartialTrie>,
     pub(crate) hash: Arc<RwLock<Option<H256>>>,
 
-    pub(crate) orphaned_hash_node_strategy: OnOrphanedHashNode,
+    pub(crate) strategy: OnOrphanedHashNode,
 }
 
 /// How to handle the following subtree on deletion of the indicated node.
@@ -356,18 +356,15 @@ impl PartialTrie for HashedPartialTrie {
         Self {
             node,
             hash: Arc::new(RwLock::new(None)),
-            orphaned_hash_node_strategy: OnOrphanedHashNode::default(),
+            strategy: OnOrphanedHashNode::default(),
         }
     }
 
-    fn new_with_strategy(
-        node: Node<Self>,
-        orphaned_hash_node_strategy: OnOrphanedHashNode,
-    ) -> Self {
+    fn new_with_strategy(node: Node<Self>, strategy: OnOrphanedHashNode) -> Self {
         Self {
             node,
             hash: Arc::new(RwLock::new(None)),
-            orphaned_hash_node_strategy,
+            strategy,
         }
     }
 
@@ -403,7 +400,7 @@ impl PartialTrie for HashedPartialTrie {
     where
         K: Into<crate::nibbles::Nibbles>,
     {
-        let res = self.node.trie_delete(k, self.orphaned_hash_node_strategy);
+        let res = self.node.trie_delete(k, self.strategy);
         self.set_hash(None);
 
         res

--- a/mpt_trie/src/trie_ops.rs
+++ b/mpt_trie/src/trie_ops.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 use crate::{
     nibbles::{Nibble, Nibbles},
-    partial_trie::{CollapseStrategy, Node, PartialTrie, WrappedNode},
+    partial_trie::{Node, OnOrphanedHashNode, PartialTrie, WrappedNode},
     utils::TrieNodeType,
 };
 
@@ -381,7 +381,7 @@ impl<T: PartialTrie> Node<T> {
     pub(crate) fn trie_delete<K>(
         &mut self,
         k: K,
-        collapse_strategy: CollapseStrategy,
+        orphaned_hash_node_strategy: OnOrphanedHashNode,
     ) -> TrieOpResult<Option<Vec<u8>>>
     where
         K: Into<Nibbles>,
@@ -389,7 +389,7 @@ impl<T: PartialTrie> Node<T> {
         let k: Nibbles = k.into();
         trace!("Deleting a leaf node with key {} if it exists", k);
 
-        delete_intern(&self.clone(), k, collapse_strategy)?.map_or(
+        delete_intern(&self.clone(), k, orphaned_hash_node_strategy)?.map_or(
             Ok(None),
             |(updated_root, deleted_val)| {
                 // Final check at the root if we have an extension node. While this check also
@@ -398,7 +398,7 @@ impl<T: PartialTrie> Node<T> {
                 let wrapped_node = try_collapse_if_extension(
                     updated_root,
                     &Nibbles::default(),
-                    collapse_strategy,
+                    orphaned_hash_node_strategy,
                 )?;
                 let node_ref: &Node<T> = &wrapped_node;
                 *self = node_ref.clone();
@@ -527,7 +527,7 @@ fn insert_into_trie_rec<N: PartialTrie>(
 fn delete_intern<N: PartialTrie>(
     node: &Node<N>,
     mut curr_k: Nibbles,
-    collapse_strategy: CollapseStrategy,
+    orphaned_hash_node_strategy: OnOrphanedHashNode,
 ) -> TrieOpResult<Option<(WrappedNode<N>, Vec<u8>)>> {
     match node {
         Node::Empty => {
@@ -544,7 +544,7 @@ fn delete_intern<N: PartialTrie>(
             let nibble = curr_k.pop_next_nibble_front();
             trace!("Delete traversed Branch nibble {:x}", nibble);
 
-            delete_intern(&children[nibble as usize], curr_k, collapse_strategy)?.map_or(Ok(None),
+            delete_intern(&children[nibble as usize], curr_k, orphaned_hash_node_strategy)?.map_or(Ok(None),
                 |(updated_child, value_deleted)| {
                     // If the child we recursively called is deleted, then we may need to reduce
                     // this branch to an extension/leaf.
@@ -556,7 +556,7 @@ fn delete_intern<N: PartialTrie>(
 
                             let mut updated_children = children.clone();
                             updated_children[nibble as usize] =
-                                try_collapse_if_extension(updated_child, &curr_k, collapse_strategy)?;
+                                try_collapse_if_extension(updated_child, &curr_k, orphaned_hash_node_strategy)?;
                             branch(updated_children, value.clone())
                         }
                         true => {
@@ -591,13 +591,13 @@ fn delete_intern<N: PartialTrie>(
                 .then(|| {
                     curr_k.truncate_n_nibbles_front_mut(ext_nibbles.count);
 
-                    delete_intern(child, curr_k, collapse_strategy).and_then(|res| {
+                    delete_intern(child, curr_k, orphaned_hash_node_strategy).and_then(|res| {
                         res.map_or(Ok(None), |(updated_child, value_deleted)| {
                             let updated_node = collapse_ext_node_if_needed(
                                 ext_nibbles,
                                 &updated_child,
                                 &curr_k,
-                                collapse_strategy,
+                                orphaned_hash_node_strategy,
                             )?;
                             Ok(Some((updated_node, value_deleted)))
                         })
@@ -618,11 +618,11 @@ fn delete_intern<N: PartialTrie>(
 fn try_collapse_if_extension<N: PartialTrie>(
     node: WrappedNode<N>,
     curr_key: &Nibbles,
-    collapse_strategy: CollapseStrategy,
+    orphaned_hash_node_strategy: OnOrphanedHashNode,
 ) -> TrieOpResult<WrappedNode<N>> {
     match node.as_ref() {
         Node::Extension { nibbles, child } => {
-            collapse_ext_node_if_needed(nibbles, child, curr_key, collapse_strategy)
+            collapse_ext_node_if_needed(nibbles, child, curr_key, orphaned_hash_node_strategy)
         }
         _ => Ok(node),
     }
@@ -656,7 +656,7 @@ fn collapse_ext_node_if_needed<N: PartialTrie>(
     ext_nibbles: &Nibbles,
     child: &WrappedNode<N>,
     curr_key: &Nibbles,
-    collapse_strategy: CollapseStrategy,
+    orphaned_hash_node_strategy: OnOrphanedHashNode,
 ) -> TrieOpResult<WrappedNode<N>> {
     trace!(
         "Collapsing extension node ({:x}) with child {}...",
@@ -677,9 +677,9 @@ fn collapse_ext_node_if_needed<N: PartialTrie>(
             nibbles: leaf_nibbles,
             value,
         } => Ok(leaf(ext_nibbles.merge_nibbles(leaf_nibbles), value.clone())),
-        Node::Hash(h) => match collapse_strategy {
-            CollapseStrategy::Pass => Ok(extension(*ext_nibbles, child.clone())),
-            CollapseStrategy::Error => Err(TrieOpError::ExtensionCollapsedIntoHashError(
+        Node::Hash(h) => match orphaned_hash_node_strategy {
+            OnOrphanedHashNode::CollapseToExtension => Ok(extension(*ext_nibbles, child.clone())),
+            OnOrphanedHashNode::Reject => Err(TrieOpError::ExtensionCollapsedIntoHashError(
                 curr_key.merge_nibbles(ext_nibbles),
                 *h,
             )),

--- a/trace_decoder/src/lib.rs
+++ b/trace_decoder/src/lib.rs
@@ -103,7 +103,7 @@ use evm_arithmetization::proof::{BlockHashes, BlockMetadata};
 use evm_arithmetization::GenerationInputs;
 use keccak_hash::keccak as hash;
 use keccak_hash::H256;
-use mpt_trie::partial_trie::{CollapseStrategy, HashedPartialTrie};
+use mpt_trie::partial_trie::{HashedPartialTrie, OnOrphanedHashNode};
 use processed_block_trace::ProcessedTxnInfo;
 use serde::{Deserialize, Serialize};
 use typed_mpt::{StateTrie, StorageTrie, TrieKey};
@@ -320,7 +320,7 @@ pub fn entrypoint(
         }) => ProcessedBlockTracePreImages {
             tries: PartialTriePreImages {
                 state: state.items().try_fold(
-                    StateTrie::new(CollapseStrategy::Error),
+                    StateTrie::new(OnOrphanedHashNode::Reject),
                     |mut acc, (nibbles, hash_or_val)| {
                         let path = TrieKey::from_nibbles(nibbles);
                         match hash_or_val {
@@ -343,7 +343,7 @@ pub fn entrypoint(
                     .map(|(k, SeparateTriePreImage::Direct(v))| {
                         v.items()
                             .try_fold(
-                                StorageTrie::new(CollapseStrategy::Error),
+                                StorageTrie::new(OnOrphanedHashNode::Reject),
                                 |mut acc, (nibbles, hash_or_val)| {
                                     let path = TrieKey::from_nibbles(nibbles);
                                     match hash_or_val {

--- a/trace_decoder/src/type1.rs
+++ b/trace_decoder/src/type1.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::{bail, ensure, Context as _};
 use either::Either;
 use evm_arithmetization::generation::mpt::AccountRlp;
-use mpt_trie::partial_trie::CollapseStrategy;
+use mpt_trie::partial_trie::OnOrphanedHashNode;
 use nunny::NonEmpty;
 use u4::U4;
 
@@ -28,7 +28,7 @@ impl Default for Frontend {
     // which covers branch-to-extension collapse edge cases.
     fn default() -> Self {
         Self {
-            state: StateTrie::new(CollapseStrategy::Pass),
+            state: StateTrie::new(OnOrphanedHashNode::CollapseToExtension),
             code: BTreeSet::new(),
             storage: BTreeMap::new(),
         }
@@ -170,7 +170,7 @@ fn node2storagetrie(node: Node) -> anyhow::Result<StorageTrie> {
         Ok(())
     }
 
-    let mut mpt = StorageTrie::new(CollapseStrategy::Pass);
+    let mut mpt = StorageTrie::new(OnOrphanedHashNode::CollapseToExtension);
     visit(&mut mpt, &stackstack::Stack::new(), node)?;
     Ok(mpt)
 }

--- a/trace_decoder/src/type1.rs
+++ b/trace_decoder/src/type1.rs
@@ -25,7 +25,7 @@ pub struct Frontend {
 
 impl Default for Frontend {
     // This frontend is intended to be used with our custom `zeroTracer`,
-    // which covers branch-to-extencion collapse edge cases.
+    // which covers branch-to-extension collapse edge cases.
     fn default() -> Self {
         Self {
             state: StateTrie::new(CollapseStrategy::Pass),

--- a/trace_decoder/src/typed_mpt.rs
+++ b/trace_decoder/src/typed_mpt.rs
@@ -7,7 +7,7 @@ use copyvec::CopyVec;
 use ethereum_types::{Address, H256};
 use evm_arithmetization::generation::mpt::AccountRlp;
 use mpt_trie::{
-    partial_trie::{CollapseStrategy, HashedPartialTrie, Node, PartialTrie as _},
+    partial_trie::{OnOrphanedHashNode, HashedPartialTrie, Node, PartialTrie as _},
     trie_ops::TrieOpError,
 };
 use u4::{AsNibbles, U4};
@@ -240,7 +240,7 @@ pub struct StateTrie {
 }
 
 impl StateTrie {
-    pub fn new(strategy: CollapseStrategy) -> Self {
+    pub fn new(strategy: OnOrphanedHashNode) -> Self {
         Self {
             typed: TypedMpt {
                 inner: HashedPartialTrie::new_with_strategy(Node::Empty, strategy),
@@ -321,7 +321,7 @@ pub struct StorageTrie {
     untyped: HashedPartialTrie,
 }
 impl StorageTrie {
-    pub fn new(strategy: CollapseStrategy) -> Self {
+    pub fn new(strategy: OnOrphanedHashNode) -> Self {
         Self {
             untyped: HashedPartialTrie::new_with_strategy(Node::Empty, strategy),
         }

--- a/trace_decoder/src/typed_mpt.rs
+++ b/trace_decoder/src/typed_mpt.rs
@@ -7,7 +7,7 @@ use copyvec::CopyVec;
 use ethereum_types::{Address, H256};
 use evm_arithmetization::generation::mpt::AccountRlp;
 use mpt_trie::{
-    partial_trie::{HashedPartialTrie, Node, PartialTrie as _},
+    partial_trie::{CollapseStrategy, HashedPartialTrie, Node, PartialTrie as _},
     trie_ops::TrieOpError,
 };
 use u4::{AsNibbles, U4};
@@ -240,6 +240,14 @@ pub struct StateTrie {
 }
 
 impl StateTrie {
+    pub fn new(strategy: CollapseStrategy) -> Self {
+        Self {
+            typed: TypedMpt {
+                inner: HashedPartialTrie::new_with_strategy(Node::Empty, strategy),
+                _ty: PhantomData,
+            },
+        }
+    }
     pub fn insert_by_address(
         &mut self,
         address: Address,
@@ -313,6 +321,11 @@ pub struct StorageTrie {
     untyped: HashedPartialTrie,
 }
 impl StorageTrie {
+    pub fn new(strategy: CollapseStrategy) -> Self {
+        Self {
+            untyped: HashedPartialTrie::new_with_strategy(Node::Empty, strategy),
+        }
+    }
     pub fn insert(&mut self, key: TrieKey, value: Vec<u8>) -> Result<Option<Vec<u8>>, Error> {
         let prev = self.untyped.get(key.into_nibbles()).map(Vec::from);
         self.untyped

--- a/trace_decoder/src/typed_mpt.rs
+++ b/trace_decoder/src/typed_mpt.rs
@@ -7,7 +7,7 @@ use copyvec::CopyVec;
 use ethereum_types::{Address, H256};
 use evm_arithmetization::generation::mpt::AccountRlp;
 use mpt_trie::{
-    partial_trie::{OnOrphanedHashNode, HashedPartialTrie, Node, PartialTrie as _},
+    partial_trie::{HashedPartialTrie, Node, OnOrphanedHashNode, PartialTrie as _},
     trie_ops::TrieOpError,
 };
 use u4::{AsNibbles, U4};


### PR DESCRIPTION
Add a collapsing strategy for the edge case of a branch node with two children being collapsed into an extension node after the deletion of one the children.

cf #202 and #455 for reference

@0xaatif I don't consider the PR _ready_ yet, especially some more doc/clarification would be good but I'm opening it to get some feedback regarding the approach taken and if it matches how you were envisioning it following our chat.