### PR TITLE
`trace_decoder`: Tweak batch size for small blocks

### DIFF
--- a/trace_decoder/src/lib.rs
+++ b/trace_decoder/src/lib.rs
@@ -398,6 +398,8 @@ pub fn entrypoint(
         )
         .collect::<Hash2Code>();
 
+    // Make sure the batch size is smaller than the total number of transactions,
+    // or we would need to generate dummy proofs for the aggregation layers.
     if batch_size > txn_info.len() {
         batch_size = txn_info.len() / 2 + 1;
     }

--- a/trace_decoder/src/lib.rs
+++ b/trace_decoder/src/lib.rs
@@ -287,7 +287,7 @@ pub struct BlockLevelData {
 pub fn entrypoint(
     trace: BlockTrace,
     other: OtherBlockData,
-    batch_size: usize,
+    mut batch_size: usize,
     use_burn_addr: bool,
 ) -> anyhow::Result<Vec<GenerationInputs>> {
     use anyhow::Context as _;
@@ -397,6 +397,10 @@ pub fn entrypoint(
                 .into_values(),
         )
         .collect::<Hash2Code>();
+
+    if batch_size > txn_info.len() {
+        batch_size = txn_info.len() / 2 + 1;
+    }
 
     let last_tx_idx = txn_info.len().saturating_sub(1) / batch_size;
 


### PR DESCRIPTION
Simply halves the block in two chunks in case the initial batch size is too large, to prevent wasting ressources on dummy payloads.

closes #457 

Follow-up work mentioned #518 will improve on this but this requires additional benchmarkings / analysis of how much our instances can optimally handle.