### PR TITLE
perf: Remove some binary ops & make KERNEL `init` section free of logic operations

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/access_lists.asm
@@ -101,7 +101,7 @@ global insert_accessed_addresses:
     // pred_ptr == start, pred_addr, pred_ptr, addr, retdest
     DUP2 DUP5 GT
     // addr > pred_addr, pred_ptr == start, pred_addr, pred_ptr, addr, retdest
-    OR
+    ADD // OR
     // (addr > pred_addr) || (pred_ptr == start), pred_addr, pred_ptr, addr, retdest
     %jumpi(insert_new_address)
     // Here, addr <= pred_addr. Assert that `addr == pred_addr`.
@@ -308,8 +308,8 @@ insert_storage_key:
     DUP8
     LT
     // stack: next_key > key, next_val == addr, addr < next_val, next_ptr, new_ptr, next_ptr_ptr, addr, key, retdest
-    AND
-    OR
+    MUL // AND
+    ADD // OR
     %assert_nonzero
     // stack: next_ptr, new_ptr, next_ptr_ptr, addr, key, retdest
     SWAP2

--- a/evm_arithmetization/src/cpu/kernel/asm/core/exception.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/exception.asm
@@ -214,7 +214,7 @@ global exc_stop:
 
     // Check the program counter.
     // stack: addr_registers, trap_info
-    DUP2 %as_u32_no_and
+    PUSH 0x100000000 DUP3 MOD
     // stack: program_counter, addr_registers, trap_info
     DUP2
     MLOAD_GENERAL
@@ -223,8 +223,9 @@ global exc_stop:
 
     // Check is_kernel_mode.
     // stack: addr_registers, trap_info
-    DUP2 %shr_const(32)
-    %as_u32_no_and
+    PUSH 0x100000000
+    DUP3 %shr_const(32)
+    MOD
     // stack: is_kernel_mode, addr_registers, trap_info
     DUP2 %increment
     MLOAD_GENERAL

--- a/evm_arithmetization/src/cpu/kernel/asm/core/exception.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/exception.asm
@@ -214,7 +214,7 @@ global exc_stop:
 
     // Check the program counter.
     // stack: addr_registers, trap_info
-    DUP2 %as_u32
+    DUP2 %as_u32_no_and
     // stack: program_counter, addr_registers, trap_info
     DUP2
     MLOAD_GENERAL
@@ -224,7 +224,7 @@ global exc_stop:
     // Check is_kernel_mode.
     // stack: addr_registers, trap_info
     DUP2 %shr_const(32)
-    %as_u32
+    %as_u32_no_and
     // stack: is_kernel_mode, addr_registers, trap_info
     DUP2 %increment
     MLOAD_GENERAL
@@ -233,7 +233,7 @@ global exc_stop:
     // Check the gas used.
     // stack: addr_registers, trap_info
     SWAP1 %shr_const(192)
-    %as_u32
+    %as_u32_no_and
     // stack: gas_used, addr_registers
     DUP2 %add_const(5)
     MLOAD_GENERAL

--- a/evm_arithmetization/src/cpu/kernel/asm/core/util.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/util.asm
@@ -90,7 +90,7 @@
     // stack: addr
     DUP1 %is_non_existent
     SWAP1 %is_empty
-    OR
+    ADD // OR
 %endmacro
 
 // Gets the size of the stack _before_ the macro is run

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/curve_add.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/curve_add.asm
@@ -222,7 +222,7 @@ global bn_double:
     // stack:         x , N, y < N, x, y
     LT
     // stack:         x < N, y < N, x, y
-    AND
+    MUL // AND
     // stack:                range, x, y
     SWAP2
     // stack:                y, x, range
@@ -249,9 +249,9 @@ global bn_double:
     // stack:       ident , curve, range
     SWAP2
     // stack:       range , curve, ident
-    AND
+    MUL // AND
     // stack:       range & curve, ident
-    OR
+    ADD // OR
     // stack:                   is_valid
 %endmacro
 

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/pairing.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/pairing.asm
@@ -196,6 +196,6 @@ bn254_pairing_output_validation:
     ISZERO
     MUL
     // stack: Q==0, P==0
-    OR
+    ADD // OR
     // stack: Q==0||P==0
 %endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/twisted_curve_checks.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/twisted_curve_checks.asm
