### PR TITLE
fix(ci): use install-action instead of cargo-binstall

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -7,7 +7,6 @@ runs:
   using: composite  
   steps:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - uses: cargo-bins/cargo-binstall@v1.10.6
     - uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/rust
       - run: cargo binstall cargo-udeps
+      - run: echo $CARGO_HOME
+      - run: which -a cargo-udeps || true
+      - run: PATH=$PATH:$HOME/.cargo/bin which -a cargo-udeps || true
       - run: cargo udeps --quiet
       - run: cargo udeps --quiet --tests --benches --examples
   rustdoc:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,10 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/rust
-      - run: cargo binstall cargo-udeps
-      - run: echo $CARGO_HOME
-      - run: which -a cargo-udeps || true
-      - run: PATH=$PATH:$HOME/.cargo/bin which -a cargo-udeps || true
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-udeps
       - run: cargo udeps --quiet
       - run: cargo udeps --quiet --tests --benches --examples
   rustdoc:
@@ -51,5 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/rust
-      - run: cargo binstall taplo-cli
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli
       - run: taplo fmt --check


### PR DESCRIPTION
I was seeing this weird behaviour:
```
Run cargo binstall taplo-cli
 INFO resolve: Resolving package: 'taplo-cli'
 INFO resolve: taplo-cli v0.9.3 is already installed, use --force to override
 INFO Done in [15]
Run taplo fmt --check
/home/runner/work/_temp/54a69868-69ab-442e-9fca-6020599020c1.sh: line 1: taplo: command not found
```
In https://github.com/0xPolygonZero/zk_evm/actions/runs/11123847101/job/30908151308#step:4:16 (an empty commit)

Not sure what's going on, but let's use someone else's github action instead