### PR TITLE
Check block_timestamp always increases.

### DIFF
--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -1381,6 +1381,13 @@ where
             agg_pv.extra_block_data,
         );
 
+        // Check that the paent block's timestamp is less than the current block's.
+        Self::check_block_timestamp(
+            &mut builder,
+            parent_pv.block_metadata.block_timestamp,
+            agg_pv.block_metadata.block_timestamp,
+        );
+
         // Connect the burn address targets.
         #[cfg(feature = "cdk_erigon")]
         {
@@ -1423,6 +1430,18 @@ where
         }
     }
 
+    fn check_block_timestamp(
+        builder: &mut CircuitBuilder<F, D>,
+        prev_timestamp: Target,
+        timestamp: Target,
+    ) {
+        // We check that timestamp > prev_timestamp.
+        // In other words, we range-check `diff = timestamp - prev_timestamp - 1`
+        // between 0 and 2ˆ32.
+        let diff = builder.sub(timestamp, prev_timestamp);
+        let diff = builder.add_const(diff, F::NEG_ONE);
+        builder.range_check(diff, 32);
+    }
     fn connect_extra_public_values(
         builder: &mut CircuitBuilder<F, D>,
         pvs: &ExtraBlockDataTarget,

--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -1435,8 +1435,8 @@ where
         prev_timestamp: Target,
         timestamp: Target,
     ) {
-        // We check that timestamp > prev_timestamp.
-        // In other words, we range-check `diff = timestamp - prev_timestamp - 1`
+        // We check that timestamp >= prev_timestamp.
+        // In other words, we range-check `diff = timestamp - prev_timestamp`
         // between 0 and 2ˆ32.
         let diff = builder.sub(timestamp, prev_timestamp);
         builder.range_check(diff, 32);

--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -1439,7 +1439,6 @@ where
         // In other words, we range-check `diff = timestamp - prev_timestamp - 1`
         // between 0 and 2ˆ32.
         let diff = builder.sub(timestamp, prev_timestamp);
-        let diff = builder.add_const(diff, F::NEG_ONE);
         builder.range_check(diff, 32);
     }
     fn connect_extra_public_values(

--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -1437,7 +1437,7 @@ where
     ) {
         // We check that timestamp >= prev_timestamp.
         // In other words, we range-check `diff = timestamp - prev_timestamp`
-        // between 0 and 2ˆ32.
+        // is between 0 and 2ˆ32.
         let diff = builder.sub(timestamp, prev_timestamp);
         builder.range_check(diff, 32);
     }


### PR DESCRIPTION
This PR aims at addressing #634.

In `create_block_circuit`, it range-checks `diff = timestamp - parent_timestamp - 1` between `0` and `2ˆ32`, as a way to ensure `timestamp > parent_timestamp`.