### PR TITLE
Fix misplaced overflow check in `wcopy`

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/memory/metadata.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/metadata.asm
@@ -457,17 +457,16 @@ zero_hash:
     // stack: sum
 %endmacro
 
-// Adds the two top elements of the stack, and faults in case of overflow modulo 2^32.
-%macro add_u32_or_fault
+// Checks that the addition of the two top elements of the stack does not overflow modulo 2^32.
+%macro check_u32_add
     // stack: x, y
     %add_or_fault
-    DUP1
-    // stack: sum, sum
+    // stack: sum
     PUSH 0xffffffff // 2^32 - 1
     LT
-    // stack: is_overflow, sum
+    // stack: is_overflow
     %jumpi(fault_exception)
-    // stack: sum
+    // stack: (empty)
 %endmacro
 
 %macro call_depth

--- a/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
@@ -79,13 +79,7 @@ calldataload_large_offset:
     // stack: kexit_info, dest_offset, offset, size
     %wcopy_charge_gas
 
-    // Ensure that `offset + size` won't overflow the reserved 32-bit limb
-    // of the `virtual` component of the source memory address.
-    DUP4 DUP4
-    // stack: offset, size, kexit_info, dest_offset, offset, size
-    %add_u32_or_fault
-
-    %stack (offset_plus_size, kexit_info, dest_offset, offset, size) ->
+    %stack (kexit_info, dest_offset, offset, size) ->
         (dest_offset, size, kexit_info, dest_offset, offset, size)
     %add_or_fault
     // stack: expanded_num_bytes, kexit_info, dest_offset, offset, size, kexit_info
@@ -97,6 +91,13 @@ calldataload_large_offset:
     DUP4
     // stack: offset, total_size, kexit_info, dest_offset, offset, size
     GT %jumpi(wcopy_large_offset)
+
+    // stack: kexit_info, dest_offset, offset, size
+    // Ensure that `offset + size` won't overflow the reserved 32-bit limb
+    // of the `virtual` component of the source memory address.
+    DUP4 DUP4
+    // stack: offset, size, kexit_info, dest_offset, offset, size
+    %check_u32_add
 
     // stack: kexit_info, dest_offset, offset, size
     GET_CONTEXT


### PR DESCRIPTION
The `u32` overflow check should be happening _after_ we check for too large offsets, as these are valid cases that would otherwise trigger a `fault_exception`.

Caught by some regression on the Ethereum test suite (`calldatacopy_d7g0v0_Cancun` notably).