### PR TITLE
misc: print script logs upon failure

### DIFF
--- a/scripts/prove_rpc.sh
+++ b/scripts/prove_rpc.sh
@@ -140,7 +140,8 @@ else
         eval $command > $OUT_LOG_PATH 2>&1
         retVal=$?
         if [ $retVal -ne 0 ]; then
-            # Some error occurred.
+            # Some error occurred, display the logs and exit.
+            cat $OUT_LOG_PATH
             echo "Block ${i} errored. See ${OUT_LOG_PATH} for more details."
             exit $retVal
         else
@@ -166,7 +167,9 @@ if [ "$RUN_VERIFICATION" = true ]; then
       echo "$proof_file_name verified successfully!";
       rm  $PROOF_OUTPUT_DIR/verify.out
   else
-      echo "there was an issue with proof verification";
+      # Some error occurred with verification, display the logs and exit.
+      cat $PROOF_OUTPUT_DIR/verify.out
+      echo "There was an issue with proof verification. See $PROOF_OUTPUT_DIR/verify.out for more details.";
       exit 1
   fi
 else

--- a/scripts/prove_stdio.sh
+++ b/scripts/prove_stdio.sh
@@ -101,7 +101,9 @@ if [[ $TEST_ONLY == "test_only" ]]; then
         rm $TEST_OUT_PATH
         exit
     else
-         echo "Failed to create proof witnesses. See \"zk_evm/tools/test.out\" for more details."
+        # Some error occurred, display the logs and exit.
+        cat $OUT_LOG_PATH
+        echo "Failed to create proof witnesses. See $OUT_LOG_PATH for more details."
         exit 1
     fi
 fi
@@ -117,6 +119,8 @@ end_time=$(date +%s%N)
 set +o pipefail
 cat $OUTPUT_LOG | grep "Successfully wrote to disk proof file " | awk '{print $NF}' | tee $PROOFS_FILE_LIST
 if [ ! -s "$PROOFS_FILE_LIST" ]; then
+  # Some error occurred, display the logs and exit.
+  cat $OUTPUT_LOG
   echo "Proof list not generated, some error happened. For more details check the log file $OUTPUT_LOG"
   exit 1
 fi
@@ -130,7 +134,9 @@ do
       echo "Proof verification for file $proof_file successful";
       rm $verify_file # we keep the generated proof for potential reuse
   else
-      echo "there was an issue with proof verification";
+      # Some error occurred with verification, display the logs and exit.
+      cat $verify_file
+      echo "There was an issue with proof verification. See $verify_file for more details.";
       exit 1
   fi
 done


### PR DESCRIPTION
We used to have `./script.sh | tee log.out` for convenience to retrieve the errors arising in CI jobs, but this was quite cumbersome locally for quick testing runs, hence reverting to `&> log.out`, which obfuscates everything.

As a simple middle ground, we can print the logs only upon failure, to easily retrieve the failures on the CI while not clogging our terminals when testing