### PR TITLE
Fix address masking in `trace_decoder` processing

### DIFF
--- a/trace_decoder/src/core.rs
+++ b/trace_decoder/src/core.rs
@@ -1,3 +1,4 @@
+use std::ops::Range;
 use std::{
     cmp,
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -458,10 +459,11 @@ fn middle<StateTrieT: StateTrie + Clone>(
                     state_mask.insert(TrieKey::from_address(addr));
                 } else {
                     // Simple state access
-                    let precompiled_addresses = address!("0000000000000000000000000000000000000001")
-                        ..address!("000000000000000000000000000000000000000a");
+                    const PRECOMPILE_ADDRESSES: Range<alloy::primitives::Address> =
+                        address!("0000000000000000000000000000000000000001")
+                            ..address!("000000000000000000000000000000000000000a");
 
-                    if receipt.status || !precompiled_addresses.contains(&addr.compat()) {
+                    if receipt.status || !PRECOMPILE_ADDRESSES.contains(&addr.compat()) {
                         // TODO(0xaatif): https://github.com/0xPolygonZero/zk_evm/pull/613
                         //                masking like this SHOULD be a space-saving optimization,
                         //                BUT if it's omitted, we actually get state root mismatches


### PR DESCRIPTION
The latest refactoring was missing an edge case of transactions fundings precompile addresses (the only way for them to be `touched` instead of simply _accessed_), which would then need to be _masked_ (not sure of the terminology) for the prover to be able to access the related account down the trie.

I've also moved the masking up as it seemed slightly clearer to me, i.e. :
- state writes -> always mask (fixes block 15 of the test chain)
- state accesses (no writes) -> do not mask precompiles upon failed txn (fixes block 35 of the test chain, I had actually commented it on the refactoring PR, this may be related to the linked ticket)

but I could leave it where it was if preferred.