@@ -17,7 +17,7 @@
     // stack: y_, x, x_, y, curve & range
     %bn_check_twisted_ident
     // stack:     ident ,   curve & range
-    OR
+    ADD // OR
     // stack:     ident || (curve & range)
 %endmacro
 

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/twisted_curve_mul.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/twisted_curve_mul.asm
@@ -34,14 +34,14 @@ bn_twisted_mul_loop:
     // stack: X1, Y1, X, Y, s, n, retdest
     %bn_twisted_double
     // stack: X2, Y2, X, Y, s, n, retdest
-    DUP9
-    // stack: s, X2, Y2, X, Y, s, n, retdest
-    PUSH 1 DUP12 SUB
-    // stack: n - 1, s, X2, Y2, X, Y, s, n, retdest
+    PUSH 2
+    DUP10
+    // stack: s, 2, X2, Y2, X, Y, s, n, retdest
+    PUSH 1 DUP13 SUB
+    // stack: n - 1, s, 2, X2, Y2, X, Y, s, n, retdest
     SHR
-    // stack: s >> n - 1, X2, Y2, X, Y, s, n, retdest
-    PUSH 1
-    AND
+    // stack: s >> n - 1, 2, X2, Y2, X, Y, s, n, retdest
+    MOD
     // stack: nth_bit, X2, Y2, X, Y, s, n, retdest
     %jumpi(bn_twisted_mul_add_base)
     // stack: X2, Y2, X, Y, s, n, retdest

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/bn254/field_arithmetic/util.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/bn254/field_arithmetic/util.asm
@@ -96,7 +96,7 @@
     // stack: x, y, y_==x_
     EQ
     // stack: x==y, y_==x_
-    AND
+    MUL // AND
 %endmacro
 
 %macro add_fp254_2

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/common.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/common.asm
@@ -26,7 +26,7 @@ global ec_twisted_double_retself:
 // Check if (x,y)==(0,0)
 %macro ec_isidentity
     // stack: x, y
-    ADD // OR
+    OR
     // stack: x | y
     ISZERO
     // stack: (x,y) == (0,0)

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/common.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/common.asm
@@ -26,7 +26,7 @@ global ec_twisted_double_retself:
 // Check if (x,y)==(0,0)
 %macro ec_isidentity
     // stack: x, y
-    OR
+    ADD // OR
     // stack: x | y
     ISZERO
     // stack: (x,y) == (0,0)

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/secp256k1/curve_add.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/secp256k1/curve_add.asm
@@ -236,7 +236,7 @@ global secp_double:
     // stack: y, N, x < N, x, y
     LT
     // stack: y < N, x < N, x, y
-    AND
+    MUL // AND
     // stack: (y < N) & (x < N), x, y
     SWAP2
     // stack: y, x, (y < N) & (x < N), x
@@ -280,8 +280,8 @@ global secp_double:
     // stack: (x,y)==(0,0), y^2 % N == (x^3 + 7) % N, b
     SWAP2
     // stack: b, y^2 % N == (x^3 + 7) % N, (x,y)==(0,0)
-    AND
+    MUL // AND
     // stack: y^2 % N == (x^3 + 7) % N & (x < N) & (y < N), (x,y)==(0,0)
-    OR
+    ADD // OR
     // stack: y^2 % N == (x^3 + 7) % N & (x < N) & (y < N) || (x,y)==(0,0)
 %endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/secp256k1/ecrecover.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/secp256k1/ecrecover.asm
@@ -76,14 +76,14 @@ ecdsa_after_precompute:
     PUSH 0 PUSH 0 PUSH 129 // 129 is the bit length of the GLV exponents
     // stack: i, accx, accy, a0, a1, b0, b1, retdest
 ecdsa_after_precompute_loop:
