### PR TITLE
Fix `clean` leader's command

### DIFF
--- a/zero_bin/common/src/prover_state/persistence.rs
+++ b/zero_bin/common/src/prover_state/persistence.rs
@@ -283,8 +283,14 @@ pub fn delete_all() -> anyhow::Result<()> {
             let file_path = entry.path();
 
             if file_path.is_file()
-                && (file_path.starts_with("prover_state")
-                    || file_path.starts_with("verifier_state"))
+                && (entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("prover_state")
+                    || entry
+                        .file_name()
+                        .to_string_lossy()
+                        .starts_with("verifier_state"))
             {
                 // Delete all circuit files.
                 fs::remove_file(file_path)?;

--- a/zero_bin/leader/src/main.rs
+++ b/zero_bin/leader/src/main.rs
@@ -56,10 +56,9 @@ async fn main() -> Result<()> {
 
     let args = cli::Cli::parse();
 
-    match args.command {
-        Command::Clean => return zero_bin_common::prover_state::persistence::delete_all(),
-        _ => (),
-    };
+    if let Command::Clean = args.command {
+        return zero_bin_common::prover_state::persistence::delete_all();
+    }
 
     let runtime = Arc::new(Runtime::from_config(&args.paladin, register()).await?);
     let prover_config: ProverConfig = args.prover_config.into();

--- a/zero_bin/leader/src/main.rs
+++ b/zero_bin/leader/src/main.rs
@@ -55,6 +55,12 @@ async fn main() -> Result<()> {
     }
 
     let args = cli::Cli::parse();
+
+    match args.command {
+        Command::Clean => return zero_bin_common::prover_state::persistence::delete_all(),
+        _ => (),
+    };
+
     let runtime = Arc::new(Runtime::from_config(&args.paladin, register()).await?);
     let prover_config: ProverConfig = args.prover_config.into();
 
@@ -69,7 +75,6 @@ async fn main() -> Result<()> {
     }
 
     match args.command {
-        Command::Clean => zero_bin_common::prover_state::persistence::delete_all()?,
         Command::Stdio { previous_proof } => {
             let previous_proof = get_previous_proof(previous_proof)?;
             stdio::stdio_main(runtime, previous_proof, Arc::new(prover_config)).await?;
@@ -118,6 +123,7 @@ async fn main() -> Result<()> {
             )
             .await?;
         }
+        Command::Clean => unreachable!("Flushing has already been handled."),
     }
 
     Ok(())


### PR DESCRIPTION
This:
- makes sure to trim the directory path prefix (by considering only the actual filename) to search for matches
- run the clean command ahead of config and runtime creation, to not have to pass any additional arguments nor go through needless preprocessing if calling `clean` with an actual missing permutation of ranges.

Tested on macbook M2 pro and Ubuntu 22.04.