### PR TITLE
Expand conditional blocks logic in Kernel parsing

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/evm_asm.pest
+++ b/evm_arithmetization/src/cpu/kernel/evm_asm.pest
@@ -44,8 +44,9 @@ prover_input_fn = { identifier ~ ("::" ~ identifier)*}
 nullary_instruction = { identifier }
 
 feature_list = { "feature" ~ "=" ~ identifier ~ ("," ~ identifier)* }
-negated_feature_list = { "not(" ~ feature_list ~ ")"}
-conditional_block_args = { negated_feature_list | feature_list }
+feature_prefix = { "not" | "all" | "any" }
+prefixed_feature_list = { feature_prefix ~ "(" ~ feature_list ~ ")"}
+conditional_block_args = { prefixed_feature_list | feature_list }
 conditional_block = { ^"#" ~ "[" ~ "cfg" ~ "(" ~ conditional_block_args ~ ")" ~ "]" ~ "{" ~ item* ~ ^"}"}
 
 file = { SOI ~ item* ~ silent_eoi }

--- a/evm_arithmetization/src/cpu/kernel/evm_asm.pest
+++ b/evm_arithmetization/src/cpu/kernel/evm_asm.pest
@@ -43,7 +43,10 @@ prover_input_instruction = { ^"PROVER_INPUT" ~ "(" ~ prover_input_fn ~ ")" }
 prover_input_fn = { identifier ~ ("::" ~ identifier)*}
 nullary_instruction = { identifier }
 
-conditional_block = { ^"#" ~ "[" ~ "cfg" ~ "(" ~ "feature" ~ "=" ~ identifier ~ ")" ~ "]" ~ "{" ~ item* ~ ^"}"}
+feature_list = { "feature" ~ "=" ~ identifier ~ ("," ~ identifier)* }
+negated_feature_list = { "not(" ~ feature_list ~ ")"}
+conditional_block_args = { negated_feature_list | feature_list }
+conditional_block = { ^"#" ~ "[" ~ "cfg" ~ "(" ~ conditional_block_args ~ ")" ~ "]" ~ "{" ~ item* ~ ^"}"}
 
 file = { SOI ~ item* ~ silent_eoi }
 silent_eoi = _{ !ANY }


### PR DESCRIPTION
Kernel parsing logic now supports:

- conditional blocks based on _any_ of the listed features, similarly to the _any_ Rust attribute syntax, i.e.:
```asm
#[cfg(any(feature = cdk_erigon,polygon_pos))]
{
    // Do something if any of `cdk_erigon` or `polygon_pos` features are enabled
}
```

Note that the default listing of features will behave as an `any` block:
```asm
#[cfg(feature = cdk_erigon,polygon_pos)]
{
    // Do something if any of `cdk_erigon` or `polygon_pos` features are enabled
}
```

- conditional blocks based on _all_ of the listed features, similarly to the _all_ Rust attribute syntax, i.e.:
```asm
#[cfg(all(feature = cdk_erigon,polygon_pos))]
{
    // Do something if both `cdk_erigon` and `polygon_pos` features are enabled
}
```

- conditional blocks based on negated features, similarly to the _not_ Rust attribute syntax, i.e.:
```asm
#[cfg(not(feature = cdk_erigon))]
{
    // Do something if the `cdk_erigon` is not activated
}
```

It _does not_ support mixed logic (i.e. something like require `feature_1` but reject `feature_2`), though I think this should be probably enough for supporting the different variants we need to handle, and this can always be manually crafted through nested conditional blocks anyway:

```asm
#[cfg(not(feature = feature_2))]
{
    #[cfg(feature = feature_1)]
    {
        // Do something if the `feature_1` is activated and feature_2 is not activated
    }
}
```