-    %stack (i, accx, accy, a0, a1, b0, b1, retdest) -> (i, b1, i, accx, accy, a0, a1, b0, b1, retdest)
-    SHR %and_const(1)
-    %stack (bit_b1, i, accx, accy, a0, a1, b0, b1, retdest) -> (i, b0, bit_b1, i, accx, accy, a0, a1, b0, b1, retdest)
-    SHR %and_const(1)
-    %stack (bit_b0, bit_b1, i, accx, accy, a0, a1, b0, b1, retdest) -> (i, a1, bit_b0, bit_b1, i, accx, accy, a0, a1, b0, b1, retdest)
-    SHR %and_const(1)
-    %stack (bit_a1, bit_b0, bit_b1, i, accx, accy, a0, a1, b0, b1, retdest) -> (i, a0, bit_a1, bit_b0, bit_b1, i, accx, accy, a0, a1, b0, b1, retdest)
-    SHR %and_const(1)
+    %stack (i, accx, accy, a0, a1, b0, b1, retdest) -> (i, b1, 2, i, accx, accy, a0, a1, b0, b1, retdest)
+    SHR MOD // mod 2
+    %stack (bit_b1, i, accx, accy, a0, a1, b0, b1, retdest) -> (i, b0, 2, bit_b1, i, accx, accy, a0, a1, b0, b1, retdest)
+    SHR MOD // mod 2
+    %stack (bit_b0, bit_b1, i, accx, accy, a0, a1, b0, b1, retdest) -> (i, a1, 2, bit_b0, bit_b1, i, accx, accy, a0, a1, b0, b1, retdest)
+    SHR MOD // mod 2
+    %stack (bit_a1, bit_b0, bit_b1, i, accx, accy, a0, a1, b0, b1, retdest) -> (i, a0, 2, bit_a1, bit_b0, bit_b1, i, accx, accy, a0, a1, b0, b1, retdest)
+    SHR MOD // mod 2
     %mul_const(2) ADD %mul_const(2) ADD %mul_const(2) ADD
     %stack (index, i, accx, accy, a0, a1, b0, b1, retdest) -> (index, index, i, accx, accy, a0, a1, b0, b1, retdest)
     %mul_const(2) %add_const(1)
@@ -147,7 +147,7 @@ pubkey_to_addr:
     // stack: (r >= N || r==0 || s >= N || s==0), (v==28 || v==27), hash, v, r, s, retdest
     ISZERO
     // stack: (r < N & r!=0 & s < N & s!=0), (v==28 || v==27), hash, v, r, s, retdest
-    AND
+    MUL // AND
     // stack: r < N & r!=0 & s < N & s!=0 & (v==28 || v==27), hash, v, r, s, retdest
 %endmacro
 

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/secp256k1/lift_x.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/secp256k1/lift_x.asm
@@ -22,12 +22,12 @@
     // stack: sqrtOk, y, parity
     SWAP2
     // stack: parity, y, sqrtOk
-    DUP2
-    // stack: y, parity, y, sqrtOk
-    PUSH 1
-    // stack: 1, y, parity, y, sqrtOk
-    AND
-    // stack: 1 & y, parity, y, sqrtOk
+    PUSH 2
+    // stack: 2, parity, y, sqrtOk
+    DUP3
+    // stack: y, 2, parity, y, sqrtOk
+    MOD
+    // stack: y % 2, parity, y, sqrtOk
     EQ
     // stack: correctParity, y, sqrtOk
     DUP2

--- a/evm_arithmetization/src/cpu/kernel/asm/curve/wnaf.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/curve/wnaf.asm
@@ -26,7 +26,7 @@ wnaf_loop_contd:
     %stack (n, i, o, segment, retdest) -> (o, i, n, segment, retdest)
     ADD
     %stack (o, n, segment, retdest) -> (n, segment, o, retdest)
-    DUP1 %and_const(31) SWAP1
+    PUSH 32 DUP2 MOD SWAP1
     PUSH 16 DUP3 GT
     // stack: m>16, n, m, segment, o, retdest
     %mul_const(32) ADD
@@ -62,7 +62,7 @@ trailing_zeros:
     PUSH 0
 trailing_zeros_loop:
     // stack: count, x, retdest
-    PUSH 1 DUP3 AND
+    PUSH 2 DUP3 MOD
     // stack: x&1, count, x, retdest
     %jumpi(trailing_zeros_end)
     // stack: count, x, retdest

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/read.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/read.asm
@@ -135,7 +135,7 @@ global mpt_read_leaf:
     %stack (num_nibbles_match, node_payload_ptr, node_key, key)
         -> (key, node_key, num_nibbles_match, node_payload_ptr)
     EQ
-    AND
+    MUL // AND
     // stack: keys_match && num_nibbles_match, node_payload_ptr, retdest
     %jumpi(mpt_read_leaf_found)
 global mpt_read_leaf_not_found:

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/util.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/util.asm
@@ -53,13 +53,14 @@
     // stack: num_nibbles, key
     %decrement // num_nibbles -= 1
     // stack: num_nibbles, key
