### PR TITLE
Fix invalid `blob_gas_fee` burn

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/transactions/type_3.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/transactions/type_3.asm
@@ -94,7 +94,7 @@ store_origin:
     // stack: address, blob_gas_fee, address, retdest
     %deduct_eth
     // stack: deduct_eth_status, address, retdest
-    %jumpi(transfer_eth_failure)
+    %jumpi(panic)
 
     // stack: address, retdest
     %mstore_txn_field(@TXN_FIELD_ORIGIN)


### PR DESCRIPTION
Similarly to base gas used, this should be a hard failure if we can't pay the base blob fee. Also the previous macro used was invalid (wrong stack)