### PR TITLE
Make test-only a CLI argument

### DIFF
--- a/zero_bin/leader/Cargo.toml
+++ b/zero_bin/leader/Cargo.toml
@@ -34,7 +34,6 @@ zero_bin_common = { workspace = true }
 
 [features]
 default = []
-test_only = ["ops/test_only", "prover/test_only"]
 
 [build-dependencies]
 cargo_metadata = { workspace = true }

--- a/zero_bin/leader/src/client.rs
+++ b/zero_bin/leader/src/client.rs
@@ -63,7 +63,7 @@ pub(crate) async fn client_main(
     runtime.close().await?;
     let proved_blocks = proved_blocks?;
 
-    if cfg!(feature = "test_only") {
+    if params.prover_config.test_only {
         info!("All proof witnesses have been generated successfully.");
     } else {
         info!("All proofs have been generated successfully.");

--- a/zero_bin/leader/src/client.rs
+++ b/zero_bin/leader/src/client.rs
@@ -69,41 +69,43 @@ pub(crate) async fn client_main(
         info!("All proofs have been generated successfully.");
     }
 
-    if params.keep_intermediate_proofs {
-        if params.proof_output_dir.is_some() {
-            // All proof files (including intermediary) are written to disk and kept
-            warn!("Skipping cleanup, intermediate proof files are kept");
+    if !params.prover_config.test_only {
+        if params.keep_intermediate_proofs {
+            if params.proof_output_dir.is_some() {
+                // All proof files (including intermediary) are written to disk and kept
+                warn!("Skipping cleanup, intermediate proof files are kept");
+            } else {
+                // Output all proofs to stdout
+                std::io::stdout().write_all(&serde_json::to_vec(
+                    &proved_blocks
+                        .into_iter()
+                        .filter_map(|(_, block)| block)
+                        .collect::<Vec<_>>(),
+                )?)?;
+            }
+        } else if let Some(proof_output_dir) = params.proof_output_dir.as_ref() {
+            // Remove intermediary proof files
+            proved_blocks
+                .into_iter()
+                .rev()
+                .skip(1)
+                .map(|(block_number, _)| {
+                    generate_block_proof_file_name(&proof_output_dir.to_str(), block_number)
+                })
+                .for_each(|path| {
+                    if let Err(e) = std::fs::remove_file(path) {
+                        error!("Failed to remove intermediate proof file: {e}");
+                    }
+                });
         } else {
-            // Output all proofs to stdout
-            std::io::stdout().write_all(&serde_json::to_vec(
-                &proved_blocks
-                    .into_iter()
-                    .filter_map(|(_, block)| block)
-                    .collect::<Vec<_>>(),
-            )?)?;
-        }
-    } else if let Some(proof_output_dir) = params.proof_output_dir.as_ref() {
-        // Remove intermediary proof files
-        proved_blocks
-            .into_iter()
-            .rev()
-            .skip(1)
-            .map(|(block_number, _)| {
-                generate_block_proof_file_name(&proof_output_dir.to_str(), block_number)
-            })
-            .for_each(|path| {
-                if let Err(e) = std::fs::remove_file(path) {
-                    error!("Failed to remove intermediate proof file: {e}");
-                }
-            });
-    } else {
-        // Output only last proof to stdout
-        if let Some(last_block) = proved_blocks
-            .into_iter()
-            .filter_map(|(_, block)| block)
-            .last()
-        {
-            std::io::stdout().write_all(&serde_json::to_vec(&last_block)?)?;
+            // Output only last proof to stdout
+            if let Some(last_block) = proved_blocks
+                .into_iter()
+                .filter_map(|(_, block)| block)
+                .last()
+            {
+                std::io::stdout().write_all(&serde_json::to_vec(&last_block)?)?;
+            }
         }
     }
 

--- a/zero_bin/leader/src/http.rs
+++ b/zero_bin/leader/src/http.rs
@@ -71,15 +71,27 @@ async fn prove(
 
     let block_number = payload.prover_input.get_block_number();
 
-    match payload
-        .prover_input
-        .prove(
-            &runtime,
-            payload.previous.map(futures::future::ok),
-            prover_config,
-        )
-        .await
-    {
+    let proof_res = if prover_config.test_only {
+        payload
+            .prover_input
+            .prove_test(
+                &runtime,
+                payload.previous.map(futures::future::ok),
+                prover_config,
+            )
+            .await
+    } else {
+        payload
+            .prover_input
+            .prove(
+                &runtime,
+                payload.previous.map(futures::future::ok),
+                prover_config,
+            )
+            .await
+    };
+
+    match proof_res {
         Ok(b_proof) => match write_to_file(output_dir, block_number, &b_proof) {
             Ok(file) => {
                 info!("Successfully wrote proof to {}", file.display());

--- a/zero_bin/leader/src/stdio.rs
+++ b/zero_bin/leader/src/stdio.rs
@@ -26,7 +26,7 @@ pub(crate) async fn stdio_main(
     runtime.close().await?;
     let proved_blocks = proved_blocks?;
 
-    if cfg!(feature = "test_only") {
+    if prover_config.test_only {
         info!("All proof witnesses have been generated successfully.");
     } else {
         info!("All proofs have been generated successfully.");

--- a/zero_bin/ops/Cargo.toml
+++ b/zero_bin/ops/Cargo.toml
@@ -21,4 +21,3 @@ zero_bin_common = { path = "../common" }
 
 [features]
 default = []
-test_only = []

--- a/zero_bin/ops/src/lib.rs
+++ b/zero_bin/ops/src/lib.rs
@@ -1,16 +1,12 @@
-#[cfg(not(feature = "test_only"))]
 use std::time::Instant;
 
-#[cfg(not(feature = "test_only"))]
 use evm_arithmetization::generation::TrimmedGenerationInputs;
 use evm_arithmetization::{proof::PublicValues, AllData};
-#[cfg(feature = "test_only")]
 use evm_arithmetization::{prover::testing::simulate_execution_all_segments, GenerationInputs};
 use paladin::{
     operation::{FatalError, FatalStrategy, Monoid, Operation, Result},
     registry, RemoteExecute,
 };
-#[cfg(feature = "test_only")]
 use proof_gen::types::Field;
 use proof_gen::{
     proof_gen::{generate_block_proof, generate_segment_agg_proof, generate_transaction_agg_proof},
@@ -20,19 +16,16 @@ use proof_gen::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::error;
-#[cfg(not(feature = "test_only"))]
 use tracing::{event, info_span, Level};
 use zero_bin_common::{debug_utils::save_inputs_to_disk, prover_state::p_state};
 
 registry!();
 
-#[cfg(feature = "test_only")]
 #[derive(Deserialize, Serialize, RemoteExecute)]
 pub struct BatchTestOnly {
     pub save_inputs_on_error: bool,
 }
 
-#[cfg(feature = "test_only")]
 impl Operation for BatchTestOnly {
     type Input = (GenerationInputs, usize);
     type Output = ();
@@ -50,7 +43,6 @@ pub struct SegmentProof {
     pub save_inputs_on_error: bool,
 }
 
-#[cfg(not(feature = "test_only"))]
 impl Operation for SegmentProof {
     type Input = AllData;
     type Output = proof_gen::proof_types::SegmentAggregatableProof;
@@ -88,8 +80,12 @@ impl Operation for SegmentProof {
     }
 }
 
-#[cfg(feature = "test_only")]
-impl Operation for SegmentProof {
+#[derive(Deserialize, Serialize, RemoteExecute)]
+pub struct SegmentProofTestOnly {
+    pub save_inputs_on_error: bool,
+}
+
+impl Operation for SegmentProofTestOnly {
     type Input = AllData;
     type Output = ();
 
@@ -102,14 +98,12 @@ impl Operation for SegmentProof {
 ///
 /// - When created, it starts a span with the transaction proof id.
 /// - When dropped, it logs the time taken by the transaction proof.
-#[cfg(not(feature = "test_only"))]
 struct SegmentProofSpan {
     _span: tracing::span::EnteredSpan,
     start: Instant,
     descriptor: String,
 }
 
-#[cfg(not(feature = "test_only"))]
 impl SegmentProofSpan {
     /// Get a unique id for the transaction proof.
     fn get_id(ir: &TrimmedGenerationInputs, segment_index: usize) -> String {
@@ -169,7 +163,6 @@ impl SegmentProofSpan {
     }
 }
 
-#[cfg(not(feature = "test_only"))]
 impl Drop for SegmentProofSpan {
     fn drop(&mut self) {
         event!(

--- a/zero_bin/ops/src/lib.rs
+++ b/zero_bin/ops/src/lib.rs
@@ -22,23 +22,6 @@ use zero_bin_common::{debug_utils::save_inputs_to_disk, prover_state::p_state};
 registry!();
 
 #[derive(Deserialize, Serialize, RemoteExecute)]
-pub struct BatchTestOnly {
-    pub save_inputs_on_error: bool,
-}
-
-impl Operation for BatchTestOnly {
-    type Input = (GenerationInputs, usize);
-    type Output = ();
-
-    fn execute(&self, inputs: Self::Input) -> Result<Self::Output> {
-        simulate_execution_all_segments::<Field>(inputs.0, inputs.1)
-            .map_err(|err| FatalError::from_anyhow(err, FatalStrategy::Terminate))?;
-
-        Ok(())
-    }
-}
-
-#[derive(Deserialize, Serialize, RemoteExecute)]
 pub struct SegmentProof {
     pub save_inputs_on_error: bool,
 }

--- a/zero_bin/ops/src/lib.rs
+++ b/zero_bin/ops/src/lib.rs
@@ -80,20 +80,6 @@ impl Operation for SegmentProof {
     }
 }
 
-#[derive(Deserialize, Serialize, RemoteExecute)]
-pub struct SegmentProofTestOnly {
-    pub save_inputs_on_error: bool,
-}
-
-impl Operation for SegmentProofTestOnly {
-    type Input = AllData;
-    type Output = ();
-
-    fn execute(&self, _all_data: Self::Input) -> Result<Self::Output> {
-        Ok(())
-    }
-}
-
 /// RAII struct to measure the time taken by a transaction proof.
 ///
 /// - When created, it starts a span with the transaction proof id.

--- a/zero_bin/prover/Cargo.toml
+++ b/zero_bin/prover/Cargo.toml
@@ -30,4 +30,3 @@ clap = {workspace = true}
 
 [features]
 default = []
-test_only = ["ops/test_only"]

--- a/zero_bin/prover/src/cli.rs
+++ b/zero_bin/prover/src/cli.rs
@@ -14,6 +14,10 @@ pub struct CliProverConfig {
     /// If true, save the public inputs to disk on error.
     #[arg(short='i', long, help_heading = HELP_HEADING, default_value_t = false)]
     save_inputs_on_error: bool,
+    /// If true, only test the trace decoder and witness generation without
+    /// generating a proof.
+    #[arg(long, help_heading = HELP_HEADING, default_value_t = false)]
+    test_only: bool,
 }
 
 impl From<CliProverConfig> for crate::ProverConfig {
@@ -22,6 +26,7 @@ impl From<CliProverConfig> for crate::ProverConfig {
             batch_size: cli.batch_size,
             max_cpu_len_log: cli.max_cpu_len_log,
             save_inputs_on_error: cli.save_inputs_on_error,
+            test_only: cli.test_only,
         }
     }
 }

--- a/zero_bin/prover/src/lib.rs
+++ b/zero_bin/prover/src/lib.rs
@@ -219,6 +219,10 @@ impl ProverInput {
                             let proof = proof?;
                             let block_number = proof.b_height;
 
+                            if tx.send(proof).is_err() {
+                                anyhow::bail!("Failed to send proof");
+                            }
+
                             // We ignore the returned dummy proof in test-only mode.
                             Ok((block_number, None))
                         })

--- a/zero_bin/prover/src/lib.rs
+++ b/zero_bin/prover/src/lib.rs
@@ -219,10 +219,6 @@ impl ProverInput {
                             let proof = proof?;
                             let block_number = proof.b_height;
 
-                            if tx.send(proof).is_err() {
-                                anyhow::bail!("Bad dummy proof?");
-                            }
-
                             // We ignore the returned dummy proof in test-only mode.
                             Ok((block_number, None))
                         })

--- a/zero_bin/tools/prove_rpc.sh
+++ b/zero_bin/tools/prove_rpc.sh
@@ -17,18 +17,8 @@ export RUST_LOG=info
 # See also .cargo/config.toml.
 export RUSTFLAGS='-C target-cpu=native -Zlinker-features=-lld'
 
-if [[ $8 == "test_only" ]]; then
-  # Circuit sizes don't matter in test_only mode, so we keep them minimal.
-    export ARITHMETIC_CIRCUIT_SIZE="16..17"
-    export BYTE_PACKING_CIRCUIT_SIZE="9..10"
-    export CPU_CIRCUIT_SIZE="12..13"
-    export KECCAK_CIRCUIT_SIZE="4..5"
-    export KECCAK_SPONGE_CIRCUIT_SIZE="9..10"
-    export LOGIC_CIRCUIT_SIZE="12..13"
-    export MEMORY_CIRCUIT_SIZE="17..18"
-    export MEMORY_BEFORE_CIRCUIT_SIZE="7..8"
-    export MEMORY_AFTER_CIRCUIT_SIZE="7..8"
-else
+# Circuit sizes only matter in non test_only mode.
+if ! [[ $8 == "test_only" ]]; then
     export ARITHMETIC_CIRCUIT_SIZE="16..21"
     export BYTE_PACKING_CIRCUIT_SIZE="8..21"
     export CPU_CIRCUIT_SIZE="8..21"
@@ -112,7 +102,7 @@ fi
 if [[ $8 == "test_only" ]]; then
     # test only run
     echo "Proving blocks ${BLOCK_INTERVAL} in a test_only mode now... (Total: ${TOT_BLOCKS})"
-    command='cargo r --release --features test_only --bin leader -- --runtime in-memory --load-strategy on-demand rpc --rpc-type "$NODE_RPC_TYPE" --rpc-url "$NODE_RPC_URL" --block-interval $BLOCK_INTERVAL --proof-output-dir $PROOF_OUTPUT_DIR $PREV_PROOF_EXTRA_ARG --backoff "$BACKOFF" --max-retries "$RETRIES" '
+    command='cargo r --release --bin leader -- --test-only --runtime in-memory --load-strategy on-demand rpc --rpc-type "$NODE_RPC_TYPE" --rpc-url "$NODE_RPC_URL" --block-interval $BLOCK_INTERVAL --proof-output-dir $PROOF_OUTPUT_DIR $PREV_PROOF_EXTRA_ARG --backoff "$BACKOFF" --max-retries "$RETRIES" '
     if [ "$OUTPUT_TO_TERMINAL" = true ]; then
         eval $command
         retVal=$?

--- a/zero_bin/tools/prove_stdio.sh
+++ b/zero_bin/tools/prove_stdio.sh
@@ -44,18 +44,8 @@ if [[ $INPUT_FILE == "" ]]; then
     exit 1
 fi
 
-if [[ $TEST_ONLY == "test_only" ]]; then
-    # Circuit sizes don't matter in test_only mode, so we keep them minimal.
-    export ARITHMETIC_CIRCUIT_SIZE="16..17"
-    export BYTE_PACKING_CIRCUIT_SIZE="9..10"
-    export CPU_CIRCUIT_SIZE="12..13"
-    export KECCAK_CIRCUIT_SIZE="4..5"
-    export KECCAK_SPONGE_CIRCUIT_SIZE="9..10"
-    export LOGIC_CIRCUIT_SIZE="12..13"
-    export MEMORY_CIRCUIT_SIZE="17..18"
-    export MEMORY_BEFORE_CIRCUIT_SIZE="7..8"
-    export MEMORY_AFTER_CIRCUIT_SIZE="7..8"
-else
+# Circuit sizes only matter in non test_only mode.
+if ! [[ $TEST_ONLY == "test_only" ]]; then
     if [[ $INPUT_FILE == *"witness_b19807080"* ]]; then
       # These sizes are configured specifically for block 19807080. Don't use this in other scenarios
         echo "Using specific circuit sizes for witness_b19807080.json"
@@ -98,7 +88,7 @@ fi
 # proof. This is useful for quickly testing decoding and all of the
 # other non-proving code.
 if [[ $TEST_ONLY == "test_only" ]]; then
-    cargo run --release --features test_only --bin leader -- --runtime in-memory --load-strategy on-demand stdio < $INPUT_FILE &> $TEST_OUT_PATH
+    cargo run --release --bin leader -- --test-only --runtime in-memory --load-strategy on-demand stdio < $INPUT_FILE &> $TEST_OUT_PATH
     if grep -q 'All proof witnesses have been generated successfully.' $TEST_OUT_PATH; then
         echo -e "\n\nSuccess - Note this was just a test, not a proof"
         rm $TEST_OUT_PATH


### PR DESCRIPTION
Remove the `test_only` conditional compilation feature and make it part of the CLI arguments instead. Technically not related to continuations, but there are enough differences with `develop` that we might as well merge it here to avoid rebasing later.

Includes https://github.com/0xPolygonZero/zk_evm/issues/288.