### PR TITLE
Small fixes to `rpc` and `common` modules

### DIFF
--- a/zero_bin/common/src/fs.rs
+++ b/zero_bin/common/src/fs.rs
@@ -21,7 +21,7 @@ pub fn get_previous_proof(path: Option<PathBuf>) -> anyhow::Result<Option<Genera
     let proof: Vec<GeneratedBlockProof> = serde_path_to_error::deserialize(des)?;
     // Individual proofs are serialized as vector to match other output formats.
     if proof.len() != 1 {
-        return Err(anyhow!("Invalid proof format."));
+        return Err(anyhow!("Invalid proof format, expected vector of generated block proofs with a single element."));
     }
 
     Ok(Some(proof[0].to_owned()))

--- a/zero_bin/common/src/fs.rs
+++ b/zero_bin/common/src/fs.rs
@@ -1,6 +1,8 @@
 use std::fs::File;
 use std::path::PathBuf;
 
+use anyhow::anyhow;
+use evm_arithmetization::proof::PublicValues;
 use proof_gen::proof_types::GeneratedBlockProof;
 
 pub fn generate_block_proof_file_name(directory: &Option<&str>, block_height: u64) -> PathBuf {
@@ -17,6 +19,20 @@ pub fn get_previous_proof(path: Option<PathBuf>) -> anyhow::Result<Option<Genera
     let path = path.unwrap();
     let file = File::open(path)?;
     let des = &mut serde_json::Deserializer::from_reader(&file);
-    let proof: GeneratedBlockProof = serde_path_to_error::deserialize(des)?;
-    Ok(Some(proof))
+    let proof: Vec<GeneratedBlockProof> = serde_path_to_error::deserialize(des)?;
+    // Individual proofs are serialized as vector to match other output formats.
+    if proof.len() != 1 {
+        return Err(anyhow!("Invalid proof format."));
+    }
+
+    std::fs::write(
+        "inputs.json",
+        serde_json::to_string(&PublicValues::from_public_inputs(
+            &proof[0].intern.public_inputs,
+        ))
+        .unwrap(),
+    )
+    .unwrap();
+
+    Ok(Some(proof[0].to_owned()))
 }

--- a/zero_bin/common/src/fs.rs
+++ b/zero_bin/common/src/fs.rs
@@ -2,7 +2,6 @@ use std::fs::File;
 use std::path::PathBuf;
 
 use anyhow::anyhow;
-use evm_arithmetization::proof::PublicValues;
 use proof_gen::proof_types::GeneratedBlockProof;
 
 pub fn generate_block_proof_file_name(directory: &Option<&str>, block_height: u64) -> PathBuf {
@@ -24,15 +23,6 @@ pub fn get_previous_proof(path: Option<PathBuf>) -> anyhow::Result<Option<Genera
     if proof.len() != 1 {
         return Err(anyhow!("Invalid proof format."));
     }
-
-    std::fs::write(
-        "inputs.json",
-        serde_json::to_string(&PublicValues::from_public_inputs(
-            &proof[0].intern.public_inputs,
-        ))
-        .unwrap(),
-    )
-    .unwrap();
 
     Ok(Some(proof[0].to_owned()))
 }

--- a/zero_bin/rpc/src/main.rs
+++ b/zero_bin/rpc/src/main.rs
@@ -14,7 +14,6 @@ use rpc::{retry::build_http_retry_provider, RpcType};
 use tracing_subscriber::{prelude::*, EnvFilter};
 use url::Url;
 use zero_bin_common::block_interval::BlockIntervalStream;
-use zero_bin_common::pre_checks::check_previous_proof_and_checkpoint;
 use zero_bin_common::provider::CachedProvider;
 use zero_bin_common::version;
 use zero_bin_common::{block_interval::BlockInterval, prover_state::persistence::CIRCUIT_VERSION};
@@ -88,7 +87,6 @@ where
     let checkpoint_block_number = params
         .checkpoint_block_number
         .unwrap_or(params.start_block - 1);
-    check_previous_proof_and_checkpoint(checkpoint_block_number, &None, params.start_block)?;
 
     let block_interval = BlockInterval::Range(params.start_block..params.end_block + 1);
     let mut block_prover_inputs = Vec::new();


### PR DESCRIPTION
- the sanity check on the RPC `fetch` command prevents to fetch individual witnesses with same checkpoint (say witnesses for block 1 and 2, both targeting genesis as checkpoint, if the goal is to prove first b1 and pass it as `--previous-proof` argument of the second payload
- `--previous-proof` expected a `ProofWithPublicInputs` but we always serialize elements as `arrays`