### PR TITLE
Start implementing typed states and typed accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c37d89f69cb43901949ba29307ada8b9e3b170f94057ad4c04d6fd169d24d65f"
+checksum = "8367891bf380210abb0d6aa30c5f85a9080cb4a066c4d5c5acadad630823751b"
 dependencies = [
  "alloy-consensus",
  "alloy-core",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.30"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4f201b0ac8f81315fbdc55269965a8ddadbc04ab47fa65a1a468f9a40f7a5f"
+checksum = "8158b4878c67837e5413721cc44298e6a2d88d39203175ea025e51892a16ba4c"
 dependencies = [
  "num_enum",
  "strum",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1468e3128e07c7afe4ff13c17e8170c330d12c322f8924b8bf6986a27e0aad3d"
+checksum = "629b62e38d471cc15fea534eb7283d2f8a4e8bdb1811bcc5d66dda6cfce6fae1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b095eb0533144b4497e84a9cc3e44a5c2e3754a3983c0376a55a2f9183a53e"
+checksum = "5ce854562e7cafd5049189d0268d6e5cba05fe6c9cb7c6f8126a79b94800629c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c35df7b972b06f1b2f4e8b7a53328522fa788054a9d3e556faf2411c5a51d5a"
+checksum = "f923dd5fca5f67a43d81ed3ebad0880bd41f6dd0ada930030353ac356c54cd0f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8866562186d237f1dfeaf989ef941a24764f764bf5c33311e37ead3519c6a429"
+checksum = "d3c717b5298fad078cd3a418335b266eba91b511383ca9bd497f742d5975d5ab"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe714e233f9eaf410de95a9af6bcd05d3a7f8c8de7a0817221e95a6b642a080"
+checksum = "fb3705ce7d8602132bcf5ac7a1dd293a42adc2f183abf5907c30ac535ceca049"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5a38117974c5776a45e140226745a0b664f79736aa900995d8e4121558e064"
+checksum = "94ad40869867ed2d9cd3842b1e800889e5b49e6b92da346e93862b4a741bedf3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -207,31 +207,36 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411aff151f2a73124ee473708e82ed51b2535f68928b6a1caa8bc1246ae6f7cd"
+checksum = "260d3ff3bff0bb84599f032a2f2c6828180b0ea0cd41fdaf44f39cef3ba41861"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more",
+ "hashbrown",
  "hex-literal",
+ "indexmap",
  "itoa",
  "k256",
  "keccak-asm",
+ "paste",
  "proptest",
  "rand",
  "ruint",
+ "rustc-hash",
  "serde",
+ "sha3",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-provider"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65633d6ef83c3626913c004eaf166a6dd50406f724772ea8567135efd6dc5d3"
+checksum = "927f708dd457ed63420400ee5f06945df9632d5d101851952056840426a10dc5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -281,14 +286,14 @@ checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fc328bb5d440599ba1b5aa44c0b9ab0625fbc3a403bb5ee94ed4a01ba23e07"
+checksum = "7d82952dca71173813d4e5733e2c986d8b04aea9e0f3b0a576664c232ad050a5"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -307,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f8ff679f94c497a8383f2cd09e2a099266e5f3d5e574bc82b4b379865707dbb"
+checksum = "64333d639f2a0cf73491813c629a405744e16343a4bc5640931be707c345ecc5"
 dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
@@ -319,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a59b1d7c86e0a653e7f3d29954f6de5a2878d8cfd1f010ff93be5c2c48cd3b1"
+checksum = "83aa984386deda02482660aa31cb8ca1e63d533f1c31a52d7d181ac5ec68e9b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -330,17 +335,19 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
+ "cfg-if",
+ "derive_more",
+ "hashbrown",
  "itertools 0.13.0",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54375e5a34ec5a2cf607f9ce98c0ece30dc76ad623afeb25d3953a8d7d30f20"
+checksum = "98db35cd42c90b484377e6bc44d95377a7a38a5ebee996e67754ac0446d542ab"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -352,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51db8a6428a2159e01b7a43ec7aac801edd0c4db1d4de06f310c288940f16fd3"
+checksum = "731f75ec5d383107fd745d781619bd9cedf145836c51ecb991623d41278e71fa"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -363,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebc1760c13592b7ba3fcd964abba546b8d6a9f10d15e8d92a8263731be33f36"
+checksum = "307324cca94354cd654d6713629f0383ec037e1ff9e3e3d547212471209860c0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -377,23 +384,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0458ccb02a564228fcd76efb8eb5a520521a8347becde37b402afec9a1b83859"
+checksum = "68e7f6e8fe5b443f82b3f1e15abfa191128f71569148428e49449d01f6f49e8b"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc65475025fc1e84bf86fc840f04f63fcccdcf3cf12053c99918e4054dfbc69"
+checksum = "6b96ce28d2fde09abb6135f410c41fad670a3a770b6776869bd852f1df102e6f"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -402,31 +409,31 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed10f0715a0b69fde3236ff3b9ae5f6f7c97db5a387747100070d3016b9266b"
+checksum = "906746396a8296537745711630d9185746c0b50c033d5e9d18b0a6eba3d53f90"
 dependencies = [
  "const-hex",
  "dunce",
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb88e4da0a1b697ed6a9f811fdba223cf4d5c21410804fd1707836af73a462b"
+checksum = "d86a533ce22525969661b25dfe296c112d35eb6861f188fd284f8bd4bb3842ae"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -435,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5dc4e902f1860d54952446d246ac05386311ad61030a2b906ae865416d36e0"
+checksum = "33616b2edf7454302a1d48084db185e52c309f73f6c10be99b0fe39354b3f1e9"
 dependencies = [
  "alloy-json-rpc",
  "base64",
@@ -454,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1742b94bb814f1ca6b322a6f9dd38a0252ff45a3119e40e888fb7029afa500ce"
+checksum = "a944f5310c690b62bbb3e7e5ce34527cbd36b2d18532a797af123271ce595a49"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -469,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol"
-version = "7.2.1"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0234884b3641db74d22ccc20fc2594db5f23d7d41ade5c93d7ee33d200960c"
+checksum = "e3a41c091e49edfcc098b4f90d4d7706a8cf9158034e84ebfee7ff346092f67c"
 dependencies = [
  "amq-protocol-tcp",
  "amq-protocol-types",
@@ -483,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-tcp"
-version = "7.2.1"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265dca43d9dbb3d5bbb0b3ef1b0cd9044ce3aa5d697d5b66cde974d1f6063f09"
+checksum = "3ed7a4a662472f88823ed2fc81babb0b00562f2c54284e3e7bffc02b6df649bf"
 dependencies = [
  "amq-protocol-uri",
  "tcp-stream",
@@ -494,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-types"
-version = "7.2.1"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7412353b58923fa012feb9a64ccc0c811747babee2e5a2fd63eb102dc8054c3"
+checksum = "bd6484fdc918c1b6e2ae8eda2914d19a5873e1975f93ad8d33d6a24d1d98df05"
 dependencies = [
  "cookie-factory",
  "nom",
@@ -506,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-uri"
-version = "7.2.1"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be91352c805d5704784e079117d5291fd5bf2569add53c914ebce6d1a795d33"
+checksum = "7f7f2da69e0e1182765bf33407cd8a843f20791b5af2b57a2645818c4776c56c"
 dependencies = [
  "amq-protocol-types",
  "percent-encoding",
@@ -572,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 dependencies = [
  "backtrace",
 ]
@@ -733,7 +740,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "synstructure",
 ]
 
@@ -745,7 +752,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -757,7 +764,7 @@ dependencies = [
  "assert2-macros",
  "diff",
  "is-terminal",
- "yansi 1.0.1",
+ "yansi",
 ]
 
 [[package]]
@@ -769,7 +776,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -913,7 +920,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -924,13 +931,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -956,20 +963,20 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -993,7 +1000,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1001,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1014,7 +1021,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1169,9 +1176,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 dependencies = [
  "serde",
 ]
@@ -1240,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "3bbb537bb4a30b90362caddba8f360c0a56bc13d3a5570028e7197204cb54a17"
 dependencies = [
  "jobserver",
  "libc",
@@ -1294,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1304,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1316,14 +1323,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1381,9 +1388,9 @@ checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "const-hex"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8a24a26d37e1ffd45343323dc9fe6654ceea44c12f2fcb3d7ac29e610bc6"
+checksum = "0121754e84117e65f9d90648ee6aa4882a6e63110307ab73967a4c5e7e69e586"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1612,7 +1619,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1623,7 +1630,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1694,7 +1701,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1735,7 +1742,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1745,7 +1752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1765,7 +1772,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "unicode-xid",
 ]
 
@@ -1834,7 +1841,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1915,7 +1922,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2289,7 +2296,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2350,18 +2357,6 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getset"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f636605b743120a8d32ed92fc27b6cde1a769f8f936c065151eb66f88ded513c"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.77",
 ]
 
 [[package]]
@@ -2577,9 +2572,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2590,7 +2585,6 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
- "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -2668,6 +2662,7 @@ checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -2805,15 +2800,24 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
  "sha2",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -2876,9 +2880,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libgit2-sys"
@@ -2949,7 +2953,7 @@ checksum = "cb26336e6dc7cc76e7927d2c9e7e3bb376d7af65a6f56a0b16c47d18a9b1abc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3218,7 +3222,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3259,9 +3263,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -3292,7 +3299,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3387,7 +3394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af25dcb10b7c0ce99abee8694e2e79e4787d7f778b9339dc5a50ba6fc45e5cc9"
 dependencies = [
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3478,9 +3485,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
 dependencies = [
  "memchr",
  "thiserror",
@@ -3489,9 +3496,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
+checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3499,22 +3506,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
+checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
+checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
 dependencies = [
  "once_cell",
  "pest",
@@ -3538,7 +3545,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3618,9 +3625,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plonky2"
@@ -3743,6 +3750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
 name = "postcard"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3772,12 +3785,12 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
- "yansi 0.5.1",
+ "yansi",
 ]
 
 [[package]]
@@ -3841,7 +3854,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3867,7 +3880,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -3903,6 +3916,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -3975,9 +3989,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -3995,14 +4009,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4016,13 +4030,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4033,9 +4047,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -4168,6 +4182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4279,9 +4299,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -4391,9 +4411,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4452,7 +4472,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4479,9 +4499,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -4518,6 +4538,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
@@ -4688,7 +4718,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4710,9 +4740,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4721,14 +4751,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b95156f8b577cb59dc0b1df15c6f29a10afc5f8a7ac9786b0b5c68c19149278"
+checksum = "0ab661c8148c2261222a4d641ad5477fd4bea79406a99056096a0b41b35617a5"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4754,7 +4784,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4777,9 +4807,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand 2.1.1",
@@ -4799,22 +4829,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4940,7 +4970,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5015,9 +5045,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "serde",
@@ -5033,8 +5063,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
- "futures-util",
- "pin-project",
  "pin-project-lite",
  "tokio",
  "tower-layer",
@@ -5052,8 +5080,10 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 0.1.2",
+ "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5136,7 +5166,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5216,9 +5246,9 @@ dependencies = [
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"
@@ -5252,18 +5282,18 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unroll"
@@ -5323,9 +5353,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.0.0"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32e7318e93a9ac53693b6caccfb05ff22e04a44c7cf8a279051f24c09da286f"
+checksum = "349ed9e45296a581f455bc18039878f409992999bc1d5da12a6800eb18c8752f"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -5336,9 +5366,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-git2"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62c52cd2b2b8b7ec75fc20111b3022ac3ff83e4fc14b9497cfcfd39c54f9c67"
+checksum = "e771aff771c0d7c2f42e434e2766d304d917e29b40f0424e8faaaa936bbc3f29"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -5351,13 +5381,12 @@ dependencies = [
 
 [[package]]
 name = "vergen-lib"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06bee42361e43b60f363bad49d63798d0f42fb1768091812270eca00c784720"
+checksum = "229eaddb0050920816cf051e619affaf18caa3dd512de8de5839ccbc8e53abb0"
 dependencies = [
  "anyhow",
  "derive_builder",
- "getset",
  "rustversion",
 ]
 
@@ -5429,7 +5458,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -5463,7 +5492,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5705,9 +5734,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -5748,12 +5777,6 @@ dependencies = [
  "thiserror",
  "time",
 ]
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yansi"
@@ -5826,7 +5849,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5846,7 +5869,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5865,6 +5888,6 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "trybuild",
 ]

--- a/evm_arithmetization/Cargo.toml
+++ b/evm_arithmetization/Cargo.toml
@@ -58,7 +58,7 @@ hex = { workspace = true }
 ripemd = { workspace = true }
 
 [features]
-default = ["eth_mainnet"]
+default = ["cdk_erigon"]
 asmtools = ["hex"]
 polygon_pos = []
 cdk_erigon = ["smt_trie"]

--- a/evm_arithmetization/benches/fibonacci_25m_gas.rs
+++ b/evm_arithmetization/benches/fibonacci_25m_gas.rs
@@ -12,13 +12,13 @@ use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
 use ethereum_types::{Address, H256, U256};
 use evm_arithmetization::cpu::kernel::aggregator::KERNEL;
 use evm_arithmetization::cpu::kernel::opcodes::{get_opcode, get_push_opcode};
-use evm_arithmetization::generation::mpt::{AccountRlp, LegacyReceiptRlp};
-use evm_arithmetization::generation::{GenerationInputs, TrieInputs};
+use evm_arithmetization::generation::mpt::{AccountRlp, LegacyReceiptRlp, Type1AccountRlp};
+use evm_arithmetization::generation::{GenerationInputs, InputStateTrie, TrieInputs};
 use evm_arithmetization::proof::{BlockHashes, BlockMetadata, TrieRoots};
 use evm_arithmetization::prover::testing::simulate_execution;
 use evm_arithmetization::testing_utils::{
     beacon_roots_account_nibbles, beacon_roots_contract_from_storage,
-    preinitialized_state_and_storage_tries, update_beacon_roots_account_storage,
+    preinitialized_state_mpt_and_beacon_roots, update_beacon_roots_account_storage,
 };
 use evm_arithmetization::{Node, EMPTY_CONSOLIDATED_BLOCKHASH};
 use hex_literal::hex;
@@ -75,20 +75,20 @@ fn prepare_setup() -> anyhow::Result<GenerationInputs<F>> {
 
     let empty_trie_root = HashedPartialTrie::from(Node::Empty).hash();
 
-    let sender_account_before = AccountRlp {
+    let sender_account_before = Type1AccountRlp {
         nonce: 169.into(),
         balance: U256::from_dec_str("999999999998417410153631615")?,
         storage_root: empty_trie_root,
         code_hash: keccak(vec![]),
     };
-    let to_account_before = AccountRlp {
+    let to_account_before = Type1AccountRlp {
         nonce: 1.into(),
         balance: 0.into(),
         storage_root: empty_trie_root,
         code_hash,
     };
 
-    let (mut state_trie_before, mut storage_tries) = preinitialized_state_and_storage_tries()?;
+    let (mut state_trie_before, mut storage_tries) = preinitialized_state_mpt_and_beacon_roots()?;
     let mut beacon_roots_account_storage = storage_tries[0].1.clone();
     state_trie_before.insert(sender_nibbles, rlp::encode(&sender_account_before).to_vec())?;
     state_trie_before.insert(to_nibbles, rlp::encode(&to_account_before).to_vec())?;
@@ -97,10 +97,10 @@ fn prepare_setup() -> anyhow::Result<GenerationInputs<F>> {
     storage_tries.push((to_state_key, Node::Empty.into()));
 
     let tries_before = TrieInputs {
-        state_trie: state_trie_before,
+        state_trie: InputStateTrie::Type1(state_trie_before),
         transactions_trie: Node::Empty.into(),
         receipts_trie: Node::Empty.into(),
-        storage_tries,
+        storage_tries: Some(storage_tries),
     };
 
     let gas_used = U256::from(0x17d7840_u32);
@@ -126,7 +126,7 @@ fn prepare_setup() -> anyhow::Result<GenerationInputs<F>> {
     contract_code.insert(keccak(vec![]), vec![]);
     contract_code.insert(code_hash, code.to_vec());
 
-    let sender_account_after = AccountRlp {
+    let sender_account_after = Type1AccountRlp {
         balance: sender_account_before.balance - value - gas_used * block_metadata.block_base_fee,
         nonce: sender_account_before.nonce + 1,
         ..sender_account_before

--- a/evm_arithmetization/src/cpu/kernel/aggregator.rs
+++ b/evm_arithmetization/src/cpu/kernel/aggregator.rs
@@ -10,9 +10,11 @@ use crate::cpu::kernel::constants::evm_constants;
 use crate::cpu::kernel::parser::parse;
 
 pub const NUMBER_KERNEL_FILES: usize = if cfg!(feature = "eth_mainnet") {
+    158
+} else if cfg!(feature = "cdk_erigon") {
+    161
+} else if cfg!(feature = "polygon_pos") {
     157
-} else if cfg!(feature = "cdk_erigon") || cfg!(feature = "polygon_pos") {
-    154
 } else {
     // unreachable
     0
@@ -146,6 +148,19 @@ pub static KERNEL_FILES: [&str; NUMBER_KERNEL_FILES] = [
     include_str!("asm/mpt/storage/storage_read.asm"),
     include_str!("asm/mpt/storage/storage_write.asm"),
     include_str!("asm/mpt/util.asm"),
+    #[cfg(feature = "cdk_erigon")]
+    include_str!("asm/smt/delete.asm"),
+    #[cfg(feature = "cdk_erigon")]
+    include_str!("asm/smt/hash.asm"),
+    #[cfg(feature = "cdk_erigon")]
+    include_str!("asm/smt/insert.asm"),
+    #[cfg(feature = "cdk_erigon")]
+    include_str!("asm/smt/keys.asm"),
+    #[cfg(feature = "cdk_erigon")]
+    include_str!("asm/smt/read.asm"),
+    #[cfg(feature = "cdk_erigon")]
+    include_str!("asm/smt/utils.asm"),
+    include_str!("asm/trie_common.asm"),
     include_str!("asm/rlp/decode.asm"),
     include_str!("asm/rlp/encode.asm"),
     include_str!("asm/rlp/encode_rlp_scalar.asm"),

--- a/evm_arithmetization/src/cpu/kernel/asm/account_code.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/account_code.asm
@@ -24,7 +24,7 @@ extcodehash_dead:
 
 global extcodehash:
     // stack: address, retdest
-    %mpt_read_state_trie
+    %read_state_trie
     // stack: account_ptr, retdest
     DUP1 ISZERO %jumpi(retzero)
     %add_const(3)

--- a/evm_arithmetization/src/cpu/kernel/asm/balance.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/balance.asm
@@ -27,7 +27,7 @@ global sys_balance:
 
 global balance:
     // stack: address, retdest
-    %mpt_read_state_trie
+    %read_state_trie
     // stack: account_ptr, retdest
     DUP1 ISZERO %jumpi(retzero) // If the account pointer is null, return 0.
     %add_const(1)

--- a/evm_arithmetization/src/cpu/kernel/asm/cdk_pre_execution.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/cdk_pre_execution.asm
@@ -108,7 +108,7 @@ global create_scalable_l2_account:
     // stack: new_account_ptr, retdest
     PUSH @ADDRESS_SCALABLE_L2_STATE_KEY
     // stack: key, new_account_ptr, retdest
-    %jump(mpt_insert_state_trie)
+    %jump(insert_state_trie)
 
 %macro write_scalable_storage
     // stack: slot, value

--- a/evm_arithmetization/src/cpu/kernel/asm/core/create.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/create.asm
@@ -251,7 +251,7 @@ create_too_deep:
 global set_codehash:
     // stack: addr, codehash, retdest
     DUP1 %insert_touched_addresses
-    DUP1 %mpt_read_state_trie
+    DUP1 %read_state_trie
     // stack: account_ptr, addr, codehash, retdest
     %add_const(3)
     // stack: codehash_ptr, addr, codehash, retdest

--- a/evm_arithmetization/src/cpu/kernel/asm/core/create_contract_account.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/create_contract_account.asm
@@ -5,7 +5,7 @@
     // stack: address
     DUP1 %insert_touched_addresses
     DUP1 %append_created_contracts
-    DUP1 %mpt_read_state_trie
+    DUP1 %read_state_trie
     // stack: existing_account_ptr, address
     // If the account doesn't exist, there's no need to check its balance or nonce,
     // so we can skip ahead, setting existing_balance = existing_account_ptr = 0.
@@ -49,7 +49,7 @@
     // stack: address, account_ptr
     %addr_to_state_key
     // stack: state_key, account_ptr
-    %mpt_insert_state_trie
+    %insert_state_trie
     // stack: (empty)
     PUSH 0 // success
     %jump(%%end)

--- a/evm_arithmetization/src/cpu/kernel/asm/core/nonce.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/nonce.asm
@@ -3,7 +3,7 @@
 // Post stack: (empty)
 global nonce:
     // stack: address, retdest
-    %mpt_read_state_trie
+    %read_state_trie
     // stack: account_ptr, retdest
     // The nonce is the first account field, so we deref the account pointer itself.
     // Note: We don't need to handle account_ptr=0, as trie_data[0] = 0,
@@ -23,7 +23,7 @@ global nonce:
 global increment_nonce:
     // stack: address, retdest
     DUP1
-    %mpt_read_state_trie
+    %read_state_trie
     // stack: account_ptr, address, retdest
     DUP1 ISZERO %jumpi(increment_nonce_no_such_account)
     // stack: nonce_ptr, address, retdest

--- a/evm_arithmetization/src/cpu/kernel/asm/core/terminate.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/terminate.asm
@@ -89,7 +89,7 @@ global sys_selfdestruct:
     // stack: balance, address, recipient, kexit_info
     PUSH 0
     // stack: 0, balance, address, recipient, kexit_info
-    DUP3 %mpt_read_state_trie
+    DUP3 %read_state_trie
     // stack: account_ptr, 0, balance, address, recipient, kexit_info
     %add_const(1)
     // stack: balance_ptr, 0, balance, address, recipient, kexit_info

--- a/evm_arithmetization/src/cpu/kernel/asm/core/transfer.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/transfer.asm
@@ -29,7 +29,7 @@ global transfer_eth_failure:
 global deduct_eth:
     // stack: addr, amount, retdest
     DUP1 %insert_touched_addresses
-    %mpt_read_state_trie
+    %read_state_trie
     // stack: account_ptr, amount, retdest
     DUP1 ISZERO %jumpi(deduct_eth_no_such_account) // If the account pointer is null, return 1.
     %add_const(1)
@@ -68,7 +68,7 @@ global add_eth:
     // stack: addr, amount, retdest
     DUP2 ISZERO %jumpi(add_eth_zero_amount)
     // stack: addr, amount, retdest
-    DUP1 %mpt_read_state_trie
+    DUP1 %read_state_trie
     // stack: account_ptr, addr, amount, retdest
     DUP1 ISZERO %jumpi(add_eth_new_account) // If the account pointer is null, we need to create the account.
     %add_const(1)
@@ -102,7 +102,7 @@ global add_eth_new_account:
     // stack: addr, new_account_ptr, retdest
     %addr_to_state_key
     // stack: key, new_account_ptr, retdest
-    %jump(mpt_insert_state_trie)
+    %jump(insert_state_trie)
 
 add_eth_zero_amount:
     // stack: addr, amount, retdest

--- a/evm_arithmetization/src/cpu/kernel/asm/core/util.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/util.asm
@@ -57,13 +57,13 @@
 // Returns 1 if the account is non-existent, 0 otherwise.
 %macro is_non_existent
     // stack: addr
-    %mpt_read_state_trie ISZERO
+    %read_state_trie ISZERO
 %endmacro
 
 // Returns 1 if the account is empty, 0 otherwise.
 %macro is_empty
     // stack: addr
-    %mpt_read_state_trie
+    %read_state_trie
     // stack: account_ptr
     DUP1 ISZERO %jumpi(%%false)
     // stack: account_ptr

--- a/evm_arithmetization/src/cpu/kernel/asm/main.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/main.asm
@@ -226,9 +226,8 @@ global check_state_trie:
     %set_initial_state_trie
     // stack: trie_data_len
 
-    PUSH @INITIAL_RLP_ADDR
-    // stack: rlp_start, trie_data_len
-    %mpt_hash_state_trie
+    // stack: trie_data_len
+    %hash_state_trie
 
     // stack: init_state_hash, trie_data_len
     // Check that the initial trie is correct.
@@ -243,9 +242,8 @@ global check_state_trie:
     PUSH 1
 global check_final_state_trie:
     %set_final_tries
-    PUSH @INITIAL_RLP_ADDR
-    // stack: rlp_start, dummy_trie_len
-    %mpt_hash_state_trie   %mload_global_metadata(@GLOBAL_METADATA_STATE_TRIE_DIGEST_AFTER)     %assert_eq
+    // stack: dummy_trie_len
+    %hash_state_trie   %mload_global_metadata(@GLOBAL_METADATA_STATE_TRIE_DIGEST_AFTER)     %assert_eq
     // We don't need the trie data length here.
     POP
 
@@ -281,4 +279,18 @@ global check_final_state_trie:
     {
         %reset_blob_versioned_hashes
     }
+%endmacro
+
+%macro hash_state_trie
+    // stack: rlp_start, trie_data_len
+    #[cfg(not(feature = cdk_erigon))]
+    {
+        PUSH @INITIAL_RLP_ADDR
+        %mpt_hash_state_trie
+    }
+    #[cfg(feature = cdk_erigon)]
+    {
+        %smt_hash_state
+    }
+    // stack: new_trie_data_len
 %endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/insert/insert_trie_specific.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/insert/insert_trie_specific.asm
@@ -1,20 +1,5 @@
 // Insertion logic specific to a particular trie.
 
-// Mutate the state trie, inserting the given key-value pair.
-// Pre stack: key, value_ptr, retdest
-// Post stack: (empty)
-// TODO: Have this take an address and do %mpt_insert_state_trie? To match mpt_read_state_trie.
-global mpt_insert_state_trie:
-    // stack: key, value_ptr, retdest
-    %insert_account_with_overwrite
-    JUMP
-
-%macro mpt_insert_state_trie
-    %stack (key, value_ptr) -> (key, value_ptr, %%after)
-    %jump(mpt_insert_state_trie)
-%%after:
-%endmacro
-
 // Insert a node in the transaction trie. The payload
 // must be pointing to the rlp encoded txn
 // Pre stack: key, txn_rlp_ptr, redest
@@ -24,7 +9,7 @@ global mpt_insert_txn_trie:
     %stack (key, num_nibbles, txn_rlp_ptr)
         -> (num_nibbles, key, txn_rlp_ptr, mpt_insert_txn_trie_save)
     %mload_global_metadata(@GLOBAL_METADATA_TXN_TRIE_ROOT)
-    // stack: txn_trie_root_ptr, num_nibbles, key, txn_rlp_ptr, mpt_insert_state_trie_save, retdest
+    // stack: txn_trie_root_ptr, num_nibbles, key, txn_rlp_ptr, mpt_insert_txn_trie_save, retdest
     %jump(mpt_insert)
 
 mpt_insert_txn_trie_save:

--- a/evm_arithmetization/src/cpu/kernel/asm/mpt/read.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/mpt/read.asm
@@ -1,21 +1,3 @@
-// Given an address, return a pointer to the associated account data, which
-// consists of four words (nonce, balance, storage_root, code_hash), in the
-// trie_data segment. Return null if the address is not found.
-global mpt_read_state_trie:
-    // stack: addr, retdest
-    %read_accounts_linked_list
-    // stack: account_ptr, retdest
-    SWAP1
-    // stack: retdest, account_ptr
-    JUMP
-
-// Convenience macro to call mpt_read_state_trie and return where we left off.
-%macro mpt_read_state_trie
-    %stack (addr) -> (addr, %%after)
-    %jump(mpt_read_state_trie)
-%%after:
-%endmacro
-
 // Read a value from a MPT.
 //
 // Arguments:

--- a/evm_arithmetization/src/cpu/kernel/asm/smt/delete.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/smt/delete.asm
@@ -1,0 +1,293 @@
+%macro smt_delete_state
+    %stack (key) -> (key, %%after)
+    %mload_global_metadata(@GLOBAL_METADATA_STATE_TRIE_ROOT) // node_ptr
+    // stack: node_ptr, key, retdest
+    %jump(smt_delete)
+%%after:
+    // stack: new_node_ptr
+    %mstore_global_metadata(@GLOBAL_METADATA_STATE_TRIE_ROOT)
+    // stack: (emtpy)
+%endmacro
+
+// Return a copy of the given node with the given key deleted.
+// Assumes that the key is in the SMT.
+//
+// Pre stack: node_ptr, key, retdest
+// Post stack: updated_node_ptr
+global smt_delete:
+    // stack: node_ptr, key, retdest
+    SWAP1 %split_key
+    %stack (k0, k1, k2, k3, node_ptr) -> (node_ptr, 0, k0, k1, k2, k3)
+smt_delete_with_keys:
+    // stack: node_ptr, level, ks, retdest
+    DUP1 %mload_trie_data
+    // stack: node_type, node_ptr, level, ks, retdest
+    // Increment node_ptr, so it points to the node payload instead of its type.
+    SWAP1 %increment SWAP1
+    // stack: node_type, node_payload_ptr, level, ks, retdest
+
+    DUP1 %eq_const(@SMT_NODE_INTERNAL)  %jumpi(smt_delete_internal)
+         %eq_const(@SMT_NODE_LEAF)      %jumpi(smt_delete_leaf)
+    PANIC // Should never happen.
+
+smt_delete_leaf:
+    // stack: node_payload_ptr, level, ks, retdest
+    %pop6
+    PUSH 0 // empty node ptr
+    SWAP1 JUMP
+
+smt_delete_internal:
+    // stack: node_type, node_payload_ptr, level, ks, retdest
+    POP
+    // stack: node_payload_ptr, level, ks, retdest
+    DUP2 %and_const(3) // level mod 4
+    // stack: level%4, node_payload_ptr, level, ks, retdest
+    DUP1 %eq_const(0) %jumpi(smt_delete_internal_0)
+    DUP1 %eq_const(1) %jumpi(smt_delete_internal_1)
+    DUP1 %eq_const(2) %jumpi(smt_delete_internal_2)
+         %eq_const(3) %jumpi(smt_delete_internal_3)
+    PANIC
+smt_delete_internal_0:
+    // stack: level%4, node_payload_ptr, level, ks, retdest
+    %stack (level_mod_4, node_payload_ptr, level, k0, k1, k2, k3 ) -> (k0, node_payload_ptr, level, k0, k1, k2, k3 )
+    %pop_bit
+    %stack (bit, newk0, node_payload_ptr, level, k0, k1, k2, k3 ) -> (bit, node_payload_ptr, level, newk0, k1, k2, k3 )
+    %jump(smt_delete_internal_contd)
+smt_delete_internal_1:
+    %stack (level_mod_4, node_payload_ptr, level, k0, k1, k2, k3 ) -> (k1, node_payload_ptr, level, k0, k1, k2, k3 )
+    %pop_bit
+    %stack (bit, newk1, node_payload_ptr, level, k0, k1, k2, k3 ) -> (bit, node_payload_ptr, level, k0, newk1, k2, k3 )
+    %jump(smt_delete_internal_contd)
+smt_delete_internal_2:
+    %stack (level_mod_4, node_payload_ptr, level, k0, k1, k2, k3 ) -> (k2, node_payload_ptr, level, k0, k1, k2, k3 )
+    %pop_bit
+    %stack (bit, newk2, node_payload_ptr, level, k0, k1, k2, k3 ) -> (bit, node_payload_ptr, level, k0, k1, newk2, k3 )
+    %jump(smt_delete_internal_contd)
+smt_delete_internal_3:
+    %stack (node_payload_ptr, level, k0, k1, k2, k3 ) -> (k3, node_payload_ptr, level, k0, k1, k2, k3 )
+    %pop_bit
+    %stack (bit, newk3, node_payload_ptr, level, k0, k1, k2, k3 ) -> (bit, node_payload_ptr, level, k0, k1, k2, newk3 )
+smt_delete_internal_contd:
+    //stack: bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    PUSH internal_update
+    //stack: internal_update, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    %rep 7
+        DUP8
+    %endrep
+    //stack: bit, node_payload_ptr, level, k0, k1, k2, k3, internal_update, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    ADD
+    //stack: child_ptr_ptr, level, k0, k1, k2, k3, internal_update, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    %mload_trie_data
+    //stack: child_ptr, level, k0, k1, k2, k3, internal_update, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    SWAP1 %increment SWAP1
+    //stack: child_ptr, level+1, k0, k1, k2, k3, internal_update, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    %jump(smt_delete_with_keys)
+
+// Update the internal node, possibly deleting it, or returning a leaf node.
+internal_update:
+    // Update the child first.
+    //stack: deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    DUP2 PUSH 1 SUB
+    //stack: 1-bit, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    DUP4 ADD
+    //stack: sibling_ptr_ptr, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    %mload_trie_data DUP1 %mload_trie_data
+    //stack: sibling_node_type, sibling_ptr, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    DUP1 %eq_const(@SMT_NODE_HASH)     %jumpi(sibling_is_hash)
+    DUP1 %eq_const(@SMT_NODE_LEAF)     %jumpi(sibling_is_leaf)
+         %eq_const(@SMT_NODE_INTERNAL) %jumpi(sibling_is_internal)
+    PANIC // Should never happen.
+sibling_is_internal:
+    //stack: sibling_ptr, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    POP
+insert_child:
+    //stack: deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    %stack (deleted_child_ptr, bit, node_payload_ptr) -> (node_payload_ptr, bit, deleted_child_ptr, node_payload_ptr)
+    ADD %mstore_trie_data
+    // stack: node_payload_ptr, level, ks, retdest
+    %decrement
+    %stack (node_ptr, level, k0, k1, k2, k3, retdest) -> (retdest, node_ptr)
+    JUMP
+
+sibling_is_hash:
+    // stack: sibling_node_type, sibling_ptr, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    POP
+    //stack: sibling_ptr, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    %increment %mload_trie_data
+    // stack: hash, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    %jumpi(insert_child) // Sibling is non-empty hash node.
+sibling_is_empty:
+    // stack: deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    DUP1 %mload_trie_data
+    // stack: deleted_child_node_type, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    DUP1 %eq_const(@SMT_NODE_HASH) %jumpi(sibling_is_empty_child_is_hash)
+    DUP1 %eq_const(@SMT_NODE_LEAF) %jumpi(sibling_is_empty_child_is_leaf)
+sibling_is_empty_child_is_internal:
+    // stack: deleted_child_node_type, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    POP
+    // stack: deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    %jump(insert_child)
+
+sibling_is_empty_child_is_hash:
+    // stack: deleted_child_node_type, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    POP
+    // stack: deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    DUP1 %increment %mload_trie_data
+    // stack: hash, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    %jumpi(insert_child)
+sibling_is_empty_child_is_empty:
+    // We can just delete this node.
+    // stack: deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    %pop8
+    SWAP1 PUSH 0
+    // stack: retdest, 0
+    JUMP
+
+sibling_is_empty_child_is_leaf:
+    // stack: deleted_child_node_type, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    POP
+    // stack: deleted_child_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    %increment
+    // stack: deleted_child_key_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    DUP4
+    // stack: level, deleted_child_key_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    DUP3
+    // stack: bit, level, deleted_child_key_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    DUP3 %mload_trie_data
+    // stack: child_key, bit, level, deleted_child_key_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    %recombine_key
+    // stack: new_child_key, deleted_child_key_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    DUP2 %mstore_trie_data
+    // stack: deleted_child_key_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    %decrement
+    // stack: deleted_child_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    SWAP7
+    // stack: k3, bit, node_payload_ptr, level, k0, k1, k2, deleted_child_ptr, retdest
+    %pop7
+    // stack: deleted_child_ptr, retdest
+    SWAP1 JUMP
+
+sibling_is_leaf:
+    // stack: sibling_node_type, sibling_ptr, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    POP
+    // stack: sibling_ptr, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    DUP2 %is_non_empty_node
+    // stack: child_is_non_empty, sibling_ptr, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    %jumpi(sibling_is_leaf_child_is_non_empty)
+sibling_is_leaf_child_is_empty:
+    // stack: sibling_ptr, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    %increment
+    // stack: sibling_key_ptr, deleted_child_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    DUP5
+    // stack: level, sibling_key_ptr, deleted_child_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    DUP4
+    // stack: bit, level, sibling_key_ptr, deleted_child_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    PUSH 1 SUB
+    // stack: obit, level, sibling_key_ptr, deleted_child_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    DUP3 %mload_trie_data
+    // stack: sibling_key, obit, level, sibling_key_ptr, deleted_child_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    %recombine_key
+    // stack: new_key, sibling_key_ptr, deleted_child_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    DUP2 %mstore_trie_data
+    // stack: sibling_key_ptr, deleted_child_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    %decrement
+    // stack: sibling_ptr, deleted_child_ptr, bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    SWAP8
+    // stack: k3, deleted_child_ptr, bit, node_payload_ptr, level, k0, k1, k2, sibling_ptr, retdest
+    %pop8
+    // stack: sibling_ptr, retdest
+    SWAP1 JUMP
+
+sibling_is_leaf_child_is_non_empty:
+    // stack: sibling_ptr, deleted_child_ptr, bit, node_payload_ptr, level, ks, retdest
+    POP
+    // stack: deleted_child_ptr, node_payload_ptr, bit, retdest
+    %jump(insert_child)
+
+
+global smt_delete_account:
+    %stack (address, retdest) -> (address, retdest)
+    DUP1 %key_nonce
+    // stack: key_nonce, address, retdest
+    DUP1 %smt_read_state ISZERO %jumpi(zero_nonce)
+    // stack: key_nonce, address, retdest
+    DUP1 %smt_delete_state
+    // stack: key_nonce, address, retdest
+zero_nonce:
+    // stack: key_nonce, address, retdest
+    POP
+    // stack: address, retdest
+    DUP1 %key_balance
+    // stack: key_balance, address, retdest
+    DUP1 %smt_read_state ISZERO %jumpi(zero_balance)
+    // stack: key_balance, address, retdest
+    DUP1 %smt_delete_state
+    // stack: key_balance, address, retdest
+zero_balance:
+    // stack: key_balance, address, retdest
+    POP
+    // stack: address, retdest
+    DUP1 %key_code
+    // stack: key_code, address, retdest
+    DUP1 %smt_read_state ISZERO %jumpi(zero_code)
+    // stack: key_code, address, retdest
+    DUP1 %smt_delete_state
+    // stack: key_code, address, retdest
+zero_code:
+    // stack: key_code, address, retdest
+    POP
+    // stack: address, retdest
+    DUP1 %key_code_length
+    // stack: key_code_length, address, retdest
+    DUP1 %smt_read_state ISZERO %jumpi(zero_code_length)
+    // stack: key_code_length, address, retdest
+    DUP1 %smt_delete_state
+zero_code_length:
+    // N.B.: We don't delete the storage, since there's no way of knowing keys used.
+    // stack: key_code_length, address, retdest
+    POP
+    // stack: address, retdest
+    %mload_global_metadata(@GLOBAL_METADATA_NEW_STORAGE_SLOTS_LEN)
+    // stack: slots_len, address, retdest
+    PUSH 0
+    // stack: i, slots_len, address, retdest
+delete_storage_slots_loop:
+    // stack: i, slots_len, address, retdest
+    DUP2 DUP2 EQ %jumpi(delete_storage_slots_loop_end)
+    // stack: i, slots_len, address, retdest
+    DUP1 %add_const(@SEGMENT_NEW_STORAGE_SLOTS)
+    // stack: addr_index, i, slots_len, address, retdest
+    MLOAD_GENERAL
+    // stack: slot_addr, i, slots_len, address, retdest
+    DUP4 EQ
+    // stack: address==slot_addr, i, slots_len, address, retdest
+    %jumpi(delete_storage_slot)
+    // stack: i, slots_len, address, retdest
+    %add_const(2) %jump(delete_storage_slots_loop)
+delete_storage_slot:
+    // stack: i, slots_len, address, retdest
+    DUP1 %increment %add_const(@SEGMENT_NEW_STORAGE_SLOTS)
+    // stack: slot_index, i, slots_len, address, retdest
+    MLOAD_GENERAL
+    // stack: slot, i, slots_len, address, retdest
+    DUP4 %key_storage
+    // stack: key_storage, i, slots_len, address, retdest
+    DUP1 %smt_read_state ISZERO %jumpi(zero_slot)
+    // stack: key_storage, i, slots_len, address, retdest
+    DUP1 %smt_delete_state
+zero_slot:
+    // stack: key_storage, i, slots_len, address, retdest
+    POP
+    // stack: i, slots_len, address, retdest
+    %add_const(2) %jump(delete_storage_slots_loop)
+
+delete_storage_slots_loop_end:
+    // stack: i, slots_len, address, retdest
+    %pop3 JUMP
+
+%macro smt_delete_account
+    %stack (address) -> (address, %%after)
+    %jump(smt_delete_account)
+%%after:
+    // stack: (empty)
+%endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/smt/hash.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/smt/hash.asm
@@ -1,0 +1,85 @@
+%macro smt_hash_state
+    %stack (cur_len) -> (cur_len, %%after)
+    %jump(smt_hash_state)
+%%after:
+%endmacro
+
+// Root hash of the state SMT.
+global smt_hash_state:
+    // stack: cur_len, retdest
+    %mload_global_metadata(@GLOBAL_METADATA_STATE_TRIE_ROOT)
+
+// Root hash of SMT stored at `trie_data[ptr]`.
+// Pseudocode:
+// ```
+// hash( HashNode { h } ) = h
+// hash( InternalNode { left, right } ) = Poseidon(hash(left) || hash(right) || [0,0,0,0])
+// hash( Leaf { rem_key, val_hash } ) = Poseidon(rem_key || val_hash || [1,0,0,0])
+// ```
+global smt_hash:
+    // stack: ptr, cur_len, retdest
+    DUP1
+    %mload_trie_data
+    // stack: node, node_ptr, cur_len, retdest
+    DUP1 %eq_const(@SMT_NODE_HASH)     %jumpi(smt_hash_hash)
+    DUP1 %eq_const(@SMT_NODE_INTERNAL) %jumpi(smt_hash_internal)
+         %eq_const(@SMT_NODE_LEAF)     %jumpi(smt_hash_leaf)
+smt_hash_unknown_node_type:
+    PANIC
+
+smt_hash_hash:
+    // stack: node, node_ptr, cur_len, retdest
+    POP
+    // stack: node_ptr, cur_len, retdest
+    SWAP1 %add_const(2) SWAP1
+    // stack: node_ptr, cur_len, retdest
+    %increment
+    // stack: node_ptr+1, cur_len, retdest
+    %mload_trie_data
+    %stack (hash, cur_len, retdest) -> (retdest, hash, cur_len)
+    JUMP
+
+smt_hash_internal:
+    // stack: node, node_ptr, cur_len, retdest
+    POP
+    // stack: node_ptr, cur_len, retdest
+    SWAP1 %add_const(3) SWAP1
+    %increment
+    // stack: node_ptr+1, cur_len, retdest
+    DUP1
+    %mload_trie_data
+    %stack (left_child_ptr, node_ptr_plus_1, cur_len, retdest) -> (left_child_ptr, cur_len, smt_hash_internal_after_left, node_ptr_plus_1, retdest)
+    %jump(smt_hash)
+smt_hash_internal_after_left:
+    %stack (left_hash, cur_len, node_ptr_plus_1, retdest) -> (node_ptr_plus_1, left_hash, cur_len, retdest)
+    %increment
+    // stack: node_ptr+2, left_hash, cur_len, retdest
+    %mload_trie_data
+    %stack (right_child_ptr, left_hash, cur_len, retdest) -> (right_child_ptr, cur_len, smt_hash_internal_after_right, left_hash, retdest)
+    %jump(smt_hash)
+smt_hash_internal_after_right:
+    %stack (right_hash, cur_len, left_hash) -> (left_hash, right_hash, 0, cur_len)
+    POSEIDON
+    %stack (hash, cur_len, retdest) -> (retdest, hash, cur_len)
+    JUMP
+
+smt_hash_leaf:
+    // stack: node_ptr, cur_len, retdest
+    SWAP1 %add_const(3) SWAP1
+    // stack: node_ptr, cur_len, retdest
+    %increment
+    // stack: node_ptr+1, cur_len, retdest
+    DUP1 %increment
+    // stack: node_ptr+2, node_ptr+1, cur_len, retdest
+    %mload_trie_data
+    // stack: value, node_ptr+1, cur_len, retdest
+    SWAP1
+    // stack: node_ptr+1, value, cur_len, retdest
+    %mload_trie_data
+    %stack (rem_key, value) -> (value, smt_hash_leaf_contd, rem_key)
+    %jump(hash_limbs)
+smt_hash_leaf_contd:
+    %stack (value_hash, rem_key) -> (rem_key, value_hash, 1)
+    POSEIDON
+    %stack (hash, cur_len, retdest) -> (retdest, hash, cur_len)
+    JUMP

--- a/evm_arithmetization/src/cpu/kernel/asm/smt/insert.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/smt/insert.asm
@@ -1,0 +1,175 @@
+// Insert a key-value pair in the state SMT.
+global smt_insert_state:
+    // stack: key, value, retdest
+    DUP2 ISZERO %jumpi(insert_zero)
+    // stack: key, value, retdest
+    %stack (key, value) -> (key, value, smt_insert_state_after)
+    %split_key
+    // stack: k0, k1, k2, k3, value, smt_insert_state_after, retdest
+    PUSH 0
+    // stack: level, k0, k1, k2, k3, value, smt_insert_state_after, retdest
+    %mload_global_metadata(@GLOBAL_METADATA_STATE_TRIE_ROOT) // node_ptr
+    // stack: node_ptr, level, k0, k1, k2, k3, value, smt_insert_state_after, retdest
+    %jump(smt_insert)
+
+smt_insert_state_after:
+    // stack: root_ptr, retdest
+    %mstore_global_metadata(@GLOBAL_METADATA_STATE_TRIE_ROOT)
+    // stack: retdest
+    JUMP
+
+%macro smt_insert_state
+    %stack (key, value_ptr) -> (key, value_ptr, %%after)
+    %jump(smt_insert_state)
+%%after:
+%endmacro
+
+// Insert a key-value pair in the SMT at `trie_data[node_ptr]`.
+// Pseudocode:
+// ```
+// insert( HashNode { h }, key, value ) = if h == 0 then Leaf { key, value } else PANIC
+// insert( InternalNode { left, right }, key, value ) = if key&1 { insert( right, key>>1, value ) } else { insert( left, key>>1, value ) }
+// insert( Leaf { key', value' }, key, value ) = {
+//    let internal = new InternalNode;
+//    insert(internal, key', value');
+//    insert(internal, key, value);
+//    return internal;}
+// ```
+global smt_insert:
+    // stack: node_ptr, level, ks, value, retdest
+    DUP1 %mload_trie_data
+    // stack: node_type, node_ptr, level, ks, value, retdest
+    // Increment node_ptr, so it points to the node payload instead of its type.
+    SWAP1 %increment SWAP1
+    // stack: node_type, node_payload_ptr, level, ks, value, retdest
+
+    DUP1 %eq_const(@SMT_NODE_HASH)        %jumpi(smt_insert_hash)
+    DUP1 %eq_const(@SMT_NODE_INTERNAL)    %jumpi(smt_insert_internal)
+    DUP1 %eq_const(@SMT_NODE_LEAF)        %jumpi(smt_insert_leaf)
+    PANIC
+
+smt_insert_hash:
+    // stack: node_type, node_payload_ptr, level, ks, value, retdest
+    POP
+    // stack: node_payload_ptr, level, ks, value, retdest
+    %mload_trie_data
+    // stack: hash, level, ks, value, retdest
+    ISZERO %jumpi(smt_insert_empty)
+    PANIC // Trying to insert in a non-empty hash node.
+smt_insert_empty:
+    // stack: level, ks, value, retdest
+    POP
+    // stack: ks, value, retdest
+    %combine_key
+    // stack: key, value, retdest
+    %get_trie_data_size
+    // stack: index, key, value, retdest
+    PUSH @SMT_NODE_LEAF %append_to_trie_data
+    %stack (index, key, value) -> (key, value, index)
+    %append_to_trie_data // key
+    %append_to_trie_data // value
+    // stack: index, retdest
+    SWAP1 JUMP
+
+smt_insert_internal:
+    // stack: node_type, node_payload_ptr, level, ks, value, retdest
+    POP
+    // stack: node_payload_ptr, level, ks, value, retdest
+    DUP2 %and_const(3) // level mod 4
+    // stack: level%4, node_payload_ptr, level, ks, value, retdest
+    DUP1 %eq_const(0) %jumpi(smt_insert_internal_0)
+    DUP1 %eq_const(1) %jumpi(smt_insert_internal_1)
+    DUP1 %eq_const(2) %jumpi(smt_insert_internal_2)
+         %eq_const(3) %jumpi(smt_insert_internal_3)
+    PANIC
+smt_insert_internal_0:
+    // stack: level%4, node_payload_ptr, level, ks, value, retdest
+    %stack (level_mod_4, node_payload_ptr, level, k0, k1, k2, k3 ) -> (k0, node_payload_ptr, level, k0, k1, k2, k3 )
+    %pop_bit
+    %stack (bit, newk0, node_payload_ptr, level, k0, k1, k2, k3 ) -> (bit, node_payload_ptr, level, newk0, k1, k2, k3 )
+    %jump(smt_insert_internal_contd)
+smt_insert_internal_1:
+    // stack: level%4, node_payload_ptr, level, ks, value, retdest
+    %stack (level_mod_4, node_payload_ptr, level, k0, k1, k2, k3 ) -> (k1, node_payload_ptr, level, k0, k1, k2, k3 )
+    %pop_bit
+    %stack (bit, newk1, node_payload_ptr, level, k0, k1, k2, k3 ) -> (bit, node_payload_ptr, level, k0, newk1, k2, k3 )
+    %jump(smt_insert_internal_contd)
+smt_insert_internal_2:
+    // stack: level%4, node_payload_ptr, level, ks, value, retdest
+    %stack (level_mod_4, node_payload_ptr, level, k0, k1, k2, k3 ) -> (k2, node_payload_ptr, level, k0, k1, k2, k3 )
+    %pop_bit
+    %stack (bit, newk2, node_payload_ptr, level, k0, k1, k2, k3 ) -> (bit, node_payload_ptr, level, k0, k1, newk2, k3 )
+    %jump(smt_insert_internal_contd)
+smt_insert_internal_3:
+    // stack: level%4, node_payload_ptr, level, ks, value, retdest
+    %stack (node_payload_ptr, level, k0, k1, k2, k3 ) -> (k3, node_payload_ptr, level, k0, k1, k2, k3 )
+    %pop_bit
+    %stack (bit, newk3, node_payload_ptr, level, k0, k1, k2, k3 ) -> (bit, node_payload_ptr, level, k0, k1, k2, newk3 )
+    %jump(smt_insert_internal_contd)
+smt_insert_internal_contd:
+    // stack: bit, node_payload_ptr, level, ks, value, retdest
+    DUP2 ADD
+    // stack: child_ptr_ptr, node_payload_ptr, level, ks, value, retdest
+    DUP1 %mload_trie_data
+    // stack: child_ptr, child_ptr_ptr, node_payload_ptr, level, ks, value, retdest
+    SWAP3 %increment SWAP3
+    %stack (child_ptr, child_ptr_ptr, node_payload_ptr, level_plus_1, k0, k1, k2, k3, value, retdest) ->
+            (child_ptr, level_plus_1, k0, k1, k2, k3, value, smt_insert_internal_after, child_ptr_ptr, node_payload_ptr, retdest)
+    %jump(smt_insert)
+
+smt_insert_internal_after:
+    // stack: new_node_ptr, child_ptr_ptr, node_payload_ptr, retdest
+    SWAP1 %mstore_trie_data
+    // stack: node_payload_ptr, retdest
+    %decrement
+    SWAP1 JUMP
+
+smt_insert_leaf:
+    // stack: node_type, node_payload_ptr, level, ks, value, retdest
+    POP
+    %stack (node_payload_ptr, level, k0, k1, k2, k3, value) -> (k0, k1, k2, k3, node_payload_ptr, level, k0, k1, k2, k3, value)
+    %combine_key
+    // stack: rem_key, node_payload_ptr, level, ks, value, retdest
+    DUP2 %mload_trie_data
+    // stack: existing_key, rem_key, node_payload_ptr, level, ks, value, retdest
+    DUP2 DUP2 EQ %jumpi(smt_insert_leaf_same_key)
+    // stack: existing_key, rem_key, node_payload_ptr, level, ks, value, retdest
+    // We create an internal node with two empty children, and then we insert the two leaves.
+    %get_trie_data_size
+    // stack: index, existing_key, rem_key, node_payload_ptr, level, ks, value, retdest
+    PUSH @SMT_NODE_INTERNAL %append_to_trie_data
+    PUSH 0 %append_to_trie_data // Empty hash node
+    PUSH 0 %append_to_trie_data // Empty hash node
+    // stack: index, existing_key, rem_key, node_payload_ptr, level, ks, value, retdest
+    SWAP1 %split_key
+    // stack: existing_k0, existing_k1, existing_k2, existing_k3, index, rem_key, node_payload_ptr, level, ks, value, retdest
+    DUP7 %increment %mload_trie_data
+    // stack: existing_value, existing_k0, existing_k1, existing_k2, existing_k3, index, rem_key, node_payload_ptr, level, ks, value, retdest
+    DUP9
+    %stack (level, existing_value, existing_k0, existing_k1, existing_k2, existing_k3, index) -> (index, level, existing_k0, existing_k1, existing_k2, existing_k3, existing_value, after_first_leaf)
+    %jump(smt_insert)
+after_first_leaf:
+    // stack: internal_ptr, rem_key, node_payload_ptr, level, ks, value, retdest
+    %stack (internal_ptr, rem_key, node_payload_ptr, level, k0, k1, k2, k3, value) -> (internal_ptr, level, k0, k1, k2, k3, value)
+    %jump(smt_insert)
+
+smt_insert_leaf_same_key:
+    // stack: existing_key, rem_key, node_payload_ptr, level, ks, value, retdest
+    %pop2
+    %stack (node_payload_ptr, level, k0, k1, k2, k3, value) -> (node_payload_ptr, value, node_payload_ptr)
+    %increment %mstore_trie_data
+    // stack: node_payload_ptr, retdest
+    %decrement
+    // stack: node_ptr, retdest
+    SWAP1 JUMP
+
+insert_zero:
+    // stack: key, value, retdest
+    DUP1 %smt_read_state %mload_trie_data %jumpi(delete)
+    // stack: key, value, retdest
+    %pop2 JUMP
+delete:
+    // stack: key, value, retdest
+    %smt_delete_state
+    // stack: value, retdest
+    POP JUMP

--- a/evm_arithmetization/src/cpu/kernel/asm/smt/keys.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/smt/keys.asm
@@ -1,0 +1,131 @@
+/// See `smt_trie::keys.rs` for documentation.
+
+// addr = sum_{0<=i<5} a_i << (32i)
+%macro key_balance
+    // stack: addr
+    PUSH 0x100000000
+    // stack: u32max, addr
+    DUP1 DUP3 MOD
+    // stack: a_0, u32max, addr
+    DUP2 DUP4 %shr_const(32) MOD %shl_const(64) ADD
+    // stack: a_0 + a_1<<64, u32max, addr
+    DUP2 DUP4 %shr_const(64) MOD %shl_const(128) ADD
+    // stack: a_0 + a_1<<64 + a_2<<128, u32max, addr
+    DUP2 DUP4 %shr_const(96) MOD %shl_const(192) ADD
+    // stack: a_0 + a_1<<64 + a_2<<128 + a_3<<192, u32max, addr
+    SWAP2 %shr_const(128)
+    // stack: a_4, u32max, a_0 + a_1<<64 + a_2<<128 + a_3<<192
+    %stack (y, u32max, x) -> (x, y, @POSEIDON_HASH_ZEROS)
+    POSEIDON
+%endmacro
+
+// addr = sum_{0<=i<5} a_i << (32i)
+%macro key_nonce
+    // stack: addr
+    PUSH 0x100000000
+    // stack: u32max, addr
+    DUP1 DUP3 MOD
+    // stack: a_0, u32max, addr
+    DUP2 DUP4 %shr_const(32) MOD %shl_const(64) ADD
+    // stack: a_0 + a_1<<64, u32max, addr
+    DUP2 DUP4 %shr_const(64) MOD %shl_const(128) ADD
+    // stack: a_0 + a_1<<64 + a_2<<128, u32max, addr
+    DUP2 DUP4 %shr_const(96) MOD %shl_const(192) ADD
+    // stack: a_0 + a_1<<64 + a_2<<128 + a_3<<192, u32max, addr
+    SWAP2 %shr_const(128)
+    // stack: a_4, u32max, a_0 + a_1<<64 + a_2<<128 + a_3<<192
+    %add_const(0x100000000000000000000000000000000) // SMT_KEY_NONCE (=1) << 128
+    %stack (y, u32max, x) -> (x, y, @POSEIDON_HASH_ZEROS)
+    POSEIDON
+%endmacro
+
+// addr = sum_{0<=i<5} a_i << (32i)
+%macro key_code
+    // stack: addr
+    PUSH 0x100000000
+    // stack: u32max, addr
+    DUP1 DUP3 MOD
+    // stack: a_0, u32max, addr
+    DUP2 DUP4 %shr_const(32) MOD %shl_const(64) ADD
+    // stack: a_0 + a_1<<64, u32max, addr
+    DUP2 DUP4 %shr_const(64) MOD %shl_const(128) ADD
+    // stack: a_0 + a_1<<64 + a_2<<128, u32max, addr
+    DUP2 DUP4 %shr_const(96) MOD %shl_const(192) ADD
+    // stack: a_0 + a_1<<64 + a_2<<128 + a_3<<192, u32max, addr
+    SWAP2 %shr_const(128)
+    // stack: a_4, u32max, a_0 + a_1<<64 + a_2<<128 + a_3<<192
+    %add_const(0x200000000000000000000000000000000) // SMT_KEY_CODE (=2) << 128
+    %stack (y, u32max, x) -> (x, y, @POSEIDON_HASH_ZEROS)
+    POSEIDON
+%endmacro
+
+// addr = sum_{0<=i<5} a_i << (32i)
+%macro key_code_length
+    // stack: addr
+    PUSH 0x100000000
+    // stack: u32max, addr
+    DUP1 DUP3 MOD
+    // stack: a_0, u32max, addr
+    DUP2 DUP4 %shr_const(32) MOD %shl_const(64) ADD
+    // stack: a_0 + a_1<<64, u32max, addr
+    DUP2 DUP4 %shr_const(64) MOD %shl_const(128) ADD
+    // stack: a_0 + a_1<<64 + a_2<<128, u32max, addr
+    DUP2 DUP4 %shr_const(96) MOD %shl_const(192) ADD
+    // stack: a_0 + a_1<<64 + a_2<<128 + a_3<<192, u32max, addr
+    SWAP2 %shr_const(128)
+    // stack: a_4, u32max, a_0 + a_1<<64 + a_2<<128 + a_3<<192
+    %add_const(0x400000000000000000000000000000000) // SMT_KEY_CODE_LENGTH (=4) << 128
+    %stack (y, u32max, x) -> (x, y, @POSEIDON_HASH_ZEROS)
+    POSEIDON
+%endmacro
+
+// addr = sum_{0<=i<5} a_i << (32i)
+%macro key_storage
+    %stack (addr, slot) -> (slot, %%after, addr)
+    %jump(hash_limbs)
+%%after:
+    // stack: capacity, addr
+    SWAP1
+    // stack: addr, capacity
+    PUSH 0x100000000
+    // stack: u32max, addr, capacity
+    DUP1 DUP3 MOD
+    // stack: a_0, u32max, addr
+    DUP2 DUP4 %shr_const(32) MOD %shl_const(64) ADD
+    // stack: a_0 + a_1<<64, u32max, addr
+    DUP2 DUP4 %shr_const(64) MOD %shl_const(128) ADD
+    // stack: a_0 + a_1<<64 + a_2<<128, u32max, addr
+    DUP2 DUP4 %shr_const(96) MOD %shl_const(192) ADD
+    // stack: a_0 + a_1<<64 + a_2<<128 + a_3<<192, u32max, addr
+    SWAP2 %shr_const(128)
+    // stack: a_4, u32max, a_0 + a_1<<64 + a_2<<128 + a_3<<192
+    %add_const(0x300000000000000000000000000000000) // SMT_KEY_STORAGE (=3) << 128
+    %stack (y, u32max, x, capacity) -> (x, y, capacity)
+    POSEIDON
+%endmacro
+
+// slot = sum_{0<=i<8} s_i << (32i)
+global hash_limbs:
+    // stack: slot, retdest
+    PUSH 0x100000000
+    // stack: u32max, slot, retdest
+    DUP1 DUP3 MOD
+    // stack: s_0, u32max, slot
+    DUP2 DUP4 %shr_const(32) MOD %shl_const(64) ADD
+    // stack: s_0 + s_1<<64, u32max, slot
+    DUP2 DUP4 %shr_const(64) MOD %shl_const(128) ADD
+    // stack: s_0 + s_1<<64 + s_2<<128, u32max, slot
+    DUP2 DUP4 %shr_const(96) MOD %shl_const(192) ADD
+    // stack: s_0 + s_1<<64 + s_2<<128 + s_3<<192, u32max, slot
+    DUP2 DUP4 %shr_const(128) MOD
+    // stack: s_4, s_0 + s_1<<64 + s_2<<128 + s_3<<192, u32max, slot
+    DUP3 DUP5 %shr_const(160) MOD %shl_const(64) ADD
+    // stack: s_4 + s_5<<64, s_0 + s_1<<64 + s_2<<128 + s_3<<192, u32max, slot
+    DUP3 DUP5 %shr_const(192) MOD %shl_const(128) ADD
+    // stack: s_4 + s_5<<64 + s_6<<128, s_0 + s_1<<64 + s_2<<128 + s_3<<192, u32max, slot
+    DUP3 DUP5 %shr_const(224) MOD %shl_const(192) ADD
+    // stack: s_4 + s_5<<64 + s_6<<128 + s_7<<192, s_0 + s_1<<64 + s_2<<128 + s_3<<192, u32max, slot
+    %stack (b, a, u32max, slot) -> (a, b, 0)
+    POSEIDON
+    // stack: hash, retdest
+    SWAP1 JUMP

--- a/evm_arithmetization/src/cpu/kernel/asm/smt/read.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/smt/read.asm
@@ -1,0 +1,110 @@
+// Given a key, return a pointer to the associated SMT entry.
+// Returns 0 if the key is not in the SMT.
+global smt_read_state:
+    // stack: key, retdest
+    %split_key
+    // stack: k0, k1, k2, k3, retdest
+    PUSH 0
+    // stack: level, k0, k1, k2, k3, retdest
+    %mload_global_metadata(@GLOBAL_METADATA_STATE_TRIE_ROOT) // node_ptr
+    // stack: node_ptr, level, k0, k1, k2, k3, retdest
+    %jump(smt_read)
+
+// Convenience macro to call smt_read_state and return where we left off.
+%macro smt_read_state
+    %stack (key) -> (key, %%after)
+    %jump(smt_read_state)
+%%after:
+%endmacro
+
+// Return a pointer to the data at the given key in the SMT at `trie_data[node_ptr]`.
+// Pseudocode:
+// ```
+// read( HashNode { h }, key ) = if h == 0 then 0 else PANIC
+// read( InternalNode { left, right }, key ) = if key&1 { read( right, key>>1 ) } else { read( left, key>>1 ) }
+// read( Leaf { rem_key', value }, key ) = if rem_key == rem_key' then &value else 0
+// ```
+global smt_read:
+    // stack: node_ptr, level, ks, retdest
+    DUP1 %mload_trie_data
+    // stack: node_type, node_ptr, level, ks, retdest
+    // Increment node_ptr, so it points to the node payload instead of its type.
+    SWAP1 %increment SWAP1
+    // stack: node_type, node_payload_ptr, level, ks, retdest
+
+    DUP1 %eq_const(@SMT_NODE_HASH)      %jumpi(smt_read_hash)
+    DUP1 %eq_const(@SMT_NODE_INTERNAL)  %jumpi(smt_read_internal)
+    %eq_const(@SMT_NODE_LEAF)           %jumpi(smt_read_leaf)
+    PANIC
+
+smt_read_hash:
+    // stack: node_type, node_payload_ptr, level, ks, retdest
+    POP
+    // stack: node_payload_ptr, level, ks, retdest
+    %mload_trie_data
+    // stack: hash, level, ks, retdest
+    ISZERO %jumpi(smt_read_empty)
+    PANIC // Trying to read a non-empty hash node. Should never happen.
+
+smt_read_empty:
+    %stack (level, k0, k1, k2, k3, retdest) -> (retdest, 0)
+    JUMP
+
+smt_read_internal:
+    // stack: node_type, node_payload_ptr, level, ks, retdest
+    POP
+    // stack: node_payload_ptr, level, ks, retdest
+    DUP2 %and_const(3) // level mod 4
+    // stack: level%4, node_payload_ptr, level, ks, retdest
+    DUP1 %eq_const(0) %jumpi(smt_read_internal_0)
+    DUP1 %eq_const(1) %jumpi(smt_read_internal_1)
+    DUP1 %eq_const(2) %jumpi(smt_read_internal_2)
+    DUP1 %eq_const(3) %jumpi(smt_read_internal_3)
+    PANIC
+smt_read_internal_0:
+    %stack (level_mod_4, node_payload_ptr, level, k0, k1, k2, k3 ) -> (k0, node_payload_ptr, level, k0, k1, k2, k3 )
+    %pop_bit
+    %stack (bit, newk0, node_payload_ptr, level, k0, k1, k2, k3 ) -> (bit, node_payload_ptr, level, newk0, k1, k2, k3 )
+    %jump(smt_read_internal_contd)
+smt_read_internal_1:
+    %stack (level_mod_4, node_payload_ptr, level, k0, k1, k2, k3 ) -> (k1, node_payload_ptr, level, k0, k1, k2, k3 )
+    %pop_bit
+    %stack (bit, newk1, node_payload_ptr, level , k0, k1, k2, k3 ) -> (bit, node_payload_ptr, level, k0, newk1, k2, k3 )
+    %jump(smt_read_internal_contd)
+smt_read_internal_2:
+    %stack (level_mod_4, node_payload_ptr, level, k0, k1, k2, k3 ) -> (k2, node_payload_ptr, level, k0, k1, k2, k3 )
+    %pop_bit
+    %stack (bit, newk2, node_payload_ptr, level, k0, k1, k2, k3 ) -> (bit, node_payload_ptr, level, k0, k1, newk2, k3 )
+    %jump(smt_read_internal_contd)
+smt_read_internal_3:
+    %stack (level_mod_4, node_payload_ptr, level, k0, k1, k2, k3 ) -> (k3, node_payload_ptr, level, k0, k1, k2, k3 )
+    %pop_bit
+    %stack (bit, newk3, node_payload_ptr, level, k0, k1, k2, k3 ) -> (bit, node_payload_ptr, level, k0, k1, k2, newk3 )
+smt_read_internal_contd:
+    // stack: bit, node_payload_ptr, level, k0, k1, k2, k3, retdest
+    ADD
+    // stack: child_ptr_ptr, level, k0, k1, k2, k3, retdest
+    %mload_trie_data
+    // stack: child_ptr, level, k0, k1, k2, k3, retdest
+    SWAP1 %increment SWAP1
+    // stack: child_ptr, level+1, k0, k1, k2, k3, retdest
+    %jump(smt_read)
+
+smt_read_leaf:
+    // stack: node_payload_ptr, level, ks, retdest
+    DUP1 %mload_trie_data
+    // stack: rem_key, node_payload_ptr, level, ks, retdest
+    SWAP1
+    // stack: node_payload_ptr, rem_key, level, ks, retdest
+    %increment
+    %stack (value_ptr, rem_key, level, k0, k1, k2, k3) -> (k0, k1, k2, k3, rem_key, value_ptr)
+    %combine_key
+    // stack: this_rem_key, rem_key, value_ptr, retdest
+    EQ %jumpi(smt_read_existing_leaf)
+smt_read_non_existing_leaf:
+    %stack (value_ptr, retdest) -> (retdest, 0)
+    JUMP
+
+smt_read_existing_leaf:
+    // stack: value_ptr, retdest
+    SWAP1 JUMP

--- a/evm_arithmetization/src/cpu/kernel/asm/smt/utils.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/smt/utils.asm
@@ -1,0 +1,129 @@
+// Input: x
+// Output: (x&1, x>>1)
+%macro pop_bit
+    // stack: key
+    DUP1 %shr_const(1)
+    // stack: key>>1, key
+    SWAP1 %mod_const(2)
+    // stack: key&1, key>>1
+%endmacro
+
+// Returns a non-zero value if the node is non-empty.
+%macro is_non_empty_node
+    // stack: node_ptr
+    DUP1 %mload_trie_data %jumpi(%%end) // If the node is not a hash node, node_ptr is non-zero.
+    // The node is a hash node
+    // stack: node_ptr
+    %increment %mload_trie_data
+    // stack: hash
+%%end:
+%endmacro
+
+// Input: key = k0 + k1.2^64 + k2.2^128 + k3.2^192, with 0<=ki<2^64.
+// Output: (k0, k1, k2, k3)
+%macro split_key
+    // stack: key
+    DUP1 %shr_const(128) %mod_const(0x10000000000000000)
+    // stack: k2, key
+    DUP2 %shr_const(64) %mod_const(0x10000000000000000)
+    // stack: k1, k2, key
+    DUP3 %shr_const(192)
+    // stack: k3, k1, k2, key
+    SWAP3 %mod_const(0x10000000000000000)
+    // stack: k0, k1, k2, k3
+%endmacro
+
+// Input: (k0, k1, k2, k3)
+// Output: k0 + k1.2^64 + k2.2^128 + k3.2^192
+%macro combine_key
+    // stack: k0, k1, k2, k3
+    SWAP1 %shl_const(64) ADD
+    // stack: k0 + k1<<64, k2, k3
+    SWAP1 %shl_const(128) ADD
+    // stack: k0 + k1<<64 + k2<<128, k3
+    SWAP1 %shl_const(192) ADD
+    // stack: k0 + k1<<64 + k2<<128 + k3<<192
+%endmacro
+
+
+// Pseudocode:
+// ```
+// def recombine_key(key, bit, level):
+//   k0, k1, k2, k3 = [(key>>(64*i))&(2**64-1) for i in range(4)]
+//   match level%4:
+//     0 => k0 = 2*k0 + bit
+//     1 => k1 = 2*k1 + bit
+//     2 => k2 = 2*k2 + bit
+//     3 => k3 = 2*k3 + bit
+//   return k0 + (k1<<64) + (k2<<128) + (k3<<192)
+// ```
+%macro recombine_key
+    // stack: key, bit, level
+    SWAP1
+    // stack: bit, key, level
+    SWAP2
+    // stack: level, key, bit
+    %mod_const(4)
+    // stack: level%4, key, bit
+    DUP1 %eq_const(0) %jumpi(%%recombine_key_0)
+    DUP1 %eq_const(1) %jumpi(%%recombine_key_1)
+    DUP1 %eq_const(2) %jumpi(%%recombine_key_2)
+    DUP1 %eq_const(3) %jumpi(%%recombine_key_3)
+    PANIC
+%%recombine_key_0:
+    // stack: level%4, key, bit
+    POP
+    // stack: key, bit
+    %split_key
+    // stack: k0, k1, k2, k3, bit
+    %shl_const(1)
+    // stack: k0<<1, k1, k2, k3, bit
+    DUP5 ADD
+    // stack: k0<<1 + bit, k1, k2, k3, bit
+    %combine_key
+    %stack (newkey, bit) -> (newkey)
+    %jump(%%after)
+%%recombine_key_1:
+    // stack: level%4, key, bit
+    POP
+    // stack: key, bit
+    %split_key
+    // stack: k0, k1, k2, k3, bit
+    DUP2 %shl_const(1)
+    // stack: k1<<1, k0, k1, k2, k3, bit
+    DUP6 ADD
+    // stack: k1<<1 + bit, k0, k1, k2, k3, bit
+    SWAP2 POP
+    %combine_key
+    %stack (newkey, bit) -> (newkey)
+    %jump(%%after)
+%%recombine_key_2:
+    // stack: key, bit
+    POP
+    // stack: key, bit
+    %split_key
+    // stack: k0, k1, k2, k3, bit
+    DUP3 %shl_const(1)
+    // stack: k2<<1, k0, k1, k2, k3, bit
+    DUP6 ADD
+    // stack: k2<<1 + bit, k0, k1, k2, k3, bit
+    SWAP3 POP
+    %combine_key
+    %stack (newkey, bit) -> (newkey)
+    %jump(%%after)
+%%recombine_key_3:
+    // stack: key, bit
+    POP
+    // stack: key, bit
+    %split_key
+    // stack: k0, k1, k2, k3, bit
+    DUP4 %shl_const(1)
+    // stack: k3<<1, k0, k1, k2, k3, bit
+    DUP6 ADD
+    // stack: k3<<1 + bit, k0, k1, k2, k3, bit
+    SWAP4 POP
+    %combine_key
+    %stack (newkey, bit) -> (newkey)
+%%after:
+    // stack: newkey
+%endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/trie_common.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/trie_common.asm
@@ -1,0 +1,32 @@
+// Given an address, return a pointer to the associated account data, which
+// consists of four words (nonce, balance, storage_root, code_hash), in the
+// trie_data segment. Return null if the address is not found.
+global read_state_trie:
+    // stack: addr, retdest
+    %read_accounts_linked_list
+    // stack: account_ptr, retdest
+    SWAP1
+    // stack: retdest, account_ptr
+    JUMP
+
+// Convenience macro to call read_state_trie and return where we left off.
+%macro read_state_trie
+    %stack (addr) -> (addr, %%after)
+    %jump(read_state_trie)
+%%after:
+%endmacro
+
+// Mutate the state trie linked list, inserting the given key-value pair.
+// Pre stack: key, value_ptr, retdest
+// Post stack: (empty)
+// TODO: Have this take an address and do %insert_state_trie? To match read_state_trie.
+global insert_state_trie:
+    // stack: key, value_ptr, retdest
+    %insert_account_with_overwrite
+    JUMP
+
+%macro insert_state_trie
+    %stack (key, value_ptr) -> (key, value_ptr, %%after)
+    %jump(insert_state_trie)
+%%after:
+%endmacro

--- a/evm_arithmetization/src/cpu/kernel/constants/global_metadata.rs
+++ b/evm_arithmetization/src/cpu/kernel/constants/global_metadata.rs
@@ -115,10 +115,13 @@ pub(crate) enum GlobalMetadata {
 
     /// Address where the base fee to be burnt is sent.
     BurnAddr,
+
+    /// Number of used storage slots in newly created contracts.
+    NewStorageSlotsLen,
 }
 
 impl GlobalMetadata {
-    pub(crate) const COUNT: usize = 55;
+    pub(crate) const COUNT: usize = 56;
 
     /// Unscales this virtual offset by their respective `Segment` value.
     pub(crate) const fn unscale(&self) -> usize {
@@ -182,6 +185,7 @@ impl GlobalMetadata {
             Self::TransientStorageLen,
             Self::BlobVersionedHashesLen,
             Self::BurnAddr,
+            Self::NewStorageSlotsLen,
         ]
     }
 
@@ -249,6 +253,7 @@ impl GlobalMetadata {
             Self::TransientStorageLen => "GLOBAL_METADATA_TRANSIENT_STORAGE_LEN",
             Self::BlobVersionedHashesLen => "GLOBAL_METADATA_BLOB_VERSIONED_HASHES_LEN",
             Self::BurnAddr => "GLOBAL_METADATA_BURN_ADDR",
+            Self::NewStorageSlotsLen => "GLOBAL_METADATA_NEW_STORAGE_SLOTS_LEN",
         }
     }
 }

--- a/evm_arithmetization/src/cpu/kernel/constants/mod.rs
+++ b/evm_arithmetization/src/cpu/kernel/constants/mod.rs
@@ -2,11 +2,12 @@ use std::collections::HashMap;
 
 use ethereum_types::{Address, H160, H256, U256};
 use hex_literal::hex;
+use smt_type::PartialSmtType;
 
 use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::cpu::kernel::constants::journal_entry::JournalEntry;
-use crate::cpu::kernel::constants::trie_type::PartialTrieType;
+use crate::cpu::kernel::constants::mpt_type::PartialMptType;
 use crate::cpu::kernel::constants::txn_fields::NormalizedTxnField;
 use crate::generation::mpt::AccountRlp;
 use crate::memory::segments::Segment;
@@ -15,7 +16,8 @@ pub(crate) mod context_metadata;
 mod exc_bitfields;
 pub(crate) mod global_metadata;
 pub(crate) mod journal_entry;
-pub(crate) mod trie_type;
+pub(crate) mod mpt_type;
+pub(crate) mod smt_type;
 pub(crate) mod txn_fields;
 
 /// A named constant.
@@ -68,6 +70,7 @@ pub(crate) fn evm_constants() -> HashMap<String, U256> {
 
     c.insert(MAX_NONCE.0.into(), U256::from(MAX_NONCE.1));
     c.insert(CALL_STACK_LIMIT.0.into(), U256::from(CALL_STACK_LIMIT.1));
+    c.insert(POSEIDON_HASH_ZEROS.0.into(), POSEIDON_HASH_ZEROS.1);
     c.insert(
         MAX_RLP_PREFIX_SIZE.0.into(),
         U256::from(MAX_RLP_PREFIX_SIZE.1),
@@ -132,7 +135,10 @@ pub(crate) fn evm_constants() -> HashMap<String, U256> {
         // These offsets are already scaled by their respective segment.
         c.insert(txn_field.var_name().into(), (txn_field as usize).into());
     }
-    for trie_type in PartialTrieType::all() {
+    for trie_type in PartialMptType::all() {
+        c.insert(trie_type.var_name().into(), (trie_type as u32).into());
+    }
+    for trie_type in PartialSmtType::all() {
         c.insert(trie_type.var_name().into(), (trie_type as u32).into());
     }
     for entry in JournalEntry::all() {
@@ -177,7 +183,7 @@ const MISC_CONSTANTS: [(&str, [u8; 32]); 4] = [
     ),
 ];
 
-const HASH_CONSTANTS: [(&str, [u8; 32]); 2] = [
+const HASH_CONSTANTS: [(&str, [u8; 32]); 3] = [
     // Hash of an empty string: keccak(b'').hex()
     (
         "EMPTY_STRING_HASH",
@@ -187,6 +193,10 @@ const HASH_CONSTANTS: [(&str, [u8; 32]); 2] = [
     (
         "EMPTY_NODE_HASH",
         hex!("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),
+    ),
+    (
+        "EMPTY_STRING_POSEIDON_HASH",
+        hex!("3baed9289a384f6c1c05d92b56c801c2d2e2a7050d6c16538b814fa186835c79"),
     ),
 ];
 
@@ -383,6 +393,16 @@ const CODE_SIZE_LIMIT: [(&str, u64); 3] = [
 const MAX_NONCE: (&str, u64) = ("MAX_NONCE", 0xffffffffffffffff);
 const CALL_STACK_LIMIT: (&str, u64) = ("CALL_STACK_LIMIT", 1024);
 
+const POSEIDON_HASH_ZEROS: (&str, U256) = (
+    "POSEIDON_HASH_ZEROS",
+    U256([
+        4330397376401421145,
+        14124799381142128323,
+        8742572140681234676,
+        14345658006221440202,
+    ]),
+);
+
 // 9 bytes, largest possible RLP prefix in our MPTs.
 const MAX_RLP_PREFIX_SIZE: (&str, u8) = ("MAX_RLP_PREFIX_SIZE", 9);
 // Address where RLP encoding generally starts.
@@ -405,6 +425,7 @@ const LINKED_LISTS_CONSTANTS: [(&str, u16); 5] = [
 pub mod cancun_constants {
 
     use super::*;
+    use crate::generation::mpt::Type1AccountRlp;
 
     pub const BLOB_BASE_FEE_UPDATE_FRACTION: U256 = U256([0x32f0ed, 0, 0, 0]);
 
@@ -450,7 +471,7 @@ pub mod cancun_constants {
     pub const BEACON_ROOTS_CONTRACT_CODE_HASH: [u8; 32] =
         hex!("f57acd40259872606d76197ef052f3d35588dadf919ee1f0e3cb9b62d3f4b02c");
 
-    pub const BEACON_ROOTS_ACCOUNT: AccountRlp = AccountRlp {
+    pub const BEACON_ROOTS_ACCOUNT: Type1AccountRlp = Type1AccountRlp {
         nonce: U256::zero(),
         balance: U256::zero(),
         // Storage root for this account at genesis.
@@ -471,6 +492,7 @@ pub mod cancun_constants {
 
 pub mod global_exit_root {
     use super::*;
+    use crate::{generation::mpt::Type2AccountRlp, util::h2u};
 
     /// Taken from https://github.com/0xPolygonHermez/cdk-erigon/blob/61f0b6912055c73f6879ea7e9b5bac22ea5fc85c/zk/utils/global_exit_root.go#L16.
     pub const GLOBAL_EXIT_ROOT_MANAGER_L2: (&str, [u8; 20]) = (
@@ -511,15 +533,14 @@ pub mod global_exit_root {
     pub const GLOBAL_EXIT_ROOT_CONTRACT_CODE_HASH: [u8; 32] =
         hex!("6bec2bf64f7e824109f6ed55f77dd7665801d6195e461666ad6a5342a9f6daf5");
 
-    pub const GLOBAL_EXIT_ROOT_ACCOUNT: AccountRlp = AccountRlp {
-        nonce: U256::zero(),
-        balance: U256::zero(),
-        // Empty storage root
-        storage_root: H256(hex!(
-            "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
-        )),
-        code_hash: H256(GLOBAL_EXIT_ROOT_CONTRACT_CODE_HASH),
-    };
+    pub fn global_exit_root_account() -> Type2AccountRlp {
+        Type2AccountRlp {
+            nonce: U256::zero(),
+            balance: U256::zero(),
+            code_hash: H256(GLOBAL_EXIT_ROOT_CONTRACT_CODE_HASH),
+            code_length: U256([GLOBAL_EXIT_ROOT_CONTRACT_CODE.len() as u64, 0, 0, 0]),
+        }
+    }
 
     #[test]
     fn hashed() {

--- a/evm_arithmetization/src/cpu/kernel/constants/mpt_type.rs
+++ b/evm_arithmetization/src/cpu/kernel/constants/mpt_type.rs
@@ -1,0 +1,49 @@
+use core::ops::Deref;
+
+use mpt_trie::partial_trie::HashedPartialTrie;
+
+use crate::Node;
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum PartialMptType {
+    Empty = 0,
+    Hash = 1,
+    Branch = 2,
+    Extension = 3,
+    Leaf = 4,
+}
+
+impl PartialMptType {
+    pub(crate) const COUNT: usize = 5;
+
+    pub(crate) fn of(trie: &HashedPartialTrie) -> Self {
+        match trie.deref() {
+            Node::Empty => Self::Empty,
+            Node::Hash(_) => Self::Hash,
+            Node::Branch { .. } => Self::Branch,
+            Node::Extension { .. } => Self::Extension,
+            Node::Leaf { .. } => Self::Leaf,
+        }
+    }
+
+    pub(crate) const fn all() -> [Self; Self::COUNT] {
+        [
+            Self::Empty,
+            Self::Hash,
+            Self::Branch,
+            Self::Extension,
+            Self::Leaf,
+        ]
+    }
+
+    /// The variable name that gets passed into kernel assembly code.
+    pub(crate) const fn var_name(&self) -> &'static str {
+        match self {
+            Self::Empty => "MPT_NODE_EMPTY",
+            Self::Hash => "MPT_NODE_HASH",
+            Self::Branch => "MPT_NODE_BRANCH",
+            Self::Extension => "MPT_NODE_EXTENSION",
+            Self::Leaf => "MPT_NODE_LEAF",
+        }
+    }
+}

--- a/evm_arithmetization/src/cpu/kernel/constants/smt_type.rs
+++ b/evm_arithmetization/src/cpu/kernel/constants/smt_type.rs
@@ -1,0 +1,23 @@
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum PartialSmtType {
+    Hash = 0,
+    Internal = 1,
+    Leaf = 2,
+}
+
+impl PartialSmtType {
+    pub(crate) const COUNT: usize = 3;
+
+    pub(crate) fn all() -> [Self; Self::COUNT] {
+        [Self::Hash, Self::Internal, Self::Leaf]
+    }
+
+    /// The variable name that gets passed into kernel assembly code.
+    pub(crate) fn var_name(&self) -> &'static str {
+        match self {
+            Self::Hash => "SMT_NODE_HASH",
+            Self::Internal => "SMT_NODE_INTERNAL",
+            Self::Leaf => "SMT_NODE_LEAF",
+        }
+    }
+}

--- a/evm_arithmetization/src/cpu/kernel/opcodes.rs
+++ b/evm_arithmetization/src/cpu/kernel/opcodes.rs
@@ -39,6 +39,8 @@ pub fn get_opcode(mnemonic: &str) -> u8 {
         "SAR" => 0x1d,
         "KECCAK256" => 0x20,
         "KECCAK_GENERAL" => 0x21,
+        "POSEIDON" => 0x22,
+        "POSEIDON_GENERAL" => 0x23,
         "ADDRESS" => 0x30,
         "BALANCE" => 0x31,
         "ORIGIN" => 0x32,

--- a/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
@@ -29,108 +29,116 @@ pub(crate) fn initialize_mpts<F: RichField>(
     interpreter: &mut Interpreter<F>,
     trie_inputs: &TrieInputs,
 ) {
-    // Load all MPTs.
-    let (mut trie_root_ptrs, state_leaves, storage_leaves, trie_data) =
-        load_linked_lists_and_txn_and_receipt_mpts(
-            &mut interpreter.generation_state.state_ptrs.accounts,
-            &mut interpreter.generation_state.state_ptrs.storage,
-            trie_inputs,
-        )
-        .expect("Invalid MPT data for preinitialization");
-
-    interpreter.generation_state.memory.contexts[0].segments
-        [Segment::AccountsLinkedList.unscale()]
-    .content = state_leaves;
-    interpreter.generation_state.memory.contexts[0].segments
-        [Segment::StorageLinkedList.unscale()]
-    .content = storage_leaves;
-    interpreter.generation_state.memory.contexts[0].segments[Segment::TrieData.unscale()].content =
-        trie_data.clone();
-    interpreter.generation_state.trie_root_ptrs = trie_root_ptrs.clone();
-
-    if trie_root_ptrs.state_root_ptr.is_none() {
-        trie_root_ptrs.state_root_ptr = Some(
-            load_state_mpt(
-                &trie_inputs.trim(),
-                &mut interpreter.generation_state.memory.contexts[0].segments
-                    [Segment::TrieData.unscale()]
-                .content,
+    if cfg!(feature = "cdk_erigon") {
+        unimplemented!()
+    } else {
+        // Load all MPTs.
+        let (mut trie_root_ptrs, state_leaves, storage_leaves, trie_data) =
+            load_linked_lists_and_txn_and_receipt_mpts(
+                &mut interpreter.generation_state.accounts_pointers,
+                &mut interpreter.generation_state.storage_pointers,
+                trie_inputs,
             )
-            .expect("Invalid MPT data for preinitialization"),
-        );
-    }
+            .expect("Invalid MPT data for preinitialization");
 
-    let accounts_len = Segment::AccountsLinkedList as usize
-        + interpreter.generation_state.memory.contexts[0].segments
+        interpreter.generation_state.memory.contexts[0].segments
             [Segment::AccountsLinkedList.unscale()]
-        .content
-        .len();
-    let storage_len = Segment::StorageLinkedList as usize
-        + interpreter.generation_state.memory.contexts[0].segments
+        .content = state_leaves;
+        interpreter.generation_state.memory.contexts[0].segments
             [Segment::StorageLinkedList.unscale()]
+        .content = storage_leaves;
+        interpreter.generation_state.memory.contexts[0].segments[Segment::TrieData.unscale()]
+            .content = trie_data.clone();
+        interpreter.generation_state.trie_root_ptrs = trie_root_ptrs.clone();
+
+        interpreter.generation_state.insert_all_slots_in_memory();
+        interpreter.generation_state.insert_all_accounts_in_memory();
+
+        if trie_root_ptrs.state_root_ptr.is_none() {
+            trie_root_ptrs.state_root_ptr = Some(
+                load_state_mpt(
+                    &trie_inputs.trim(),
+                    &mut interpreter.generation_state.memory.contexts[0].segments
+                        [Segment::TrieData.unscale()]
+                    .content,
+                )
+                .expect("Invalid MPT data for preinitialization"),
+            );
+        }
+
+        let accounts_len = Segment::AccountsLinkedList as usize
+            + interpreter.generation_state.memory.contexts[0].segments
+                [Segment::AccountsLinkedList.unscale()]
+            .content
+            .len();
+        let storage_len = Segment::StorageLinkedList as usize
+            + interpreter.generation_state.memory.contexts[0].segments
+                [Segment::StorageLinkedList.unscale()]
+            .content
+            .len();
+        let accounts_len_addr = MemoryAddress {
+            context: 0,
+            segment: Segment::GlobalMetadata.unscale(),
+            virt: GlobalMetadata::AccountsLinkedListNextAvailable.unscale(),
+        };
+        let storage_len_addr = MemoryAddress {
+            context: 0,
+            segment: Segment::GlobalMetadata.unscale(),
+            virt: GlobalMetadata::StorageLinkedListNextAvailable.unscale(),
+        };
+        let initial_accounts_len_addr = MemoryAddress {
+            context: 0,
+            segment: Segment::GlobalMetadata.unscale(),
+            virt: GlobalMetadata::InitialAccountsLinkedListLen.unscale(),
+        };
+        let initial_storage_len_addr = MemoryAddress {
+            context: 0,
+            segment: Segment::GlobalMetadata.unscale(),
+            virt: GlobalMetadata::InitialStorageLinkedListLen.unscale(),
+        };
+        let trie_data_len_addr = MemoryAddress {
+            context: 0,
+            segment: Segment::GlobalMetadata.unscale(),
+            virt: GlobalMetadata::TrieDataSize.unscale(),
+        };
+        let trie_data_len = interpreter.generation_state.memory.contexts[0].segments
+            [Segment::TrieData.unscale()]
         .content
         .len();
-    let accounts_len_addr = MemoryAddress {
-        context: 0,
-        segment: Segment::GlobalMetadata.unscale(),
-        virt: GlobalMetadata::AccountsLinkedListNextAvailable.unscale(),
-    };
-    let storage_len_addr = MemoryAddress {
-        context: 0,
-        segment: Segment::GlobalMetadata.unscale(),
-        virt: GlobalMetadata::StorageLinkedListNextAvailable.unscale(),
-    };
-    let initial_accounts_len_addr = MemoryAddress {
-        context: 0,
-        segment: Segment::GlobalMetadata.unscale(),
-        virt: GlobalMetadata::InitialAccountsLinkedListLen.unscale(),
-    };
-    let initial_storage_len_addr = MemoryAddress {
-        context: 0,
-        segment: Segment::GlobalMetadata.unscale(),
-        virt: GlobalMetadata::InitialStorageLinkedListLen.unscale(),
-    };
-    let trie_data_len_addr = MemoryAddress {
-        context: 0,
-        segment: Segment::GlobalMetadata.unscale(),
-        virt: GlobalMetadata::TrieDataSize.unscale(),
-    };
-    let trie_data_len = interpreter.generation_state.memory.contexts[0].segments
-        [Segment::TrieData.unscale()]
-    .content
-    .len();
-    interpreter.set_memory_multi_addresses(&[
-        (accounts_len_addr, accounts_len.into()),
-        (storage_len_addr, storage_len.into()),
-        (trie_data_len_addr, trie_data_len.into()),
-        (initial_accounts_len_addr, accounts_len.into()),
-        (initial_storage_len_addr, storage_len.into()),
-    ]);
+        interpreter.set_memory_multi_addresses(&[
+            (accounts_len_addr, accounts_len.into()),
+            (storage_len_addr, storage_len.into()),
+            (trie_data_len_addr, trie_data_len.into()),
+            (initial_accounts_len_addr, accounts_len.into()),
+            (initial_storage_len_addr, storage_len.into()),
+        ]);
 
-    let state_addr =
-        MemoryAddress::new_bundle((GlobalMetadata::StateTrieRoot as usize).into()).unwrap();
-    let txn_addr =
-        MemoryAddress::new_bundle((GlobalMetadata::TransactionTrieRoot as usize).into()).unwrap();
-    let receipts_addr =
-        MemoryAddress::new_bundle((GlobalMetadata::ReceiptTrieRoot as usize).into()).unwrap();
+        let state_addr =
+            MemoryAddress::new_bundle((GlobalMetadata::StateTrieRoot as usize).into()).unwrap();
+        let txn_addr =
+            MemoryAddress::new_bundle((GlobalMetadata::TransactionTrieRoot as usize).into())
+                .unwrap();
+        let receipts_addr =
+            MemoryAddress::new_bundle((GlobalMetadata::ReceiptTrieRoot as usize).into()).unwrap();
 
-    let mut to_set = vec![];
-    if let Some(state_root_ptr) = trie_root_ptrs.state_root_ptr {
-        to_set.push((state_addr, state_root_ptr.into()));
-    }
-    to_set.extend([
-        (txn_addr, trie_root_ptrs.txn_root_ptr.into()),
-        (receipts_addr, trie_root_ptrs.receipt_root_ptr.into()),
-    ]);
+        let mut to_set = vec![];
+        if let Some(state_root_ptr) = trie_root_ptrs.state_root_ptr {
+            to_set.push((state_addr, state_root_ptr.into()));
+        }
+        to_set.extend([
+            (txn_addr, trie_root_ptrs.txn_root_ptr.into()),
+            (receipts_addr, trie_root_ptrs.receipt_root_ptr.into()),
+        ]);
 
-    interpreter.set_memory_multi_addresses(&to_set);
+        interpreter.set_memory_multi_addresses(&to_set);
 
-    for (i, data) in trie_data.iter().enumerate() {
-        let trie_addr = MemoryAddress::new(0, Segment::TrieData, i);
-        interpreter
-            .generation_state
-            .memory
-            .set(trie_addr, data.unwrap_or_default());
+        for (i, data) in trie_data.iter().enumerate() {
+            let trie_addr = MemoryAddress::new(0, Segment::TrieData, i);
+            interpreter
+                .generation_state
+                .memory
+                .set(trie_addr, data.unwrap_or_default());
+        }
     }
 }
 
@@ -144,12 +152,7 @@ pub(crate) fn prepare_interpreter<F: RichField>(
     let mpt_insert_state_trie = KERNEL.global_labels["mpt_insert_state_trie"];
     let check_state_trie = KERNEL.global_labels["check_final_state_trie"];
     let mut state_trie: HashedPartialTrie = HashedPartialTrie::from(Node::Empty);
-    let trie_inputs = TrieInputs {
-        state_trie: HashedPartialTrie::from(Node::Empty),
-        transactions_trie: HashedPartialTrie::from(Node::Empty),
-        receipts_trie: HashedPartialTrie::from(Node::Empty),
-        storage_tries: vec![],
-    };
+    let trie_inputs = TrieInputs::default();
 
     initialize_mpts(interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);

--- a/evm_arithmetization/src/cpu/kernel/tests/mod.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mod.rs
@@ -1,6 +1,8 @@
+#[cfg(not(feature = "cdk_erigon"))]
 mod account_code;
 #[cfg(feature = "eth_mainnet")]
 mod add11;
+#[cfg(not(feature = "cdk_erigon"))]
 mod balance;
 mod bignum;
 mod blake2_f;
@@ -14,12 +16,15 @@ mod core;
 mod ecc;
 mod exp;
 mod hash;
+#[cfg(not(feature = "cdk_erigon"))]
 mod init_exc_stop;
 mod kernel_consistency;
 mod log;
 mod mcopy;
+#[cfg(not(feature = "cdk_erigon"))]
 mod mpt;
 mod packing;
+#[cfg(not(feature = "cdk_erigon"))]
 mod receipt;
 mod rlp;
 mod signed_syscalls;

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/load.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/load.rs
@@ -8,7 +8,7 @@ use mpt_trie::partial_trie::HashedPartialTrie;
 use plonky2::field::goldilocks_field::GoldilocksField as F;
 
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
-use crate::cpu::kernel::constants::trie_type::PartialTrieType;
+use crate::cpu::kernel::constants::mpt_type::PartialMptType;
 use crate::cpu::kernel::interpreter::Interpreter;
 use crate::cpu::kernel::tests::account_code::initialize_mpts;
 use crate::cpu::kernel::tests::mpt::{extension_to_leaf, test_account_1, test_account_1_rlp};
@@ -66,7 +66,7 @@ fn load_all_mpts_leaf() -> Result<()> {
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
-    let type_leaf = U256::from(PartialTrieType::Leaf as u32);
+    let type_leaf = U256::from(PartialMptType::Leaf as u32);
     assert_eq!(
         interpreter.get_trie_data(),
         vec![
@@ -86,7 +86,7 @@ fn load_all_mpts_leaf() -> Result<()> {
             13.into(), // pointer to storage trie root
             test_account_1().code_hash.into_uint(),
             // These last two elements encode the storage trie, which is a hash node.
-            (PartialTrieType::Hash as u32).into(),
+            (PartialMptType::Hash as u32).into(),
             test_account_1().storage_root.into_uint(),
         ]
     );
@@ -118,7 +118,7 @@ fn load_all_mpts_hash() -> Result<()> {
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
-    let type_hash = U256::from(PartialTrieType::Hash as u32);
+    let type_hash = U256::from(PartialMptType::Hash as u32);
     assert_eq!(
         interpreter.get_trie_data(),
         vec![0.into(), type_hash, hash.into_uint(),]
@@ -156,7 +156,7 @@ fn load_all_mpts_empty_branch() -> Result<()> {
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
-    let type_branch = U256::from(PartialTrieType::Branch as u32);
+    let type_branch = U256::from(PartialMptType::Branch as u32);
     assert_eq!(
         interpreter.get_trie_data(),
         vec![
@@ -208,8 +208,8 @@ fn load_all_mpts_ext_to_leaf() -> Result<()> {
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
-    let type_extension = U256::from(PartialTrieType::Extension as u32);
-    let type_leaf = U256::from(PartialTrieType::Leaf as u32);
+    let type_extension = U256::from(PartialMptType::Extension as u32);
+    let type_leaf = U256::from(PartialMptType::Leaf as u32);
     assert_eq!(
         interpreter.get_trie_data(),
         vec![
@@ -233,7 +233,7 @@ fn load_all_mpts_ext_to_leaf() -> Result<()> {
             17.into(), // pointer to storage trie root
             test_account_1().code_hash.into_uint(),
             // These last two elements encode the storage trie, which is a hash node.
-            (PartialTrieType::Hash as u32).into(),
+            (PartialMptType::Hash as u32).into(),
             test_account_1().storage_root.into_uint(),
         ]
     );
@@ -262,7 +262,7 @@ fn load_mpt_txn_trie() -> Result<()> {
 
     let mut expected_trie_data = vec![
         0.into(),
-        U256::from(PartialTrieType::Leaf as u32),
+        U256::from(PartialMptType::Leaf as u32),
         2.into(),
         128.into(), // Nibble
         5.into(),   // value_ptr

--- a/evm_arithmetization/src/generation/prover_input.rs
+++ b/evm_arithmetization/src/generation/prover_input.rs
@@ -15,6 +15,7 @@ use super::linked_list::testing::{LinkedList, ADDRESSES_ACCESS_LIST_LEN};
 use super::linked_list::{
     LinkedListsPtrs, ACCOUNTS_LINKED_LIST_NODE_SIZE, DUMMYHEAD, STORAGE_LINKED_LIST_NODE_SIZE,
 };
+#[cfg(not(feature = "cdk_erigon"))]
 use super::mpt::load_state_mpt;
 use crate::cpu::kernel::cancun_constants::KZG_VERSIONED_HASH;
 use crate::cpu::kernel::constants::cancun_constants::{
@@ -92,6 +93,7 @@ impl<F: RichField> GenerationState<F> {
     fn run_trie_ptr(&mut self, input_fn: &ProverInputFn) -> Result<U256, ProgramError> {
         let trie = input_fn.0[1].as_str();
         match trie {
+            #[cfg(not(feature = "cdk_erigon"))]
             "initial_state" => self
                 .trie_root_ptrs
                 .state_root_ptr
@@ -112,6 +114,8 @@ impl<F: RichField> GenerationState<F> {
                     Ok,
                 )
                 .map(U256::from),
+            #[cfg(feature = "cdk_erigon")]
+            "initial_state" => unimplemented!(),
             "txn" => Ok(U256::from(self.trie_root_ptrs.txn_root_ptr)),
             "receipt" => Ok(U256::from(self.trie_root_ptrs.receipt_root_ptr)),
             "trie_data_size" => Ok(self

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -390,33 +390,37 @@ impl<F: RichField> GenerationState<F> {
         &mut self,
         trie_inputs: &TrieInputs,
     ) -> TrieRootPtrs {
-        let generation_state = self.get_mut_generation_state();
-        let (trie_roots_ptrs, state_leaves, storage_leaves, trie_data) =
-            load_linked_lists_and_txn_and_receipt_mpts(
-                &mut generation_state.state_ptrs.accounts,
-                &mut generation_state.state_ptrs.storage,
-                trie_inputs,
-            )
-            .expect("Invalid MPT data for preinitialization");
+        if cfg!(feature = "cdk_erigon") {
+            unimplemented!()
+        } else {
+            let generation_state = self.get_mut_generation_state();
+            let (trie_roots_ptrs, state_leaves, storage_leaves, trie_data) =
+                load_linked_lists_and_txn_and_receipt_mpts(
+                    &mut generation_state.state_ptrs.accounts,
+                    &mut generation_state.state_ptrs.storage,
+                    trie_inputs,
+                )
+                .expect("Invalid MPT data for preinitialization");
 
-        self.memory.insert_preinitialized_segment(
-            Segment::AccountsLinkedList,
-            crate::witness::memory::MemorySegmentState {
-                content: state_leaves,
-            },
-        );
-        self.memory.insert_preinitialized_segment(
-            Segment::StorageLinkedList,
-            crate::witness::memory::MemorySegmentState {
-                content: storage_leaves,
-            },
-        );
-        self.memory.insert_preinitialized_segment(
-            Segment::TrieData,
-            crate::witness::memory::MemorySegmentState { content: trie_data },
-        );
+            self.memory.insert_preinitialized_segment(
+                Segment::AccountsLinkedList,
+                crate::witness::memory::MemorySegmentState {
+                    content: state_leaves,
+                },
+            );
+            self.memory.insert_preinitialized_segment(
+                Segment::StorageLinkedList,
+                crate::witness::memory::MemorySegmentState {
+                    content: storage_leaves,
+                },
+            );
+            self.memory.insert_preinitialized_segment(
+                Segment::TrieData,
+                crate::witness::memory::MemorySegmentState { content: trie_data },
+            );
 
-        trie_roots_ptrs
+            trie_roots_ptrs
+        }
     }
 
     pub(crate) fn new(

--- a/evm_arithmetization/src/memory/segments.rs
+++ b/evm_arithmetization/src/memory/segments.rs
@@ -86,6 +86,8 @@ pub(crate) enum Segment {
     CreatedContracts = 37 << SEGMENT_SCALING_FACTOR,
     /// Blob versioned hashes specified in a type-3 transaction.
     TxnBlobVersionedHashes = 38 << SEGMENT_SCALING_FACTOR,
+    /// List of used storage slots in newly created contracts.
+    NewStorageSlots = 39 << SEGMENT_SCALING_FACTOR,
 }
 
 // These segments are not zero-initialized.
@@ -97,7 +99,7 @@ pub(crate) const PREINITIALIZED_SEGMENTS_INDICES: [usize; 4] = [
 ];
 
 impl Segment {
-    pub(crate) const COUNT: usize = 39;
+    pub(crate) const COUNT: usize = 40;
 
     /// Unscales this segment by `SEGMENT_SCALING_FACTOR`.
     pub(crate) const fn unscale(&self) -> usize {
@@ -145,6 +147,7 @@ impl Segment {
             Self::TransientStorage,
             Self::CreatedContracts,
             Self::TxnBlobVersionedHashes,
+            Self::NewStorageSlots,
         ]
     }
 
@@ -190,6 +193,7 @@ impl Segment {
             Segment::TransientStorage => "SEGMENT_TRANSIENT_STORAGE",
             Segment::CreatedContracts => "SEGMENT_CREATED_CONTRACTS",
             Segment::TxnBlobVersionedHashes => "SEGMENT_TXN_BLOB_VERSIONED_HASHES",
+            Segment::NewStorageSlots => "SEGMENT_NEW_STORAGE_SLOTS",
         }
     }
 
@@ -234,6 +238,7 @@ impl Segment {
             Segment::TransientStorage => 256,
             Segment::CreatedContracts => 256,
             Segment::TxnBlobVersionedHashes => 256,
+            Segment::NewStorageSlots => 256,
         }
     }
 }

--- a/evm_arithmetization/src/testing_utils.rs
+++ b/evm_arithmetization/src/testing_utils.rs
@@ -1,18 +1,29 @@
 //! A set of utility functions and constants to be used by `evm_arithmetization`
 //! unit and integration tests.
 
+use std::collections::HashMap;
+
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
-use ethereum_types::{BigEndianHash, H256, U256};
+use ethereum_types::{Address, BigEndianHash, H160, H256, U256};
 use hex_literal::hex;
 use keccak_hash::keccak;
 use mpt_trie::{
     nibbles::Nibbles,
     partial_trie::{HashedPartialTrie, Node, PartialTrie},
 };
+use smt_trie::{
+    db::{Db, MemoryDb},
+    keys::{key_balance, key_code, key_code_length, key_nonce, key_storage},
+    smt::Smt,
+};
 
 pub use crate::cpu::kernel::cancun_constants::*;
 pub use crate::cpu::kernel::constants::global_exit_root::*;
-use crate::{generation::mpt::AccountRlp, proof::BlockMetadata, util::h2u};
+use crate::{
+    generation::mpt::{AccountRlp, Type1AccountRlp, Type2AccountRlp},
+    proof::BlockMetadata,
+    util::h2u,
+};
 
 pub const EMPTY_NODE_HASH: H256 = H256(hex!(
     "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
@@ -32,8 +43,8 @@ pub fn sh2u(s: &str) -> U256 {
     U256::from_str_radix(s, 16).unwrap()
 }
 
-/// Inserts a new pair `(slot, value)` into the provided storage trie.
-fn insert_storage(trie: &mut HashedPartialTrie, slot: U256, value: U256) -> anyhow::Result<()> {
+/// Inserts a new pair `(slot, value)` into the provided storage MPT.
+fn insert_storage_mpt(trie: &mut HashedPartialTrie, slot: U256, value: U256) -> anyhow::Result<()> {
     let mut bytes = [0; 32];
     slot.to_big_endian(&mut bytes);
     let key = keccak(bytes);
@@ -47,12 +58,17 @@ fn insert_storage(trie: &mut HashedPartialTrie, slot: U256, value: U256) -> anyh
     Ok(())
 }
 
-/// Creates a storage trie for an account, given a list of `(slot, value)`
+/// Inserts a new pair `(slot, value)` into the provided state SMT.
+fn insert_storage_smt<D: Db>(smt: &mut Smt<D>, addr: Address, slot: U256, value: U256) {
+    smt.set(key_storage(addr, slot), value);
+}
+
+/// Creates a storage MPT for an account, given a list of `(slot, value)`
 /// pairs.
 pub fn create_account_storage(storage_pairs: &[(U256, U256)]) -> anyhow::Result<HashedPartialTrie> {
     let mut trie = HashedPartialTrie::from(Node::Empty);
     for (slot, value) in storage_pairs {
-        insert_storage(&mut trie, *slot, *value)?;
+        insert_storage_mpt(&mut trie, *slot, *value)?;
     }
     Ok(trie)
 }
@@ -67,21 +83,21 @@ pub fn update_beacon_roots_account_storage(
     let timestamp_idx = timestamp % HISTORY_BUFFER_LENGTH.value;
     let root_idx = timestamp_idx + HISTORY_BUFFER_LENGTH.value;
 
-    insert_storage(storage_trie, timestamp_idx, timestamp)?;
-    insert_storage(storage_trie, root_idx, h2u(parent_root))
+    insert_storage_mpt(storage_trie, timestamp_idx, timestamp)?;
+    insert_storage_mpt(storage_trie, root_idx, h2u(parent_root))
 }
 
 /// Returns the beacon roots contract account from its provided storage trie.
-pub fn beacon_roots_contract_from_storage(storage_trie: &HashedPartialTrie) -> AccountRlp {
-    AccountRlp {
+pub fn beacon_roots_contract_from_storage(storage_trie: &HashedPartialTrie) -> Type1AccountRlp {
+    Type1AccountRlp {
         storage_root: storage_trie.hash(),
         ..BEACON_ROOTS_ACCOUNT
     }
 }
 
-/// Returns an initial state trie containing the beacon roots and global exit
-/// roots contracts, along with their storage tries.
-pub fn preinitialized_state_and_storage_tries(
+/// Returns an initial state trie containing the beacon roots contract, along
+/// with its storage trie.
+pub fn preinitialized_state_mpt_and_beacon_roots(
 ) -> anyhow::Result<(HashedPartialTrie, Vec<(H256, HashedPartialTrie)>)> {
     let mut state_trie = HashedPartialTrie::from(Node::Empty);
     state_trie.insert(
@@ -94,6 +110,32 @@ pub fn preinitialized_state_and_storage_tries(
     Ok((state_trie, storage_tries))
 }
 
+/// Returns an initial state SMT containing the global exit
+/// roots contract.
+#[cfg(feature = "cdk_erigon")]
+pub fn preinitialized_state_smt_ger() -> Smt<MemoryDb> {
+    let mut smt = Smt::<MemoryDb>::default();
+    set_global_exit_root_account(&mut smt, &HashMap::new());
+
+    smt
+}
+
+/// Returns a final state trie containing the global exit
+/// roots contracts, with its updated storage.
+pub fn preinitialized_state_with_updated_storage(
+    global_exit_roots: &[(U256, H256)],
+) -> Smt<MemoryDb> {
+    let mut smt = Smt::<MemoryDb>::default();
+
+    let mut storage = HashMap::new();
+    for &(timestamp, root) in global_exit_roots {
+        storage.insert(ger_storage_slot(root), timestamp);
+    }
+    set_global_exit_root_account(&mut smt, &storage);
+
+    smt
+}
+
 /// Returns the `Nibbles` corresponding to the beacon roots contract account.
 pub fn beacon_roots_account_nibbles() -> Nibbles {
     Nibbles::from_bytes_be(BEACON_ROOTS_CONTRACT_ADDRESS_HASHED.as_bytes()).unwrap()
@@ -104,60 +146,97 @@ pub fn ger_account_nibbles() -> Nibbles {
     Nibbles::from_bytes_be(GLOBAL_EXIT_ROOT_ADDRESS_HASHED.as_bytes()).unwrap()
 }
 
-pub fn update_ger_account_storage(
-    storage_trie: &mut HashedPartialTrie,
-    ger_data: Option<(H256, H256)>,
-) -> anyhow::Result<()> {
-    if let Some((root, l1blockhash)) = ger_data {
-        let mut arr = [0; 64];
-        arr[0..32].copy_from_slice(&root.0);
-        U256::from(GLOBAL_EXIT_ROOT_STORAGE_POS.1).to_big_endian(&mut arr[32..64]);
-        let slot = keccak(arr);
-        insert_storage(storage_trie, slot.into_uint(), h2u(l1blockhash))?
-    }
-
-    Ok(())
+fn ger_storage_slot(root: H256) -> U256 {
+    let mut arr = [0; 64];
+    arr[0..32].copy_from_slice(&root.0);
+    U256::from(GLOBAL_EXIT_ROOT_STORAGE_POS.1).to_big_endian(&mut arr[32..64]);
+    let slot = keccak(arr);
+    h2u(slot)
 }
 
-/// Returns the `Nibbles` corresponding to the 5ca1ab1e contract account.
+#[cfg(feature = "cdk_erigon")]
+pub fn update_ger_account_storage(state_smt: &mut Smt<MemoryDb>, root: H256, timestamp: U256) {
+    insert_storage_smt(
+        state_smt,
+        H160(GLOBAL_EXIT_ROOT_MANAGER_L2.1),
+        ger_storage_slot(root),
+        timestamp,
+    );
+}
+
+/// Returns the `Nibbles` corresponding to the sca1ab1e contract account.
 pub fn scalable_account_nibbles() -> Nibbles {
     Nibbles::from_bytes_be(ADDRESS_SCALABLE_L2_ADDRESS_HASHED.as_bytes()).unwrap()
 }
 
 /// Note: This *will* overwrite the timestamp stored at the contract address.
 pub fn update_scalable_account_storage(
-    storage_trie: &mut HashedPartialTrie,
+    state_smt: &mut Smt<MemoryDb>,
     block: &BlockMetadata,
     initial_trie_hash: H256,
-) -> anyhow::Result<()> {
-    insert_storage(
-        storage_trie,
+) {
+    insert_storage_smt(
+        state_smt,
+        ADDRESS_SCALABLE_L2,
         U256::from(LAST_BLOCK_STORAGE_POS.1),
         block.block_number,
-    )?;
-    insert_storage(
-        storage_trie,
+    );
+    insert_storage_smt(
+        state_smt,
+        ADDRESS_SCALABLE_L2,
         U256::from(TIMESTAMP_STORAGE_POS.1),
         block.block_timestamp,
-    )?;
+    );
 
     let mut arr = [0; 64];
     (block.block_number - U256::one()).to_big_endian(&mut arr[0..32]);
     U256::from(STATE_ROOT_STORAGE_POS.1).to_big_endian(&mut arr[32..64]);
     let slot = keccak(arr);
-    insert_storage(storage_trie, slot.into_uint(), h2u(initial_trie_hash))
+    insert_storage_smt(
+        state_smt,
+        ADDRESS_SCALABLE_L2,
+        slot.into_uint(),
+        h2u(initial_trie_hash),
+    );
 }
 
-pub fn ger_contract_from_storage(storage_trie: &HashedPartialTrie) -> AccountRlp {
-    AccountRlp {
-        storage_root: storage_trie.hash(),
-        ..GLOBAL_EXIT_ROOT_ACCOUNT
+/// Converts an amount in `ETH` to `wei` units.
+pub fn eth_to_wei(eth: U256) -> U256 {
+    // 1 ether = 10^18 wei.
+    eth * U256::from(10).pow(18.into())
+}
+
+pub fn set_account<D: Db>(
+    smt: &mut Smt<D>,
+    addr: Address,
+    account: &Type2AccountRlp,
+    storage: &HashMap<U256, U256>,
+) {
+    smt.set(key_balance(addr), account.balance);
+    smt.set(key_nonce(addr), account.nonce);
+    smt.set(key_code(addr), h2u(account.code_hash));
+    smt.set(key_code_length(addr), account.code_length);
+    for (&k, &v) in storage {
+        smt.set(key_storage(addr, k), v);
     }
 }
 
-pub fn scalable_contract_from_storage(storage_trie: &HashedPartialTrie) -> AccountRlp {
-    AccountRlp {
-        storage_root: storage_trie.hash(),
-        ..Default::default()
-    }
+#[cfg(feature = "eth_mainnet")]
+pub fn set_beacon_roots_account<D: Db>(smt: &mut Smt<D>, storage: &HashMap<U256, U256>) {
+    set_account(
+        smt,
+        H160(BEACON_ROOTS_CONTRACT_STATE_KEY.1),
+        &beacon_roots_account(),
+        storage,
+    );
+}
+
+#[cfg(feature = "cdk_erigon")]
+pub fn set_global_exit_root_account<D: Db>(smt: &mut Smt<D>, storage: &HashMap<U256, U256>) {
+    set_account(
+        smt,
+        H160(GLOBAL_EXIT_ROOT_MANAGER_L2.1),
+        &global_exit_root_account(),
+        storage,
+    );
 }

--- a/evm_arithmetization/src/util.rs
+++ b/evm_arithmetization/src/util.rs
@@ -210,7 +210,7 @@ pub(crate) fn biguint_to_mem_vec(x: BigUint) -> Vec<U256> {
     mem_vec
 }
 
-pub(crate) fn h2u(h: H256) -> U256 {
+pub fn h2u(h: H256) -> U256 {
     U256::from_big_endian(&h.0)
 }
 

--- a/evm_arithmetization/tests/erc20.rs
+++ b/evm_arithmetization/tests/erc20.rs
@@ -1,17 +1,19 @@
-#![cfg(feature = "eth_mainnet")]
+#![cfg(feature = "cdk_erigon")]
 
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::Duration;
 
 use ethereum_types::{Address, BigEndianHash, H160, H256, U256};
-use evm_arithmetization::generation::mpt::{AccountRlp, LegacyReceiptRlp, LogRlp};
-use evm_arithmetization::generation::{GenerationInputs, TrieInputs};
+use evm_arithmetization::generation::mpt::{AccountRlp, LegacyReceiptRlp, LogRlp, Type2AccountRlp};
+use evm_arithmetization::generation::{GenerationInputs, InputStateTrie, TrieInputs};
 use evm_arithmetization::proof::{BlockHashes, BlockMetadata, TrieRoots};
+use evm_arithmetization::prover::prove;
 use evm_arithmetization::prover::testing::prove_all_segments;
 use evm_arithmetization::testing_utils::{
-    beacon_roots_account_nibbles, beacon_roots_contract_from_storage, create_account_storage,
-    init_logger, preinitialized_state_and_storage_tries, sd2u, update_beacon_roots_account_storage,
+    init_logger, preinitialized_state_smt_ger, preinitialized_state_with_updated_storage, sd2u,
 };
+use evm_arithmetization::util::h2u;
 use evm_arithmetization::verifier::testing::verify_all_proofs;
 use evm_arithmetization::{AllStark, Node, StarkConfig, EMPTY_CONSOLIDATED_BLOCKHASH};
 use hex_literal::hex;
@@ -22,6 +24,11 @@ use plonky2::field::goldilocks_field::GoldilocksField;
 use plonky2::field::types::Field;
 use plonky2::plonk::config::KeccakGoldilocksConfig;
 use plonky2::util::timing::TimingTree;
+use smt_trie::code::hash_bytecode_u256;
+use smt_trie::db::{Db, MemoryDb};
+use smt_trie::keys::{key_balance, key_code, key_code_length, key_nonce, key_storage};
+use smt_trie::smt::Smt;
+use smt_trie::utils::hashout2u;
 
 type F = GoldilocksField;
 const D: usize = 2;
@@ -59,30 +66,31 @@ fn test_erc20() -> anyhow::Result<()> {
     let giver = hex!("e7f1725E7734CE288F8367e1Bb143E90bb3F0512");
     let token = hex!("5FbDB2315678afecb367f032d93F642f64180aa3");
 
-    let sender_state_key = keccak(sender);
-    let giver_state_key = keccak(giver);
-    let token_state_key = keccak(token);
-
-    let sender_nibbles = Nibbles::from_bytes_be(sender_state_key.as_bytes()).unwrap();
-    let giver_nibbles = Nibbles::from_bytes_be(giver_state_key.as_bytes()).unwrap();
-    let token_nibbles = Nibbles::from_bytes_be(token_state_key.as_bytes()).unwrap();
-
-    let (mut state_trie_before, mut storage_tries) = preinitialized_state_and_storage_tries()?;
-    let mut beacon_roots_account_storage = storage_tries[0].1.clone();
-    state_trie_before.insert(sender_nibbles, rlp::encode(&sender_account()).to_vec())?;
-    state_trie_before.insert(giver_nibbles, rlp::encode(&giver_account()?).to_vec())?;
-    state_trie_before.insert(token_nibbles, rlp::encode(&token_account()?).to_vec())?;
-
-    storage_tries.extend([
-        (giver_state_key, giver_storage()?),
-        (token_state_key, token_storage()?),
-    ]);
+    let mut state_smt_before = preinitialized_state_smt_ger();
+    set_account(
+        &mut state_smt_before,
+        H160(sender),
+        &sender_account(),
+        &HashMap::new(),
+    );
+    set_account(
+        &mut state_smt_before,
+        H160(giver),
+        &giver_account(),
+        &giver_storage(),
+    );
+    set_account(
+        &mut state_smt_before,
+        H160(token),
+        &token_account(),
+        &token_storage(),
+    );
 
     let tries_before = TrieInputs {
-        state_trie: state_trie_before,
+        state_trie: InputStateTrie::Type2(state_smt_before.serialize()),
         transactions_trie: HashedPartialTrie::from(Node::Empty),
         receipts_trie: HashedPartialTrie::from(Node::Empty),
-        storage_tries,
+        storage_tries: None,
     };
 
     let txn = signed_tx();
@@ -107,35 +115,29 @@ fn test_erc20() -> anyhow::Result<()> {
         .map(|v| (keccak(v.clone()), v))
         .into();
 
-    let expected_state_trie_after: HashedPartialTrie = {
-        update_beacon_roots_account_storage(
-            &mut beacon_roots_account_storage,
-            block_metadata.block_timestamp,
-            block_metadata.parent_beacon_block_root,
-        )?;
-        let beacon_roots_account =
-            beacon_roots_contract_from_storage(&beacon_roots_account_storage);
-
-        let mut state_trie_after = HashedPartialTrie::from(Node::Empty);
+    let expected_smt_after: Smt<MemoryDb> = {
+        let mut smt = preinitialized_state_with_updated_storage(&[]);
         let sender_account = sender_account();
-        let sender_account_after = AccountRlp {
+        let sender_account_after = Type2AccountRlp {
             nonce: sender_account.nonce + 1,
             balance: sender_account.balance - gas_used * 0xa,
             ..sender_account
         };
-        state_trie_after.insert(sender_nibbles, rlp::encode(&sender_account_after).to_vec())?;
-        state_trie_after.insert(giver_nibbles, rlp::encode(&giver_account()?).to_vec())?;
-        let token_account_after = AccountRlp {
-            storage_root: token_storage_after()?.hash(),
-            ..token_account()?
-        };
-        state_trie_after.insert(token_nibbles, rlp::encode(&token_account_after).to_vec())?;
-        state_trie_after.insert(
-            beacon_roots_account_nibbles(),
-            rlp::encode(&beacon_roots_account).to_vec(),
-        )?;
+        set_account(
+            &mut smt,
+            H160(sender),
+            &sender_account_after,
+            &HashMap::new(),
+        );
+        set_account(&mut smt, H160(giver), &giver_account(), &giver_storage());
+        set_account(
+            &mut smt,
+            H160(token),
+            &token_account(),
+            &token_storage_after(),
+        );
 
-        state_trie_after
+        smt
     };
 
     let receipt_0 = LegacyReceiptRlp {
@@ -172,7 +174,7 @@ fn test_erc20() -> anyhow::Result<()> {
     .into();
 
     let trie_roots_after = TrieRoots {
-        state_root: expected_state_trie_after.hash(),
+        state_root: H256::from_uint(&hashout2u(expected_smt_after.root)),
         transactions_root: transactions_trie.hash(),
         receipts_root: receipts_trie.hash(),
     };
@@ -181,7 +183,6 @@ fn test_erc20() -> anyhow::Result<()> {
         signed_txns: vec![txn.to_vec()],
         burn_addr: None,
         withdrawals: vec![],
-        ger_data: None,
         tries: tries_before,
         trie_roots_after,
         contract_code,
@@ -195,11 +196,11 @@ fn test_erc20() -> anyhow::Result<()> {
             prev_hashes: vec![H256::default(); 256],
             cur_hash: H256::default(),
         },
+        ger_data: Some((H256::random(), H256::random())),
     };
 
     let max_cpu_len_log = 20;
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-
     let proofs = prove_all_segments::<F, C, D>(
         &all_stark,
         &config,
@@ -208,7 +209,6 @@ fn test_erc20() -> anyhow::Result<()> {
         &mut timing,
         None,
     )?;
-
     timing.filter(Duration::from_millis(100)).print();
 
     verify_all_proofs(&all_stark, &proofs, &config)
@@ -222,57 +222,64 @@ fn token_bytecode() -> Vec<u8> {
     hex!("608060405234801561001057600080fd5b50600436106100935760003560e01c8063313ce56711610066578063313ce567146100fe57806370a082311461010d57806395d89b4114610136578063a9059cbb1461013e578063dd62ed3e1461015157600080fd5b806306fdde0314610098578063095ea7b3146100b657806318160ddd146100d957806323b872dd146100eb575b600080fd5b6100a061018a565b6040516100ad919061056a565b60405180910390f35b6100c96100c43660046105d4565b61021c565b60405190151581526020016100ad565b6002545b6040519081526020016100ad565b6100c96100f93660046105fe565b610236565b604051601281526020016100ad565b6100dd61011b36600461063a565b6001600160a01b031660009081526020819052604090205490565b6100a061025a565b6100c961014c3660046105d4565b610269565b6100dd61015f36600461065c565b6001600160a01b03918216600090815260016020908152604080832093909416825291909152205490565b6060600380546101999061068f565b80601f01602080910402602001604051908101604052809291908181526020018280546101c59061068f565b80156102125780601f106101e757610100808354040283529160200191610212565b820191906000526020600020905b8154815290600101906020018083116101f557829003601f168201915b5050505050905090565b60003361022a818585610277565b60019150505b92915050565b600033610244858285610289565b61024f85858561030c565b506001949350505050565b6060600480546101999061068f565b60003361022a81858561030c565b610284838383600161036b565b505050565b6001600160a01b03838116600090815260016020908152604080832093861683529290522054600019811461030657818110156102f757604051637dc7a0d960e11b81526001600160a01b038416600482015260248101829052604481018390526064015b60405180910390fd5b6103068484848403600061036b565b50505050565b6001600160a01b03831661033657604051634b637e8f60e11b8152600060048201526024016102ee565b6001600160a01b0382166103605760405163ec442f0560e01b8152600060048201526024016102ee565b610284838383610440565b6001600160a01b0384166103955760405163e602df0560e01b8152600060048201526024016102ee565b6001600160a01b0383166103bf57604051634a1406b160e11b8152600060048201526024016102ee565b6001600160a01b038085166000908152600160209081526040808320938716835292905220829055801561030657826001600160a01b0316846001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b9258460405161043291815260200190565b60405180910390a350505050565b6001600160a01b03831661046b57806002600082825461046091906106c9565b909155506104dd9050565b6001600160a01b038316600090815260208190526040902054818110156104be5760405163391434e360e21b81526001600160a01b038516600482015260248101829052604481018390526064016102ee565b6001600160a01b03841660009081526020819052604090209082900390555b6001600160a01b0382166104f957600280548290039055610518565b6001600160a01b03821660009081526020819052604090208054820190555b816001600160a01b0316836001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8360405161055d91815260200190565b60405180910390a3505050565b600060208083528351808285015260005b818110156105975785810183015185820160400152820161057b565b506000604082860101526040601f19601f8301168501019250505092915050565b80356001600160a01b03811681146105cf57600080fd5b919050565b600080604083850312156105e757600080fd5b6105f0836105b8565b946020939093013593505050565b60008060006060848603121561061357600080fd5b61061c846105b8565b925061062a602085016105b8565b9150604084013590509250925092565b60006020828403121561064c57600080fd5b610655826105b8565b9392505050565b6000806040838503121561066f57600080fd5b610678836105b8565b9150610686602084016105b8565b90509250929050565b600181811c908216806106a357607f821691505b6020821081036106c357634e487b7160e01b600052602260045260246000fd5b50919050565b8082018082111561023057634e487b7160e01b600052601160045260246000fdfea2646970667358221220266a323ae4a816f6c6342a5be431fedcc0d45c44b02ea75f5474eb450b5d45b364736f6c63430008140033").into()
 }
 
-fn giver_storage() -> anyhow::Result<HashedPartialTrie> {
-    create_account_storage(&[(
+fn giver_storage() -> HashMap<U256, U256> {
+    let mut storage = HashMap::new();
+    storage.insert(
         U256::zero(),
         sd2u("546584486846459126461364135121053344201067465379"),
-    )])
+    );
+    storage
 }
 
-fn token_storage() -> anyhow::Result<HashedPartialTrie> {
-    create_account_storage(&[(
+fn token_storage() -> HashMap<U256, U256> {
+    let mut storage = HashMap::new();
+    storage.insert(
         sd2u("82183438603287090451672504949863617512989139203883434767553028632841710582583"),
         sd2u("1000000000000000000000"),
-    )])
+    );
+    storage
 }
 
-fn token_storage_after() -> anyhow::Result<HashedPartialTrie> {
-    create_account_storage(&[
-        (
-            sd2u("82183438603287090451672504949863617512989139203883434767553028632841710582583"),
-            sd2u("900000000000000000000"),
-        ),
-        (
-            sd2u("53006154680716014998529145169423020330606407246856709517064848190396281160729"),
-            sd2u("100000000000000000000"),
-        ),
-    ])
+fn token_storage_after() -> HashMap<U256, U256> {
+    let mut storage = HashMap::new();
+    storage.insert(
+        sd2u("82183438603287090451672504949863617512989139203883434767553028632841710582583"),
+        sd2u("900000000000000000000"),
+    );
+    storage.insert(
+        sd2u("53006154680716014998529145169423020330606407246856709517064848190396281160729"),
+        sd2u("100000000000000000000"),
+    );
+    storage
 }
 
-fn giver_account() -> anyhow::Result<AccountRlp> {
-    Ok(AccountRlp {
+fn giver_account() -> Type2AccountRlp {
+    let code = giver_bytecode();
+    let len = code.len();
+    Type2AccountRlp {
         nonce: 1.into(),
         balance: 0.into(),
-        storage_root: giver_storage()?.hash(),
-        code_hash: keccak(giver_bytecode()),
-    })
+        code_hash: keccak(code),
+        code_length: len.into(),
+    }
 }
 
-fn token_account() -> anyhow::Result<AccountRlp> {
-    Ok(AccountRlp {
+fn token_account() -> Type2AccountRlp {
+    let code = token_bytecode();
+    let len = code.len();
+    Type2AccountRlp {
         nonce: 1.into(),
         balance: 0.into(),
-        storage_root: token_storage()?.hash(),
-        code_hash: keccak(token_bytecode()),
-    })
+        code_hash: keccak(code),
+        code_length: len.into(),
+    }
 }
 
-fn sender_account() -> AccountRlp {
-    AccountRlp {
+fn sender_account() -> Type2AccountRlp {
+    Type2AccountRlp {
         nonce: 0.into(),
         balance: sd2u("10000000000000000000000"),
-        storage_root: Default::default(),
-        code_hash: keccak([]),
+        ..Default::default()
     }
 }
 
@@ -290,4 +297,19 @@ fn bloom() -> [U256; 8] {
         .map(U256::from_big_endian)
         .collect::<Vec<_>>();
     bloom.try_into().unwrap()
+}
+
+fn set_account<D: Db>(
+    smt: &mut Smt<D>,
+    addr: Address,
+    account: &Type2AccountRlp,
+    storage: &HashMap<U256, U256>,
+) {
+    smt.set(key_balance(addr), account.balance);
+    smt.set(key_nonce(addr), account.nonce);
+    smt.set(key_code(addr), h2u(account.code_hash));
+    smt.set(key_code_length(addr), account.code_length);
+    for (&k, &v) in storage {
+        smt.set(key_storage(addr, k), v);
+    }
 }

--- a/evm_arithmetization/tests/global_exit_root.rs
+++ b/evm_arithmetization/tests/global_exit_root.rs
@@ -3,14 +3,15 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use ethereum_types::H256;
-use evm_arithmetization::generation::{GenerationInputs, TrieInputs};
+use ethereum_types::{BigEndianHash, H256};
+use evm_arithmetization::generation::{GenerationInputs, InputStateTrie, TrieInputs};
 use evm_arithmetization::proof::{BlockHashes, BlockMetadata, TrieRoots};
 use evm_arithmetization::prover::testing::prove_all_segments;
 use evm_arithmetization::testing_utils::{
-    ger_account_nibbles, ger_contract_from_storage, init_logger, scalable_account_nibbles,
-    scalable_contract_from_storage, update_ger_account_storage, update_scalable_account_storage,
-    ADDRESS_SCALABLE_L2_ADDRESS_HASHED, GLOBAL_EXIT_ROOT_ACCOUNT, GLOBAL_EXIT_ROOT_ADDRESS_HASHED,
+    ger_account_nibbles, init_logger, preinitialized_state_smt_ger,
+    preinitialized_state_with_updated_storage, scalable_account_nibbles, set_account,
+    update_ger_account_storage, update_scalable_account_storage,
+    ADDRESS_SCALABLE_L2_ADDRESS_HASHED, GLOBAL_EXIT_ROOT_ADDRESS_HASHED,
 };
 use evm_arithmetization::verifier::testing::verify_all_proofs;
 use evm_arithmetization::{AllStark, Node, StarkConfig, EMPTY_CONSOLIDATED_BLOCKHASH};
@@ -20,6 +21,9 @@ use plonky2::field::goldilocks_field::GoldilocksField;
 use plonky2::field::types::Field;
 use plonky2::plonk::config::PoseidonGoldilocksConfig;
 use plonky2::util::timing::TimingTree;
+use smt_trie::db::MemoryDb;
+use smt_trie::smt::Smt;
+use smt_trie::utils::hashout2u;
 
 type F = GoldilocksField;
 const D: usize = 2;
@@ -39,21 +43,22 @@ fn test_global_exit_root() -> anyhow::Result<()> {
         ..BlockMetadata::default()
     };
 
-    let mut state_trie_before = HashedPartialTrie::from(Node::Empty);
-    let mut storage_tries = vec![];
-    state_trie_before.insert(
-        ger_account_nibbles(),
-        rlp::encode(&GLOBAL_EXIT_ROOT_ACCOUNT).to_vec(),
-    )?;
+    let mut state_smt_before = preinitialized_state_smt_ger();
+    // let mut state_trie_before = HashedPartialTrie::from(Node::Empty);
+    // let mut storage_tries = vec![];
+    // state_trie_before.insert(
+    //     ger_account_nibbles(),
+    //     rlp::encode(&GLOBAL_EXIT_ROOT_ACCOUNT).to_vec(),
+    // )?;
 
-    let mut ger_account_storage = HashedPartialTrie::from(Node::Empty);
-    let mut scalable_account_storage = HashedPartialTrie::from(Node::Empty);
+    // let mut ger_account_storage = HashedPartialTrie::from(Node::Empty);
+    // let mut scalable_account_storage = HashedPartialTrie::from(Node::Empty);
 
-    storage_tries.push((GLOBAL_EXIT_ROOT_ADDRESS_HASHED, ger_account_storage.clone()));
-    storage_tries.push((
-        ADDRESS_SCALABLE_L2_ADDRESS_HASHED,
-        scalable_account_storage.clone(),
-    ));
+    // storage_tries.push((GLOBAL_EXIT_ROOT_ADDRESS_HASHED,
+    // ger_account_storage.clone())); storage_tries.push((
+    //     ADDRESS_SCALABLE_L2_ADDRESS_HASHED,
+    //     scalable_account_storage.clone(),
+    // ));
 
     let transactions_trie = HashedPartialTrie::from(Node::Empty);
     let receipts_trie = HashedPartialTrie::from(Node::Empty);
@@ -63,29 +68,15 @@ fn test_global_exit_root() -> anyhow::Result<()> {
 
     let ger_data = Some((H256::random(), H256::random()));
 
-    let state_trie_after = {
-        let mut trie = HashedPartialTrie::from(Node::Empty);
-        update_ger_account_storage(&mut ger_account_storage, ger_data)?;
-        update_scalable_account_storage(
-            &mut scalable_account_storage,
-            &block_metadata,
-            state_trie_before.hash(),
-        )?;
+    let expected_smt_after: Smt<MemoryDb> = {
+        let mut smt = preinitialized_state_with_updated_storage(&[]);
+        // TODO: Update GER and scalable account.
 
-        let ger_account = ger_contract_from_storage(&ger_account_storage);
-        let scalable_account = scalable_contract_from_storage(&scalable_account_storage);
-
-        trie.insert(ger_account_nibbles(), rlp::encode(&ger_account).to_vec())?;
-        trie.insert(
-            scalable_account_nibbles(),
-            rlp::encode(&scalable_account).to_vec(),
-        )?;
-
-        trie
+        smt
     };
 
     let trie_roots_after = TrieRoots {
-        state_root: state_trie_after.hash(),
+        state_root: H256::from_uint(&hashout2u(expected_smt_after.root)),
         transactions_root: transactions_trie.hash(),
         receipts_root: receipts_trie.hash(),
     };
@@ -96,10 +87,10 @@ fn test_global_exit_root() -> anyhow::Result<()> {
         withdrawals: vec![],
         ger_data,
         tries: TrieInputs {
-            state_trie: state_trie_before,
+            state_trie: InputStateTrie::Type2(state_smt_before.serialize()),
             transactions_trie,
             receipts_trie,
-            storage_tries,
+            storage_tries: None,
         },
         trie_roots_after,
         contract_code,

--- a/trace_decoder/Cargo.toml
+++ b/trace_decoder/Cargo.toml
@@ -60,7 +60,7 @@ serde_json = { workspace = true }
 serde_path_to_error = { workspace = true }
 
 [features]
-default = ["eth_mainnet"]
+default = ["cdk_erigon"]
 eth_mainnet = ["evm_arithmetization/eth_mainnet", "zero/eth_mainnet"]
 cdk_erigon = ["evm_arithmetization/cdk_erigon", "zero/cdk_erigon"]
 polygon_pos = ["evm_arithmetization/polygon_pos", "zero/polygon_pos"]

--- a/trace_decoder/src/lib.rs
+++ b/trace_decoder/src/lib.rs
@@ -62,7 +62,7 @@ mod type1;
 #[cfg(test)]
 #[allow(dead_code)]
 mod type2;
-mod typed_mpt;
+pub mod typed_mpt;
 mod wire;
 
 pub use core::entrypoint;

--- a/trace_decoder/src/observer.rs
+++ b/trace_decoder/src/observer.rs
@@ -4,12 +4,12 @@ use std::marker::PhantomData;
 use ethereum_types::{H256, U256};
 
 use crate::core::IntraBlockTries;
-use crate::typed_mpt::{ReceiptTrie, StorageTrie, TransactionTrie};
+use crate::typed_mpt::{ReceiptTrie, StateTrie, StorageTrie, TransactionTrie};
 
 /// Observer API for the trace decoder.
 /// Observer is used to collect various debugging and metadata info
 /// from the trace decoder run.
-pub trait Observer<StateTrieT> {
+pub trait Observer<StateTrieT: StateTrie + Clone> {
     /// Collect tries after the transaction/batch execution.
     ///
     /// Passing the arguments one by one through reference, because
@@ -55,7 +55,7 @@ impl<StateTrieT> TriesObserver<StateTrieT> {
     }
 }
 
-impl<StateTrieT: Clone> Observer<StateTrieT> for TriesObserver<StateTrieT> {
+impl<StateTrieT: StateTrie + Clone> Observer<StateTrieT> for TriesObserver<StateTrieT> {
     fn collect_tries(
         &mut self,
         block: U256,
@@ -99,7 +99,7 @@ impl<StateTrieT> DummyObserver<StateTrieT> {
     }
 }
 
-impl<StateTrieT> Observer<StateTrieT> for DummyObserver<StateTrieT> {
+impl<StateTrieT: StateTrie + Clone> Observer<StateTrieT> for DummyObserver<StateTrieT> {
     fn collect_tries(
         &mut self,
         _block: U256,

--- a/trace_decoder/src/type1.rs
+++ b/trace_decoder/src/type1.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{bail, ensure, Context as _};
 use either::Either;
-use evm_arithmetization::generation::mpt::AccountRlp;
+use evm_arithmetization::generation::mpt::{AccountRlp, Type1AccountRlp};
 use keccak_hash::H256;
 use mpt_trie::partial_trie::OnOrphanedHashNode;
 use nunny::NonEmpty;
@@ -80,7 +80,7 @@ fn visit(
                     storage,
                     code,
                 }) => {
-                    let account = AccountRlp {
+                    let account = Type1AccountRlp {
                         nonce: nonce.into(),
                         balance,
                         storage_root: {

--- a/zero/Cargo.toml
+++ b/zero/Cargo.toml
@@ -62,7 +62,7 @@ vergen-git2 = { version = "1.0.0", features = ["build"] }
 
 
 [features]
-default = ["eth_mainnet"]
+default = ["cdk_erigon"]
 eth_mainnet = ["evm_arithmetization/eth_mainnet", "trace_decoder/eth_mainnet"]
 cdk_erigon = ["evm_arithmetization/cdk_erigon", "trace_decoder/cdk_erigon"]
 polygon_pos = ["evm_arithmetization/polygon_pos", "trace_decoder/polygon_pos"]

--- a/zero/src/prover.rs
+++ b/zero/src/prover.rs
@@ -21,6 +21,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::{oneshot, Semaphore};
 use trace_decoder::observer::DummyObserver;
+use trace_decoder::typed_mpt::{StateMpt, StateSmt};
 use trace_decoder::{BlockTrace, OtherBlockData};
 use tracing::{error, info};
 
@@ -83,12 +84,21 @@ impl BlockProverInput {
 
         let block_number = self.get_block_number();
 
-        let block_generation_inputs = trace_decoder::entrypoint(
-            self.block_trace,
-            self.other_data,
-            batch_size,
-            &mut DummyObserver::new(),
-        )?;
+        let block_generation_inputs = if cfg!(feature = "cdk_erigon") {
+            trace_decoder::entrypoint::<StateSmt>(
+                self.block_trace,
+                self.other_data,
+                batch_size,
+                //&mut DummyObserver::new(),
+            )?
+        } else {
+            trace_decoder::entrypoint::<StateMpt>(
+                self.block_trace,
+                self.other_data,
+                batch_size,
+                //&mut DummyObserver::new(),
+            )?
+        };
 
         // Create segment proof.
         let seg_prove_ops = ops::SegmentProof {
@@ -176,12 +186,21 @@ impl BlockProverInput {
         let block_number = self.get_block_number();
         info!("Testing witness generation for block {block_number}.");
 
-        let block_generation_inputs = trace_decoder::entrypoint(
-            self.block_trace,
-            self.other_data,
-            batch_size,
-            &mut DummyObserver::new(),
-        )?;
+        let block_generation_inputs = if cfg!(feature = "cdk_erigon") {
+            trace_decoder::entrypoint::<StateSmt>(
+                self.block_trace,
+                self.other_data,
+                batch_size,
+                //&mut DummyObserver::new(),
+            )?
+        } else {
+            trace_decoder::entrypoint::<StateMpt>(
+                self.block_trace,
+                self.other_data,
+                batch_size,
+                //&mut DummyObserver::new(),
+            )?
+        };
 
         let seg_ops = ops::SegmentProofTestOnly {
             save_inputs_on_error,

--- a/zero/src/trie_diff/mod.rs
+++ b/zero/src/trie_diff/mod.rs
@@ -1,4 +1,4 @@
-use evm_arithmetization::generation::mpt::{AccountRlp, LegacyReceiptRlp};
+use evm_arithmetization::generation::mpt::{AccountRlp, LegacyReceiptRlp, Type1AccountRlp};
 use evm_arithmetization::generation::DebugOutputTries;
 use mpt_trie::debug_tools::diff::{create_diff_between_tries, DiffPoint};
 use mpt_trie::utils::TrieNodeType;
@@ -83,7 +83,7 @@ pub fn compare_tries(
     }
 
     let state_trie_diff = create_diff_between_tries(&left.state_trie, &right.state_trie);
-    compare_tries_and_output_results::<usize, AccountRlp>(
+    compare_tries_and_output_results::<usize, Type1AccountRlp>(
         "state trie",
         state_trie_diff.latest_diff_res,
         block_number,


### PR DESCRIPTION
@0xaatif I've tried to clean it up as much as possible. For now I'm using an enum for the different types in `evm_arithmetization` and I'm keeping your trait approach for `trace_decoder`. I might switch one or the other, and I think that the end goal would be to use the same structs/trait in both.

@atanmarko I couldn't manage to make it work with the observer because of some trait bound issues, I'll ask you some questions about it later.