### PR TITLE
continuations: have segment iterator return a `Result`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,6 +2029,7 @@ dependencies = [
  "sha2",
  "starky",
  "static_assertions",
+ "thiserror",
  "tiny-keccak",
  "zk_evm_proc_macro",
 ]

--- a/evm_arithmetization/Cargo.toml
+++ b/evm_arithmetization/Cargo.toml
@@ -41,6 +41,7 @@ serde = { workspace = true, features = ["derive"] }
 sha2 = { workspace = true }
 static_assertions = { workspace = true }
 hashbrown = { workspace = true }
+thiserror = { workspace = true }
 tiny-keccak = { workspace = true }
 serde_json = { workspace = true }
 serde-big-array = { workspace = true }

--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -1730,12 +1730,13 @@ where
 
         let mut proofs = vec![];
 
-        for mut next_data in segment_iterator {
+        for segment_run in segment_iterator {
+            let (_, mut next_data) = segment_run.map_err(|e| anyhow::format_err!(e))?;
             let proof = self.prove_segment(
                 all_stark,
                 config,
                 generation_inputs.trim(),
-                &mut next_data.1,
+                &mut next_data,
                 timing,
                 abort_signal.clone(),
             )?;

--- a/evm_arithmetization/src/lib.rs
+++ b/evm_arithmetization/src/lib.rs
@@ -227,5 +227,6 @@ pub use generation::GenerationInputs;
 use prover::GenerationSegmentData;
 pub use starky::config::StarkConfig;
 
-/// All data needed to prove all transaction segments.
-pub type AllData = (TrimmedGenerationInputs, GenerationSegmentData);
+/// Returned type from a `SegmentDataIterator`, needed to prove all segments in
+/// a transaction batch.
+pub type AllData = Result<(TrimmedGenerationInputs, GenerationSegmentData), String>;

--- a/evm_arithmetization/src/lib.rs
+++ b/evm_arithmetization/src/lib.rs
@@ -224,9 +224,9 @@ pub type BlockHeight = u64;
 pub use all_stark::AllStark;
 pub use fixed_recursive_verifier::AllRecursiveCircuits;
 pub use generation::GenerationInputs;
-use prover::GenerationSegmentData;
+use prover::{GenerationSegmentData, SegmentError};
 pub use starky::config::StarkConfig;
 
 /// Returned type from a `SegmentDataIterator`, needed to prove all segments in
 /// a transaction batch.
-pub type AllData = Result<(TrimmedGenerationInputs, GenerationSegmentData), String>;
+pub type AllData = Result<(TrimmedGenerationInputs, GenerationSegmentData), SegmentError>;

--- a/zero_bin/common/src/prover_state/mod.rs
+++ b/zero_bin/common/src/prover_state/mod.rs
@@ -19,7 +19,7 @@ use evm_arithmetization::{
     generation::TrimmedGenerationInputs,
     proof::AllProof,
     prover::{prove, GenerationSegmentData},
-    AllData, AllStark, StarkConfig,
+    AllStark, StarkConfig,
 };
 use plonky2::{
     field::goldilocks_field::GoldilocksField, plonk::config::PoseidonGoldilocksConfig,
@@ -255,7 +255,10 @@ impl ProverStateManager {
     /// - If the persistence strategy is [`CircuitPersistence::Disk`] with
     ///   [`TableLoadStrategy::OnDemand`], the table circuits are loaded as
     ///   needed.
-    pub fn generate_segment_proof(&self, input: AllData) -> anyhow::Result<GeneratedSegmentProof> {
+    pub fn generate_segment_proof(
+        &self,
+        input: (TrimmedGenerationInputs, GenerationSegmentData),
+    ) -> anyhow::Result<GeneratedSegmentProof> {
         let (generation_inputs, mut segment_data) = input;
 
         match self.persistence {

--- a/zero_bin/ops/src/lib.rs
+++ b/zero_bin/ops/src/lib.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 #[cfg(not(feature = "test_only"))]
 use evm_arithmetization::generation::TrimmedGenerationInputs;
-use evm_arithmetization::{proof::PublicValues, AllData};
+use evm_arithmetization::proof::PublicValues;
 #[cfg(feature = "test_only")]
 use evm_arithmetization::{prover::testing::simulate_execution_all_segments, GenerationInputs};
 use paladin::{
@@ -26,25 +26,6 @@ use zero_bin_common::{debug_utils::save_inputs_to_disk, prover_state::p_state};
 
 registry!();
 
-#[cfg(feature = "test_only")]
-#[derive(Deserialize, Serialize, RemoteExecute)]
-pub struct BatchTestOnly {
-    pub save_inputs_on_error: bool,
-}
-
-#[cfg(feature = "test_only")]
-impl Operation for BatchTestOnly {
-    type Input = (GenerationInputs, usize);
-    type Output = ();
-
-    fn execute(&self, inputs: Self::Input) -> Result<Self::Output> {
-        simulate_execution_all_segments::<Field>(inputs.0, inputs.1)
-            .map_err(|err| FatalError::from_anyhow(err, FatalStrategy::Terminate))?;
-
-        Ok(())
-    }
-}
-
 #[derive(Deserialize, Serialize, RemoteExecute)]
 pub struct SegmentProof {
     pub save_inputs_on_error: bool,
@@ -52,10 +33,13 @@ pub struct SegmentProof {
 
 #[cfg(not(feature = "test_only"))]
 impl Operation for SegmentProof {
-    type Input = AllData;
+    type Input = evm_arithmetization::AllData;
     type Output = proof_gen::proof_types::SegmentAggregatableProof;
 
     fn execute(&self, all_data: Self::Input) -> Result<Self::Output> {
+        let all_data =
+            all_data.map_err(|err| FatalError::from_str(&err, FatalStrategy::Terminate))?;
+
         let input = all_data.0.clone();
         let segment_index = all_data.1.segment_index();
         let _span = SegmentProofSpan::new(&input, all_data.1.segment_index());
@@ -65,7 +49,7 @@ impl Operation for SegmentProof {
                 .map_err(|err| {
                     if let Err(write_err) = save_inputs_to_disk(
                         format!(
-                            "b{}_txns_{}-{}-({})_input.json",
+                            "b{}_txns_{}..{}-({})_input.json",
                             input.block_metadata.block_number,
                             input.txn_number_before,
                             input.txn_number_before + input.txn_hashes.len(),
@@ -90,10 +74,31 @@ impl Operation for SegmentProof {
 
 #[cfg(feature = "test_only")]
 impl Operation for SegmentProof {
-    type Input = AllData;
+    type Input = (GenerationInputs, usize);
     type Output = ();
 
-    fn execute(&self, _all_data: Self::Input) -> Result<Self::Output> {
+    fn execute(&self, inputs: Self::Input) -> Result<Self::Output> {
+        if self.save_inputs_on_error {
+            simulate_execution_all_segments::<Field>(inputs.0.clone(), inputs.1).map_err(|err| {
+                if let Err(write_err) = save_inputs_to_disk(
+                    format!(
+                        "b{}_txns_{}..{}_input.json",
+                        inputs.0.block_metadata.block_number,
+                        inputs.0.txn_number_before,
+                        inputs.0.txn_number_before + inputs.0.signed_txns.len(),
+                    ),
+                    inputs.0,
+                ) {
+                    error!("Failed to save txn proof input to disk: {:?}", write_err);
+                }
+
+                FatalError::from_anyhow(err, FatalStrategy::Terminate)
+            })?
+        } else {
+            simulate_execution_all_segments::<Field>(inputs.0, inputs.1)
+                .map_err(|err| FatalError::from_anyhow(err, FatalStrategy::Terminate))?;
+        }
+
         Ok(())
     }
 }

--- a/zero_bin/ops/src/lib.rs
+++ b/zero_bin/ops/src/lib.rs
@@ -38,7 +38,7 @@ impl Operation for SegmentProof {
 
     fn execute(&self, all_data: Self::Input) -> Result<Self::Output> {
         let all_data =
-            all_data.map_err(|err| FatalError::from_str(&err, FatalStrategy::Terminate))?;
+            all_data.map_err(|err| FatalError::from_str(&err.0, FatalStrategy::Terminate))?;
 
         let input = all_data.0.clone();
         let segment_index = all_data.1.segment_index();

--- a/zero_bin/prover/src/lib.rs
+++ b/zero_bin/prover/src/lib.rs
@@ -131,7 +131,7 @@ impl BlockProverInput {
     pub async fn prove(
         self,
         runtime: &Runtime,
-        _previous: Option<impl Future<Output = Result<GeneratedBlockProof>>>,
+        previous: Option<impl Future<Output = Result<GeneratedBlockProof>>>,
         prover_config: ProverConfig,
     ) -> Result<GeneratedBlockProof> {
         use std::iter::repeat;
@@ -175,6 +175,12 @@ impl BlockProverInput {
             .await?;
 
         info!("Successfully generated witness for block {block_number}.");
+
+        // Wait for previous block proof
+        let _prev = match previous {
+            Some(it) => Some(it.await?),
+            None => None,
+        };
 
         // Dummy proof to match expected output type.
         Ok(GeneratedBlockProof {


### PR DESCRIPTION
Prevent failed CPU runs from panicking and aborting segment data generation, by returning a `Result` instead in the `SegmentDataIterator`.

Also allows to log inputs upon failure.

I had to tweak the `Result` type for `std` instead of `anyhow` in `evm_arithmetization` because of the need for `Deserialize`.