### PR TITLE
Remove unnecessary overhead in linked list preprocessing

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -259,10 +259,6 @@ impl<F: RichField> Interpreter<F> {
         );
         self.insert_preinitialized_segment(Segment::StorageLinkedList, preinit_storage_ll_segment);
 
-        // Initialize the accounts and storage BTrees.
-        self.generation_state.insert_all_slots_in_memory();
-        self.generation_state.insert_all_accounts_in_memory();
-
         // Update the RLP and withdrawal prover inputs.
         let rlp_prover_inputs = all_rlp_prover_inputs_reversed(&inputs.signed_txns);
         let withdrawal_prover_inputs = all_withdrawals_prover_inputs_reversed(&inputs.withdrawals);

--- a/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
@@ -48,9 +48,6 @@ pub(crate) fn initialize_mpts<F: RichField>(
         trie_data.clone();
     interpreter.generation_state.trie_root_ptrs = trie_root_ptrs.clone();
 
-    interpreter.generation_state.insert_all_slots_in_memory();
-    interpreter.generation_state.insert_all_accounts_in_memory();
-
     if trie_root_ptrs.state_root_ptr.is_none() {
         trie_root_ptrs.state_root_ptr = Some(
             load_state_mpt(

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/linked_list.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/linked_list.rs
@@ -12,11 +12,15 @@ use rand::{thread_rng, Rng};
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::cpu::kernel::interpreter::Interpreter;
-use crate::generation::linked_list::AccountsLinkedList;
-use crate::generation::linked_list::StorageLinkedList;
+use crate::generation::linked_list::LinkedList;
+use crate::generation::linked_list::ACCOUNTS_LINKED_LIST_NODE_SIZE;
+use crate::generation::linked_list::STORAGE_LINKED_LIST_NODE_SIZE;
 use crate::memory::segments::Segment;
 use crate::witness::memory::MemoryAddress;
 use crate::witness::memory::MemorySegmentState;
+
+pub(crate) type AccountsLinkedList<'a> = LinkedList<'a, ACCOUNTS_LINKED_LIST_NODE_SIZE>;
+pub(crate) type StorageLinkedList<'a> = LinkedList<'a, STORAGE_LINKED_LIST_NODE_SIZE>;
 
 fn init_logger() {
     let _ = try_init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "debug"));

--- a/evm_arithmetization/src/generation/linked_list.rs
+++ b/evm_arithmetization/src/generation/linked_list.rs
@@ -24,9 +24,6 @@ pub(crate) struct Bounded;
 impl LinkedListType for Cyclic {}
 impl LinkedListType for Bounded {}
 
-pub(crate) type AccountsLinkedList<'a> = LinkedList<'a, ACCOUNTS_LINKED_LIST_NODE_SIZE>;
-pub(crate) type StorageLinkedList<'a> = LinkedList<'a, STORAGE_LINKED_LIST_NODE_SIZE>;
-
 // A linked list implemented using a vector `access_list_mem`.
 // In this representation, the values of nodes are stored in the range
 // `access_list_mem[i..i + node_size - 1]`, and `access_list_mem[i + node_size -

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -8,7 +8,6 @@ use keccak_hash::keccak;
 use log::Level;
 use plonky2::hash::hash_types::RichField;
 
-use super::linked_list::{AccountsLinkedList, StorageLinkedList};
 use super::mpt::TrieRootPtrs;
 use super::segments::GenerationSegmentData;
 use super::{TrieInputs, TrimmedGenerationInputs, NUM_EXTRA_CYCLES_AFTER};
@@ -454,9 +453,6 @@ impl<F: RichField> GenerationState<F> {
         let trie_root_ptrs =
             state.preinitialize_linked_lists_and_txn_and_receipt_mpts(&inputs.tries);
 
-        state.insert_all_accounts_in_memory();
-        state.insert_all_slots_in_memory();
-
         state.trie_root_ptrs = trie_root_ptrs;
         Ok(state)
     }
@@ -594,50 +590,6 @@ impl<F: RichField> GenerationState<F> {
             check_overflow: false,
             ..segment_data.registers_before
         };
-    }
-
-    /// Insert all the slots stored in the `StorageLinkedList`` segment into
-    /// the accounts `BtreeMap`.
-    pub(crate) fn insert_all_slots_in_memory(&mut self) {
-        let storage_mem = self.memory.get_preinit_memory(Segment::StorageLinkedList);
-        self.storage_pointers.extend(
-            StorageLinkedList::from_mem_and_segment(&storage_mem, Segment::StorageLinkedList)
-                .expect("There must be at least an empty storage linked list")
-                .tuple_windows()
-                .enumerate()
-                .map_while(
-                    |(i, ([prev_account_key, .., ptr], [account_key, slot_key, ..]))| {
-                        if i != 0 && prev_account_key == U256::MAX {
-                            None
-                        } else {
-                            Some((
-                                (account_key, slot_key),
-                                u256_to_usize(ptr).expect("Node pointer must fit in a usize"),
-                            ))
-                        }
-                    },
-                ),
-        );
-    }
-
-    pub(crate) fn insert_all_accounts_in_memory(&mut self) {
-        let accounts_mem = self.memory.get_preinit_memory(Segment::AccountsLinkedList);
-        self.accounts_pointers.extend(
-            AccountsLinkedList::from_mem_and_segment(&accounts_mem, Segment::AccountsLinkedList)
-                .expect("There must be at least an empty accounts linked list")
-                .tuple_windows()
-                .enumerate()
-                .map_while(|(i, ([prev_account_key, .., ptr], [account_key, ..]))| {
-                    if i != 0 && prev_account_key == U256::MAX {
-                        None
-                    } else {
-                        Some((
-                            account_key,
-                            u256_to_usize(ptr).expect("Node pointer must fit in a usize"),
-                        ))
-                    }
-                }),
-        );
     }
 }
 


### PR DESCRIPTION
The steps `insert_all_slots_in_memory` and `insert_all_accounts_in_memory` actually don't do anything, because we're inserting exactly the accounts and slots we've already added when processing the trie data.

cc @4l0n50 