### PR TITLE
Clarify `eth_to_gwei` helper name and move to `common` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,6 +2075,7 @@ dependencies = [
  "static_assertions",
  "thiserror",
  "tiny-keccak",
+ "zk_evm_common",
  "zk_evm_proc_macro",
 ]
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,4 +1,4 @@
-use ethereum_types::H256;
+use ethereum_types::{H256, U256};
 
 /// The hash value of an account empty EVM code.
 /// 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
@@ -14,6 +14,26 @@ pub const EMPTY_TRIE_HASH: H256 = H256([
     108, 173, 192, 1, 98, 47, 181, 227, 99, 180, 33,
 ]);
 
+/// Converts an amount in `ETH` to `wei` units.
+pub fn eth_to_wei(eth: U256) -> U256 {
+    // 1 ether = 10^18 wei.
+    eth * U256::from(10).pow(18.into())
+}
+
+/// Converts an amount in `gwei` to `wei` units.
+/// This also works for converting `ETH` to `gwei`.
+pub fn gwei_to_wei(eth: U256) -> U256 {
+    // 1 ether = 10^9 gwei = 10^18 wei.
+    eth * U256::from(10).pow(9.into())
+}
+
+#[test]
+fn test_eth_conversion() {
+    assert_eq!(
+        eth_to_wei(U256::one()),
+        gwei_to_wei(gwei_to_wei(U256::one()))
+    );
+}
 #[test]
 fn test_empty_code_hash() {
     assert_eq!(EMPTY_CODE_HASH, keccak_hash::keccak([]));

--- a/evm_arithmetization/Cargo.toml
+++ b/evm_arithmetization/Cargo.toml
@@ -50,6 +50,7 @@ serde-big-array = { workspace = true }
 mpt_trie = { workspace = true }
 smt_trie = { workspace = true, optional = true }
 zk_evm_proc_macro = { workspace = true }
+zk_evm_common = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/evm_arithmetization/src/testing_utils.rs
+++ b/evm_arithmetization/src/testing_utils.rs
@@ -161,9 +161,3 @@ pub fn scalable_contract_from_storage(storage_trie: &HashedPartialTrie) -> Accou
         ..Default::default()
     }
 }
-
-/// Converts an amount in `ETH` to `wei` units.
-pub fn eth_to_wei(eth: U256) -> U256 {
-    // 1 ether = 10^18 wei.
-    eth * U256::from(10).pow(18.into())
-}

--- a/evm_arithmetization/tests/selfdestruct.rs
+++ b/evm_arithmetization/tests/selfdestruct.rs
@@ -9,7 +9,7 @@ use evm_arithmetization::generation::{GenerationInputs, TrieInputs};
 use evm_arithmetization::proof::{BlockHashes, BlockMetadata, TrieRoots};
 use evm_arithmetization::prover::testing::prove_all_segments;
 use evm_arithmetization::testing_utils::{
-    beacon_roots_account_nibbles, beacon_roots_contract_from_storage, eth_to_wei, init_logger,
+    beacon_roots_account_nibbles, beacon_roots_contract_from_storage, init_logger,
     preinitialized_state_and_storage_tries, update_beacon_roots_account_storage,
 };
 use evm_arithmetization::verifier::testing::verify_all_proofs;
@@ -21,6 +21,7 @@ use mpt_trie::partial_trie::{HashedPartialTrie, PartialTrie};
 use plonky2::field::goldilocks_field::GoldilocksField;
 use plonky2::plonk::config::KeccakGoldilocksConfig;
 use plonky2::util::timing::TimingTree;
+use zk_evm_common::eth_to_wei;
 
 type F = GoldilocksField;
 const D: usize = 2;

--- a/evm_arithmetization/tests/simple_transfer.rs
+++ b/evm_arithmetization/tests/simple_transfer.rs
@@ -10,7 +10,7 @@ use evm_arithmetization::generation::{GenerationInputs, TrieInputs};
 use evm_arithmetization::proof::{BlockHashes, BlockMetadata, TrieRoots};
 use evm_arithmetization::prover::testing::prove_all_segments;
 use evm_arithmetization::testing_utils::{
-    beacon_roots_account_nibbles, beacon_roots_contract_from_storage, eth_to_wei, init_logger,
+    beacon_roots_account_nibbles, beacon_roots_contract_from_storage, init_logger,
     preinitialized_state_and_storage_tries, update_beacon_roots_account_storage,
 };
 use evm_arithmetization::verifier::testing::verify_all_proofs;
@@ -22,6 +22,7 @@ use mpt_trie::partial_trie::{HashedPartialTrie, PartialTrie};
 use plonky2::field::goldilocks_field::GoldilocksField;
 use plonky2::plonk::config::KeccakGoldilocksConfig;
 use plonky2::util::timing::TimingTree;
+use zk_evm_common::eth_to_wei;
 
 type F = GoldilocksField;
 const D: usize = 2;

--- a/trace_decoder/src/decoding.rs
+++ b/trace_decoder/src/decoding.rs
@@ -20,6 +20,7 @@ use mpt_trie::{
     trie_ops::TrieOpError,
     utils::{IntoTrieKey as _, TriePath},
 };
+use zk_evm_common::gwei_to_wei;
 
 use crate::{
     hash,
@@ -442,7 +443,7 @@ fn add_withdrawals_to_txns(
 ) -> anyhow::Result<()> {
     // Scale withdrawals amounts.
     for (_addr, amt) in withdrawals.iter_mut() {
-        *amt = eth_to_gwei(*amt)
+        *amt = gwei_to_wei(*amt)
     }
 
     let withdrawals_with_hashed_addrs_iter = || {
@@ -690,11 +691,6 @@ fn create_trie_subset_wrapped(
         accesses.into_iter().map(TrieKey::into_nibbles),
     )
     .context(format!("missing keys when creating {}", trie_type))
-}
-
-fn eth_to_gwei(eth: U256) -> U256 {
-    // 1 ether = 10^9 gwei.
-    eth * U256::from(10).pow(9.into())
 }
 
 // This is just `rlp(0)`.


### PR DESCRIPTION
closes #618 

Note that `zk_evm_common` is technically only necessary as dev-dependency for `evm_arithmetization`, but it will be brought in as regular dependency soon (cf #605) anyway.