### PR TITLE
Fix decoder parsing with new storage tries

### DIFF
--- a/trace_decoder/src/core.rs
+++ b/trace_decoder/src/core.rs
@@ -393,6 +393,12 @@ fn middle<StateTrieT: StateTrie + Clone>(
                     .map(|acct| (acct, false))
                     .unwrap_or((AccountRlp::default(), true));
 
+                if born {
+                    // Empty accounts cannot have non-empty storage,
+                    // so we can safely insert a default trie.
+                    storage_tries.insert(keccak_hash::keccak(addr), StorageTrie::default());
+                }
+
                 if born || just_access {
                     state_trie
                         .clone()


### PR DESCRIPTION
We are not adding a default new trie mapped to a created address, which can cause errors in parsing if trying to write to storage of a newly created account.

Fixes a bunch of `missing storage trie for address FOO` on the test chain (I'm not including new payloads on the test cases folder because I am still trying to debug follow-up issues with some of these blocks on the prover side, but I can share payloads, the `consistent-with-header` integration test passes now).