-    DUP2
-    // stack: key, num_nibbles, key
-    DUP2 %mul_const(4)
-    // stack: num_nibbles_x4, key, num_nibbles, key
+    PUSH 0x10
+    DUP3
+    // stack: key, nibbles_mod, num_nibbles, key
+    DUP3 %mul_const(4)
+    // stack: num_nibbles_x4, key, nibbles_mod, num_nibbles, key
     SHR
-    // stack: key >> num_nibbles_x4, num_nibbles, key
-    %and_const(0xF)
+    // stack: key >> num_nibbles_x4, nibbles_mod, num_nibbles, key
+    MOD
     // stack: first_nibble, num_nibbles, key
     DUP1
     // stack: first_nibble, first_nibble, num_nibbles, key
@@ -141,9 +142,9 @@
     DUP3 DUP6 MUL ISZERO %jumpi(%%return)
 
     // first_nib_2 = (key_2 >> (bits_2 - 4)) & 0xF
-    DUP6 PUSH 4 DUP7 SUB SHR %and_const(0xF)
+    PUSH 0x10 DUP7 PUSH 4 DUP8 SUB SHR MOD
     // first_nib_1 = (key_1 >> (bits_1 - 4)) & 0xF
-    DUP5 PUSH 4 DUP6 SUB SHR %and_const(0xF)
+    PUSH 0x10 DUP6 PUSH 4 DUP7 SUB SHR MOD
     // stack: first_nib_1, first_nib_2, len_common, key_common, bits_1, key_1, bits_2, key_2
 
     // if first_nib_1 != first_nib_2: break

--- a/evm_arithmetization/src/cpu/kernel/asm/util/basic_macros.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/util/basic_macros.asm
@@ -303,6 +303,16 @@
     // stack: ceil(x / c), ...
 %endmacro
 
+/// Same as `%as_u32`, but does not rely on
+/// the AND operation.
+/// *Note*: This is heavier, `%as_u32` should be preferred.
+%macro as_u32_no_and
+    // stack: word
+    PUSH 0x100000000
+    SWAP1
+    MOD
+%endmacro
+
 %macro as_u32
     %and_const(0xffffffff)
 %endmacro

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -45,7 +45,7 @@ use crate::witness::util::mem_write_log;
 
 /// Number of cycles to go after having reached the halting state. It is
 /// equal to the number of cycles in `exc_stop` + 1.
-pub const NUM_EXTRA_CYCLES_AFTER: usize = 81;
+pub const NUM_EXTRA_CYCLES_AFTER: usize = 84;
 /// Number of cycles to go before starting the execution: it is the number of
 /// cycles in `init`.
 pub const NUM_EXTRA_CYCLES_BEFORE: usize = 64;

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -45,7 +45,7 @@ use crate::witness::util::mem_write_log;
 
 /// Number of cycles to go after having reached the halting state. It is
 /// equal to the number of cycles in `exc_stop` + 1.
-pub const NUM_EXTRA_CYCLES_AFTER: usize = 84;
+pub const NUM_EXTRA_CYCLES_AFTER: usize = 82;
 /// Number of cycles to go before starting the execution: it is the number of
 /// cycles in `init`.
 pub const NUM_EXTRA_CYCLES_BEFORE: usize = 64;

--- a/evm_arithmetization/tests/two_to_one_block.rs
+++ b/evm_arithmetization/tests/two_to_one_block.rs
@@ -174,17 +174,7 @@ fn test_two_to_one_block_aggregation() -> anyhow::Result<()> {
 
     let all_circuits = AllRecursiveCircuits::new(
         &all_stark,
-        &[
-            16..17,
-            8..9,
-            12..13,
-            9..10,
-            8..9,
-            6..7,
-            17..18,
-            17..18,
-            7..8,
-        ],
+        &[16..17, 8..9, 12..13, 8..9, 8..9, 6..7, 17..18, 17..18, 7..8],
         &config,
     );
 


### PR DESCRIPTION
Removes the 3 logic operations initially required by the segmentation mechanism (at the cost of ~3 extra~ 1 extra CPU cycle per segment), to allow for full removal of `LogicStark` table when possible, following @sai-deng's approach on the Keccak table.

Also did a pass on binary ops in the Kernel, as most of them could be expressed differently at no extra cost, to try make it even more likely to happen (`simple_transfer` goes from 1112 to 173 binary ops).