### PR TITLE
chore: cleanup rpc tool parameters

### DIFF
--- a/zero_bin/rpc/src/lib.rs
+++ b/zero_bin/rpc/src/lib.rs
@@ -33,14 +33,6 @@ pub enum RpcType {
     Native,
 }
 
-#[derive(Clone, Debug, Copy)]
-pub struct RpcParams {
-    pub start_block: u64,
-    pub end_block: u64,
-    pub checkpoint_block_number: Option<u64>,
-    pub rpc_type: RpcType,
-}
-
 /// Obtain the prover input for one block
 pub async fn block_prover_input<ProviderT, TransportT>(
     cached_provider: Arc<CachedProvider<ProviderT, TransportT>>,


### PR DESCRIPTION
Resolves https://github.com/0xPolygonZero/zk_evm/issues/548

Rpc fetch tool and leader have quite different CLI parameters scope due to nature of their job, so I have thought that any effort to force unification there is not meaningful. I have isolated rpc tool parameters into their own binary file.