### PR TITLE
refactor: Hash2Code

### DIFF
--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -20,7 +20,7 @@ use mpt_trie::{
 use crate::{
     hash,
     processed_block_trace::{
-        NodesUsedByTxn, ProcessedBlockTrace, ProcessedTxnInfo, StateTrieWrites, TxnMetaState,
+        NodesUsedByTxn, ProcessedBlockTrace, ProcessedTxnInfo, StateWrite, TxnMetaState,
     },
     typed_mpt::{ReceiptTrie, StateTrie, StorageTrie, TransactionTrie, TrieKey},
     OtherBlockData, PartialTriePreImages,
@@ -201,15 +201,12 @@ fn update_txn_and_receipt_tries(
     meta: &TxnMetaState,
     txn_idx: usize,
 ) -> anyhow::Result<()> {
-    if meta.is_dummy() {
-        // This is a dummy payload, that does not mutate these tries.
-        return Ok(());
-    }
-
-    trie_state.txn.insert(txn_idx, meta.txn_bytes())?;
-    trie_state
-        .receipt
-        .insert(txn_idx, meta.receipt_node_bytes.clone())?;
+    if let Some(bytes) = &meta.txn_bytes {
+        trie_state.txn.insert(txn_idx, bytes.clone())?;
+        trie_state
+            .receipt
+            .insert(txn_idx, meta.receipt_node_bytes.clone())?;
+    } // else it's just a dummy
     Ok(())
 }
 
@@ -219,11 +216,11 @@ fn update_txn_and_receipt_tries(
 fn init_any_needed_empty_storage_tries<'a>(
     storage_tries: &mut HashMap<H256, StorageTrie>,
     accounts_with_storage: impl Iterator<Item = &'a H256>,
-    state_accounts_with_no_accesses_but_storage_tries: &'a HashMap<H256, H256>,
+    accts_with_unaccessed_storage: &HashMap<H256, H256>,
 ) {
     for h_addr in accounts_with_storage {
         if !storage_tries.contains_key(h_addr) {
-            let trie = state_accounts_with_no_accesses_but_storage_tries
+            let trie = accts_with_unaccessed_storage
                 .get(h_addr)
                 .map(|s_root| {
                     let mut it = StorageTrie::default();
@@ -519,9 +516,7 @@ fn process_txn_info(
             .storage_accesses
             .iter()
             .map(|(k, _)| k),
-        &txn_info
-            .nodes_used_by_txn
-            .state_accounts_with_no_accesses_but_storage_tries,
+        &txn_info.nodes_used_by_txn.accts_with_unaccessed_storage,
     );
     // For each non-dummy txn, we increment `txn_number_after` by 1, and
     // update `gas_used_after` accordingly.
@@ -577,7 +572,11 @@ fn process_txn_info(
             receipts_root: curr_block_tries.receipt.root(),
         },
         checkpoint_state_trie_root: extra_data.checkpoint_state_trie_root,
-        contract_code: txn_info.contract_code_accessed,
+        contract_code: txn_info
+            .contract_code_accessed
+            .into_iter()
+            .map(|code| (hash(&code), code))
+            .collect(),
         block_metadata: other_data.b_data.b_meta.clone(),
         block_hashes: other_data.b_data.b_hashes.clone(),
         global_exit_roots: vec![],
@@ -591,7 +590,7 @@ fn process_txn_info(
     Ok(gen_inputs)
 }
 
-impl StateTrieWrites {
+impl StateWrite {
     fn apply_writes_to_state_node(
         &self,
         state_node: &mut AccountRlp,
@@ -676,21 +675,6 @@ fn create_trie_subset_wrapped(
         accesses.into_iter().map(TrieKey::into_nibbles),
     )
     .context(format!("missing keys when creating {}", trie_type))
-}
-
-impl TxnMetaState {
-    /// Outputs a boolean indicating whether this `TxnMetaState`
-    /// represents a dummy payload or an actual transaction.
-    const fn is_dummy(&self) -> bool {
-        self.txn_bytes.is_none()
-    }
-
-    fn txn_bytes(&self) -> Vec<u8> {
-        match self.txn_bytes.as_ref() {
-            Some(v) => v.clone(),
-            None => Vec::default(),
-        }
-    }
 }
 
 fn eth_to_gwei(eth: U256) -> U256 {

--- a/trace_decoder/src/lib.rs
+++ b/trace_decoder/src/lib.rs
@@ -258,15 +258,6 @@ pub enum ContractCodeUsage {
     Write(#[serde(with = "crate::hex")] Vec<u8>),
 }
 
-impl ContractCodeUsage {
-    fn get_code_hash(&self) -> H256 {
-        match self {
-            ContractCodeUsage::Read(hash) => *hash,
-            ContractCodeUsage::Write(bytes) => hash(bytes),
-        }
-    }
-}
-
 /// Other data that is needed for proof gen.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OtherBlockData {
@@ -397,15 +388,17 @@ pub fn entrypoint(
         .map(|(addr, data)| (addr.into_hash_left_padded(), data))
         .collect::<Vec<_>>();
 
-    let code_db = {
-        let mut code_db = code_db.unwrap_or_default();
-        if let Some(code_mappings) = pre_images.extra_code_hash_mappings {
-            code_db.extend(code_mappings);
-        }
-        code_db
-    };
-
-    let mut code_hash_resolver = Hash2Code::new(code_db);
+    // Note we discard any user-provided hashes.
+    let mut hash2code = code_db
+        .unwrap_or_default()
+        .into_values()
+        .chain(
+            pre_images
+                .extra_code_hash_mappings
+                .unwrap_or_default()
+                .into_values(),
+        )
+        .collect::<Hash2Code>();
 
     let last_tx_idx = txn_info.len().saturating_sub(1);
 
@@ -430,7 +423,7 @@ pub fn entrypoint(
                 &pre_images.tries,
                 &all_accounts_in_pre_images,
                 &extra_state_accesses,
-                &mut code_hash_resolver,
+                &mut hash2code,
             )
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -457,8 +450,6 @@ struct PartialTriePreImages {
 
 /// Like `#[serde(with = "hex")`, but tolerates and emits leading `0x` prefixes
 mod hex {
-    use std::{borrow::Cow, fmt};
-
     use serde::{de::Error as _, Deserialize as _, Deserializer, Serializer};
 
     pub fn serialize<S: Serializer, T>(data: T, serializer: S) -> Result<S::Ok, S::Error>
@@ -472,9 +463,9 @@ mod hex {
     pub fn deserialize<'de, D: Deserializer<'de>, T>(deserializer: D) -> Result<T, D::Error>
     where
         T: hex::FromHex,
-        T::Error: fmt::Display,
+        T::Error: std::fmt::Display,
     {
-        let s = Cow::<str>::deserialize(deserializer)?;
+        let s = String::deserialize(deserializer)?;
         match s.strip_prefix("0x") {
             Some(rest) => T::from_hex(rest),
             None => T::from_hex(&*s),

--- a/trace_decoder/src/processed_block_trace.rs
+++ b/trace_decoder/src/processed_block_trace.rs
@@ -1,16 +1,13 @@
-use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
-use std::iter::once;
 
-use anyhow::bail;
+use anyhow::{bail, Context as _};
 use ethereum_types::{Address, H256, U256};
 use evm_arithmetization::generation::mpt::{AccountRlp, LegacyReceiptRlp};
-use zk_evm_common::{EMPTY_CODE_HASH, EMPTY_TRIE_HASH};
+use zk_evm_common::EMPTY_TRIE_HASH;
 
-use crate::hash;
 use crate::typed_mpt::TrieKey;
 use crate::PartialTriePreImages;
+use crate::{hash, TxnTrace};
 use crate::{ContractCodeUsage, TxnInfo};
 
 const FIRST_PRECOMPILE_ADDRESS: U256 = U256([1, 0, 0, 0]);
@@ -32,7 +29,7 @@ pub(crate) struct ProcessedBlockTracePreImages {
 #[derive(Debug, Default)]
 pub(crate) struct ProcessedTxnInfo {
     pub nodes_used_by_txn: NodesUsedByTxn,
-    pub contract_code_accessed: HashMap<H256, Vec<u8>>,
+    pub contract_code_accessed: HashSet<Vec<u8>>,
     pub meta: TxnMetaState,
 }
 
@@ -41,22 +38,34 @@ pub(crate) struct ProcessedTxnInfo {
 /// If there are any txns that create contracts, then they will also
 /// get added here as we process the deltas.
 pub(crate) struct Hash2Code {
+    /// Key must always be [`hash`] of value.
     inner: HashMap<H256, Vec<u8>>,
 }
 
 impl Hash2Code {
-    pub fn new(inner: HashMap<H256, Vec<u8>>) -> Self {
-        Self { inner }
-    }
-    fn resolve(&mut self, c_hash: &H256) -> anyhow::Result<Vec<u8>> {
-        match self.inner.get(c_hash) {
-            Some(code) => Ok(code.clone()),
-            None => bail!("no code for hash {}", c_hash),
+    pub fn new() -> Self {
+        Self {
+            inner: HashMap::new(),
         }
     }
+    fn get(&mut self, hash: H256) -> anyhow::Result<Vec<u8>> {
+        match self.inner.get(&hash) {
+            Some(code) => Ok(code.clone()),
+            None => bail!("no code for hash {}", hash),
+        }
+    }
+    fn insert(&mut self, code: Vec<u8>) {
+        self.inner.insert(hash(&code), code);
+    }
+}
 
-    fn insert_code(&mut self, c_hash: H256, code: Vec<u8>) {
-        self.inner.insert(c_hash, code);
+impl FromIterator<Vec<u8>> for Hash2Code {
+    fn from_iter<II: IntoIterator<Item = Vec<u8>>>(iter: II) -> Self {
+        let mut this = Self::new();
+        for code in iter {
+            this.insert(code)
+        }
+        this
     }
 }
 
@@ -69,56 +78,58 @@ impl TxnInfo {
         hash2code: &mut Hash2Code,
     ) -> anyhow::Result<ProcessedTxnInfo> {
         let mut nodes_used_by_txn = NodesUsedByTxn::default();
-        let mut contract_code_accessed = create_empty_code_access_map();
+        let mut contract_code_accessed = HashSet::from([vec![]]); // we always "access" empty code
 
-        for (addr, trace) in self.traces {
+        for (
+            addr,
+            TxnTrace {
+                balance,
+                nonce,
+                storage_read,
+                storage_written,
+                code_usage,
+                self_destructed,
+            },
+        ) in self.traces
+        {
             let hashed_addr = hash(addr.as_bytes());
 
-            let storage_writes = trace.storage_written.unwrap_or_default();
-
-            let storage_read_keys = trace
-                .storage_read
-                .into_iter()
-                .flat_map(|reads| reads.into_iter());
-
-            let storage_write_keys = storage_writes.keys();
-            let storage_access_keys = storage_read_keys.chain(storage_write_keys.copied());
-
+            // record storage changes
+            let storage_written = storage_written.unwrap_or_default();
             nodes_used_by_txn.storage_accesses.push((
                 hashed_addr,
-                storage_access_keys
+                storage_read
+                    .into_iter()
+                    .flatten()
+                    .chain(storage_written.keys().copied())
                     .map(|H256(bytes)| TrieKey::from_hash(hash(bytes)))
                     .collect(),
             ));
+            nodes_used_by_txn.storage_writes.push((
+                hashed_addr,
+                storage_written
+                    .iter()
+                    .map(|(k, v)| (TrieKey::from_hash(*k), rlp::encode(v).to_vec()))
+                    .collect(),
+            ));
 
-            let storage_trie_change = !storage_writes.is_empty();
-            let code_change = trace.code_usage.is_some();
-            let state_write_occurred = trace.balance.is_some()
-                || trace.nonce.is_some()
-                || storage_trie_change
-                || code_change;
+            // record state changes
+            let state_write = StateWrite {
+                balance,
+                nonce,
+                storage_trie_change: !storage_written.is_empty(),
+                code_hash: code_usage.as_ref().map(|it| match it {
+                    ContractCodeUsage::Read(hash) => *hash,
+                    ContractCodeUsage::Write(bytes) => hash(bytes),
+                }),
+            };
 
-            if state_write_occurred {
-                let state_trie_writes = StateTrieWrites {
-                    balance: trace.balance,
-                    nonce: trace.nonce,
-                    storage_trie_change,
-                    code_hash: trace.code_usage.as_ref().map(|usage| usage.get_code_hash()),
-                };
-
+            if state_write != StateWrite::default() {
+                // a write occurred
                 nodes_used_by_txn
                     .state_writes
-                    .push((hashed_addr, state_trie_writes))
+                    .push((hashed_addr, state_write))
             }
-
-            let storage_writes_vec = storage_writes
-                .into_iter()
-                .map(|(k, v)| (TrieKey::from_hash(k), rlp::encode(&v).to_vec()))
-                .collect();
-
-            nodes_used_by_txn
-                .storage_writes
-                .push((hashed_addr, storage_writes_vec));
 
             let is_precompile = (FIRST_PRECOMPILE_ADDRESS..LAST_PRECOMPILE_ADDRESS)
                 .contains(&U256::from_big_endian(&addr.0));
@@ -136,23 +147,18 @@ impl TxnInfo {
                 nodes_used_by_txn.state_accesses.push(hashed_addr);
             }
 
-            if let Some(c_usage) = trace.code_usage {
-                match c_usage {
-                    ContractCodeUsage::Read(c_hash) => {
-                        if let Entry::Vacant(vacant) = contract_code_accessed.entry(c_hash) {
-                            vacant.insert(hash2code.resolve(&c_hash)?);
-                        }
-                    }
-                    ContractCodeUsage::Write(c_bytes) => {
-                        let c_hash = hash(&c_bytes);
-
-                        contract_code_accessed.insert(c_hash, c_bytes.clone());
-                        hash2code.insert_code(c_hash, c_bytes);
-                    }
+            match code_usage {
+                Some(ContractCodeUsage::Read(hash)) => {
+                    contract_code_accessed.insert(hash2code.get(hash)?);
                 }
+                Some(ContractCodeUsage::Write(code)) => {
+                    contract_code_accessed.insert(code.clone());
+                    hash2code.insert(code);
+                }
+                None => {}
             }
 
-            if trace.self_destructed.unwrap_or_default() {
+            if self_destructed.unwrap_or_default() {
                 nodes_used_by_txn.self_destructed_accounts.push(hashed_addr);
             }
         }
@@ -161,78 +167,64 @@ impl TxnInfo {
             nodes_used_by_txn.state_accesses.push(hashed_addr);
         }
 
-        let accounts_with_storage_accesses: HashSet<_> = HashSet::from_iter(
-            nodes_used_by_txn
-                .storage_accesses
-                .iter()
-                .filter(|(_, slots)| !slots.is_empty())
-                .map(|(addr, _)| *addr),
-        );
-
-        let all_accounts_with_non_empty_storage = all_accounts_in_pre_image
+        let accounts_with_storage_accesses = nodes_used_by_txn
+            .storage_accesses
             .iter()
-            .filter(|(_, data)| data.storage_root != EMPTY_TRIE_HASH);
+            .filter(|(_, slots)| !slots.is_empty())
+            .map(|(addr, _)| *addr)
+            .collect::<HashSet<_>>();
 
-        let accounts_with_storage_but_no_storage_accesses = all_accounts_with_non_empty_storage
-            .filter(|&(addr, _data)| !accounts_with_storage_accesses.contains(addr))
-            .map(|(addr, data)| (*addr, data.storage_root));
-
-        nodes_used_by_txn
-            .state_accounts_with_no_accesses_but_storage_tries
-            .extend(accounts_with_storage_but_no_storage_accesses);
-
-        let txn_bytes = match self.meta.byte_code.is_empty() {
-            false => Some(self.meta.byte_code),
-            true => None,
-        };
-
-        let receipt_node_bytes =
-            process_rlped_receipt_node_bytes(self.meta.new_receipt_trie_node_byte);
-
-        let new_meta_state = TxnMetaState {
-            txn_bytes,
-            receipt_node_bytes,
-            gas_used: self.meta.gas_used,
-        };
+        for (addr, state) in all_accounts_in_pre_image {
+            if state.storage_root != EMPTY_TRIE_HASH
+                && !accounts_with_storage_accesses.contains(addr)
+            {
+                nodes_used_by_txn
+                    .accts_with_unaccessed_storage
+                    .insert(*addr, state.storage_root);
+            }
+        }
 
         Ok(ProcessedTxnInfo {
             nodes_used_by_txn,
             contract_code_accessed,
-            meta: new_meta_state,
+            meta: TxnMetaState {
+                txn_bytes: match self.meta.byte_code.is_empty() {
+                    false => Some(self.meta.byte_code),
+                    true => None,
+                },
+                receipt_node_bytes: check_receipt_bytes(self.meta.new_receipt_trie_node_byte)?,
+                gas_used: self.meta.gas_used,
+            },
         })
     }
 }
 
-fn process_rlped_receipt_node_bytes(raw_bytes: Vec<u8>) -> Vec<u8> {
-    match rlp::decode::<LegacyReceiptRlp>(&raw_bytes) {
-        Ok(_) => raw_bytes,
+fn check_receipt_bytes(bytes: Vec<u8>) -> anyhow::Result<Vec<u8>> {
+    match rlp::decode::<LegacyReceiptRlp>(&bytes) {
+        Ok(_) => Ok(bytes),
         Err(_) => {
-            // Must be non-legacy.
-            rlp::decode::<Vec<u8>>(&raw_bytes).unwrap()
+            rlp::decode(&bytes).context("couldn't decode receipt as a legacy receipt or raw bytes")
         }
     }
-}
-
-fn create_empty_code_access_map() -> HashMap<H256, Vec<u8>> {
-    HashMap::from_iter(once((EMPTY_CODE_HASH, Vec::new())))
 }
 
 /// Note that "*_accesses" includes writes.
 #[derive(Debug, Default)]
 pub(crate) struct NodesUsedByTxn {
     pub state_accesses: Vec<H256>,
-    pub state_writes: Vec<(H256, StateTrieWrites)>,
+    pub state_writes: Vec<(H256, StateWrite)>,
 
     // Note: All entries in `storage_writes` also appear in `storage_accesses`.
     pub storage_accesses: Vec<(H256, Vec<TrieKey>)>,
     #[allow(clippy::type_complexity)]
     pub storage_writes: Vec<(H256, Vec<(TrieKey, Vec<u8>)>)>,
-    pub state_accounts_with_no_accesses_but_storage_tries: HashMap<H256, H256>,
+    /// Hashed address -> storage root.
+    pub accts_with_unaccessed_storage: HashMap<H256, H256>,
     pub self_destructed_accounts: Vec<H256>,
 }
 
-#[derive(Debug)]
-pub(crate) struct StateTrieWrites {
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct StateWrite {
     pub balance: Option<U256>,
     pub nonce: Option<U256>,
     pub storage_trie_change: bool,
@@ -241,7 +233,14 @@ pub(crate) struct StateTrieWrites {
 
 #[derive(Debug, Default)]
 pub(crate) struct TxnMetaState {
+    /// [`None`] if this is a dummy transaction inserted for padding.
     pub txn_bytes: Option<Vec<u8>>,
     pub receipt_node_bytes: Vec<u8>,
     pub gas_used: u64,
+}
+
+impl TxnMetaState {
+    pub fn is_dummy(&self) -> bool {
+        self.txn_bytes.is_none()
+    }
 }


### PR DESCRIPTION
Clean up the contract and interface of `Hash2Code`.