### PR TITLE
Add a debugger tool to check Kernel (user code) execution against StructLogs 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c37d89f69cb43901949ba29307ada8b9e3b170f94057ad4c04d6fd169d24d65f"
+checksum = "8367891bf380210abb0d6aa30c5f85a9080cb4a066c4d5c5acadad630823751b"
 dependencies = [
  "alloy-consensus",
  "alloy-core",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.30"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4f201b0ac8f81315fbdc55269965a8ddadbc04ab47fa65a1a468f9a40f7a5f"
+checksum = "8158b4878c67837e5413721cc44298e6a2d88d39203175ea025e51892a16ba4c"
 dependencies = [
  "num_enum",
  "strum",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1468e3128e07c7afe4ff13c17e8170c330d12c322f8924b8bf6986a27e0aad3d"
+checksum = "629b62e38d471cc15fea534eb7283d2f8a4e8bdb1811bcc5d66dda6cfce6fae1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b095eb0533144b4497e84a9cc3e44a5c2e3754a3983c0376a55a2f9183a53e"
+checksum = "5ce854562e7cafd5049189d0268d6e5cba05fe6c9cb7c6f8126a79b94800629c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d319bb544ca6caeab58c39cea8921c55d924d4f68f2c60f24f914673f9a74a"
+checksum = "ea59dc42102bc9a1905dc57901edc6dd48b9f38115df86c7d252acba70d71d04"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c35df7b972b06f1b2f4e8b7a53328522fa788054a9d3e556faf2411c5a51d5a"
+checksum = "f923dd5fca5f67a43d81ed3ebad0880bd41f6dd0ada930030353ac356c54cd0f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8866562186d237f1dfeaf989ef941a24764f764bf5c33311e37ead3519c6a429"
+checksum = "d3c717b5298fad078cd3a418335b266eba91b511383ca9bd497f742d5975d5ab"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe714e233f9eaf410de95a9af6bcd05d3a7f8c8de7a0817221e95a6b642a080"
+checksum = "fb3705ce7d8602132bcf5ac7a1dd293a42adc2f183abf5907c30ac535ceca049"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5a38117974c5776a45e140226745a0b664f79736aa900995d8e4121558e064"
+checksum = "94ad40869867ed2d9cd3842b1e800889e5b49e6b92da346e93862b4a741bedf3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -207,31 +207,36 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411aff151f2a73124ee473708e82ed51b2535f68928b6a1caa8bc1246ae6f7cd"
+checksum = "260d3ff3bff0bb84599f032a2f2c6828180b0ea0cd41fdaf44f39cef3ba41861"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more",
+ "hashbrown 0.14.5",
  "hex-literal",
+ "indexmap",
  "itoa",
  "k256",
  "keccak-asm",
+ "paste",
  "proptest",
  "rand",
  "ruint",
+ "rustc-hash",
  "serde",
+ "sha3",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-provider"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65633d6ef83c3626913c004eaf166a6dd50406f724772ea8567135efd6dc5d3"
+checksum = "927f708dd457ed63420400ee5f06945df9632d5d101851952056840426a10dc5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -281,14 +286,14 @@ checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fc328bb5d440599ba1b5aa44c0b9ab0625fbc3a403bb5ee94ed4a01ba23e07"
+checksum = "7d82952dca71173813d4e5733e2c986d8b04aea9e0f3b0a576664c232ad050a5"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -307,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f8ff679f94c497a8383f2cd09e2a099266e5f3d5e574bc82b4b379865707dbb"
+checksum = "64333d639f2a0cf73491813c629a405744e16343a4bc5640931be707c345ecc5"
 dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
@@ -319,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a59b1d7c86e0a653e7f3d29954f6de5a2878d8cfd1f010ff93be5c2c48cd3b1"
+checksum = "83aa984386deda02482660aa31cb8ca1e63d533f1c31a52d7d181ac5ec68e9b8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -330,17 +335,19 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
+ "cfg-if",
+ "derive_more",
+ "hashbrown 0.14.5",
  "itertools 0.13.0",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54375e5a34ec5a2cf607f9ce98c0ece30dc76ad623afeb25d3953a8d7d30f20"
+checksum = "98db35cd42c90b484377e6bc44d95377a7a38a5ebee996e67754ac0446d542ab"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -352,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51db8a6428a2159e01b7a43ec7aac801edd0c4db1d4de06f310c288940f16fd3"
+checksum = "731f75ec5d383107fd745d781619bd9cedf145836c51ecb991623d41278e71fa"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -363,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebc1760c13592b7ba3fcd964abba546b8d6a9f10d15e8d92a8263731be33f36"
+checksum = "307324cca94354cd654d6713629f0383ec037e1ff9e3e3d547212471209860c0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -377,23 +384,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0458ccb02a564228fcd76efb8eb5a520521a8347becde37b402afec9a1b83859"
+checksum = "68e7f6e8fe5b443f82b3f1e15abfa191128f71569148428e49449d01f6f49e8b"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc65475025fc1e84bf86fc840f04f63fcccdcf3cf12053c99918e4054dfbc69"
+checksum = "6b96ce28d2fde09abb6135f410c41fad670a3a770b6776869bd852f1df102e6f"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -402,31 +409,31 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed10f0715a0b69fde3236ff3b9ae5f6f7c97db5a387747100070d3016b9266b"
+checksum = "906746396a8296537745711630d9185746c0b50c033d5e9d18b0a6eba3d53f90"
 dependencies = [
  "const-hex",
  "dunce",
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb88e4da0a1b697ed6a9f811fdba223cf4d5c21410804fd1707836af73a462b"
+checksum = "d86a533ce22525969661b25dfe296c112d35eb6861f188fd284f8bd4bb3842ae"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -435,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5dc4e902f1860d54952446d246ac05386311ad61030a2b906ae865416d36e0"
+checksum = "33616b2edf7454302a1d48084db185e52c309f73f6c10be99b0fe39354b3f1e9"
 dependencies = [
  "alloy-json-rpc",
  "base64",
@@ -454,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1742b94bb814f1ca6b322a6f9dd38a0252ff45a3119e40e888fb7029afa500ce"
+checksum = "a944f5310c690b62bbb3e7e5ce34527cbd36b2d18532a797af123271ce595a49"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -469,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol"
-version = "7.2.1"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0234884b3641db74d22ccc20fc2594db5f23d7d41ade5c93d7ee33d200960c"
+checksum = "e3a41c091e49edfcc098b4f90d4d7706a8cf9158034e84ebfee7ff346092f67c"
 dependencies = [
  "amq-protocol-tcp",
  "amq-protocol-types",
@@ -483,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-tcp"
-version = "7.2.1"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265dca43d9dbb3d5bbb0b3ef1b0cd9044ce3aa5d697d5b66cde974d1f6063f09"
+checksum = "3ed7a4a662472f88823ed2fc81babb0b00562f2c54284e3e7bffc02b6df649bf"
 dependencies = [
  "amq-protocol-uri",
  "tcp-stream",
@@ -494,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-types"
-version = "7.2.1"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7412353b58923fa012feb9a64ccc0c811747babee2e5a2fd63eb102dc8054c3"
+checksum = "bd6484fdc918c1b6e2ae8eda2914d19a5873e1975f93ad8d33d6a24d1d98df05"
 dependencies = [
  "cookie-factory",
  "nom",
@@ -506,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-uri"
-version = "7.2.1"
+version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be91352c805d5704784e079117d5291fd5bf2569add53c914ebce6d1a795d33"
+checksum = "7f7f2da69e0e1182765bf33407cd8a843f20791b5af2b57a2645818c4776c56c"
 dependencies = [
  "amq-protocol-types",
  "percent-encoding",
@@ -572,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 dependencies = [
  "backtrace",
 ]
@@ -733,7 +740,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "synstructure",
 ]
 
@@ -745,7 +752,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -769,7 +776,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -896,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -907,13 +914,13 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -924,13 +931,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -956,20 +963,20 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -993,7 +1000,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1001,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1014,7 +1021,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1169,9 +1176,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 dependencies = [
  "serde",
 ]
@@ -1214,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
 dependencies = [
  "jobserver",
  "libc",
@@ -1268,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1278,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1290,14 +1297,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1355,9 +1362,9 @@ checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "const-hex"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8a24a26d37e1ffd45343323dc9fe6654ceea44c12f2fcb3d7ac29e610bc6"
+checksum = "0121754e84117e65f9d90648ee6aa4882a6e63110307ab73967a4c5e7e69e586"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1586,7 +1593,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1597,7 +1604,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1607,7 +1614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1621,7 +1628,7 @@ checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1668,7 +1675,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1709,7 +1716,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1719,7 +1726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1739,7 +1746,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "unicode-xid",
 ]
 
@@ -1808,7 +1815,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1889,7 +1896,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1957,7 +1964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3aeb0284b473041df2419a28e3cdf0c64a78d2b9511af4b6e40bad3964b172"
 dependencies = [
  "ethereum-types",
- "hashbrown",
+ "hashbrown 0.14.5",
  "keccak-hash 0.10.0",
  "log",
  "parking_lot",
@@ -2022,12 +2029,15 @@ dependencies = [
 name = "evm_arithmetization"
 version = "0.4.0"
 dependencies = [
+ "alloy",
+ "alloy-primitives",
+ "alloy-serde",
  "anyhow",
  "bytes",
  "criterion",
  "env_logger 0.11.5",
  "ethereum-types",
- "hashbrown",
+ "hashbrown 0.14.5",
  "hex",
  "hex-literal",
  "itertools 0.13.0",
@@ -2268,7 +2278,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2329,18 +2339,6 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getset"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f636605b743120a8d32ed92fc27b6cde1a769f8f936c065151eb66f88ded513c"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.77",
 ]
 
 [[package]]
@@ -2409,6 +2407,12 @@ dependencies = [
  "rayon",
  "serde",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heapless"
@@ -2502,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -2556,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2569,7 +2573,6 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
- "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -2641,12 +2644,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.0",
+ "serde",
 ]
 
 [[package]]
@@ -2784,15 +2788,24 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
  "sha2",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -2855,9 +2868,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libgit2-sys"
@@ -2938,7 +2951,7 @@ checksum = "cb26336e6dc7cc76e7927d2c9e7e3bb376d7af65a6f56a0b16c47d18a9b1abc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2976,7 +2989,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3226,7 +3239,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3267,9 +3280,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -3300,7 +3316,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3395,7 +3411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af25dcb10b7c0ce99abee8694e2e79e4787d7f778b9339dc5a50ba6fc45e5cc9"
 dependencies = [
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3486,9 +3502,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
 dependencies = [
  "memchr",
  "thiserror",
@@ -3497,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
+checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3507,22 +3523,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
+checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
+checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
 dependencies = [
  "once_cell",
  "pest",
@@ -3546,7 +3562,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3626,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plonky2"
@@ -3638,7 +3654,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "getrandom",
- "hashbrown",
+ "hashbrown 0.14.5",
  "itertools 0.11.0",
  "keccak-hash 0.8.0",
  "log",
@@ -3751,6 +3767,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
 name = "postcard"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3839,7 +3861,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3865,7 +3887,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -3901,6 +3923,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -3973,9 +3996,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -3993,14 +4016,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4014,13 +4037,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -4031,15 +4054,15 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64",
  "bytes",
@@ -4166,6 +4189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4267,19 +4296,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -4389,9 +4417,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4447,7 +4475,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4480,14 +4508,14 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -4524,6 +4552,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
@@ -4654,7 +4692,7 @@ source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=dc77c77f2b06500e1
 dependencies = [
  "ahash",
  "anyhow",
- "hashbrown",
+ "hashbrown 0.14.5",
  "itertools 0.11.0",
  "log",
  "num-bigint",
@@ -4694,7 +4732,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4716,9 +4754,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4727,14 +4765,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b95156f8b577cb59dc0b1df15c6f29a10afc5f8a7ac9786b0b5c68c19149278"
+checksum = "0ab661c8148c2261222a4d641ad5477fd4bea79406a99056096a0b41b35617a5"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4760,7 +4798,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4783,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand 2.1.1",
@@ -4811,22 +4849,22 @@ checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4952,7 +4990,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5027,9 +5065,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "serde",
@@ -5064,8 +5102,10 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 0.1.2",
+ "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5105,7 +5145,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5180,7 +5220,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5260,9 +5300,9 @@ dependencies = [
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"
@@ -5296,18 +5336,18 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unroll"
@@ -5368,9 +5408,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.0.0"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32e7318e93a9ac53693b6caccfb05ff22e04a44c7cf8a279051f24c09da286f"
+checksum = "349ed9e45296a581f455bc18039878f409992999bc1d5da12a6800eb18c8752f"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -5381,9 +5421,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-git2"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62c52cd2b2b8b7ec75fc20111b3022ac3ff83e4fc14b9497cfcfd39c54f9c67"
+checksum = "e771aff771c0d7c2f42e434e2766d304d917e29b40f0424e8faaaa936bbc3f29"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -5396,13 +5436,12 @@ dependencies = [
 
 [[package]]
 name = "vergen-lib"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06bee42361e43b60f363bad49d63798d0f42fb1768091812270eca00c784720"
+checksum = "229eaddb0050920816cf051e619affaf18caa3dd512de8de5839ccbc8e53abb0"
 dependencies = [
  "anyhow",
  "derive_builder",
- "getset",
  "rustversion",
 ]
 
@@ -5474,7 +5513,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -5508,7 +5547,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5750,9 +5789,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -5806,6 +5845,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "alloy-compat",
+ "alloy-primitives",
  "anyhow",
  "async-stream",
  "axum",
@@ -5815,7 +5855,7 @@ dependencies = [
  "dotenvy",
  "evm_arithmetization",
  "futures",
- "hashbrown",
+ "hashbrown 0.14.5",
  "hex",
  "itertools 0.13.0",
  "jemallocator",
@@ -5863,7 +5903,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5883,7 +5923,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5902,6 +5942,6 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "trybuild",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ alloy = { version = '0.3.0', default-features = false, features = [
 ] }
 anyhow = "1.0.86"
 async-stream = "0.3.5"
+alloy-primitives = "0.8.0"
+alloy-serde = "0.3.0"
 axum = "0.7.5"
 bitflags = "2.5.0"
 bitvec = "1.0.1"

--- a/evm_arithmetization/Cargo.toml
+++ b/evm_arithmetization/Cargo.toml
@@ -16,6 +16,9 @@ keywords.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+alloy.workspace = true
+alloy-serde.workspace = true
+alloy-primitives.workspace = true
 bytes.workspace = true
 env_logger.workspace = true
 ethereum-types.workspace = true

--- a/evm_arithmetization/src/cpu/kernel/constants/txn_fields.rs
+++ b/evm_arithmetization/src/cpu/kernel/constants/txn_fields.rs
@@ -41,7 +41,7 @@ impl NormalizedTxnField {
     pub(crate) const COUNT: usize = 18;
 
     /// Unscales this virtual offset by their respective `Segment` value.
-    // #[cfg(test)]
+    #[cfg(test)]
     pub(crate) const fn unscale(&self) -> usize {
         *self as usize - Segment::TxnFields as usize
     }

--- a/evm_arithmetization/src/cpu/kernel/constants/txn_fields.rs
+++ b/evm_arithmetization/src/cpu/kernel/constants/txn_fields.rs
@@ -41,7 +41,7 @@ impl NormalizedTxnField {
     pub(crate) const COUNT: usize = 18;
 
     /// Unscales this virtual offset by their respective `Segment` value.
-    #[cfg(test)]
+    // #[cfg(test)]
     pub(crate) const fn unscale(&self) -> usize {
         *self as usize - Segment::TxnFields as usize
     }

--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -72,8 +72,13 @@ pub(crate) struct Interpreter<F: RichField> {
     pub(crate) struct_log_debugger_info: StructLogDebuggerInfo,
 }
 
+/// Structure holding necessary information to check the kernel execution
+/// against struct logs.
 pub(crate) struct StructLogDebuggerInfo {
+    /// Opcode counter within a transaction.
     pub(crate) counter: usize,
+    /// Gas value in the kernel for a transaction (starting at `GasLimit` and
+    /// decreasing with each user opcode).
     pub(crate) gas: usize,
 }
 
@@ -611,10 +616,7 @@ impl<F: RichField> State<F> for Interpreter<F> {
                 // Check stack.
                 if let Some(txn_stack) = cur_txn_struct_logs.stack {
                     let cur_stack = self.get_full_stack();
-                    let txn_stack = txn_stack
-                        .into_iter()
-                        .map(|s| U256::from(s))
-                        .collect::<Vec<_>>();
+                    let txn_stack = txn_stack.into_iter().map(U256::from).collect::<Vec<_>>();
 
                     if txn_stack != cur_stack {
                         log::warn!(
@@ -763,7 +765,6 @@ impl<F: RichField> State<F> for Interpreter<F> {
         stack
     }
 
-    /// Returns the entire stack. Only used for checking against struct logs.
     fn get_full_stack(&self) -> Vec<U256> {
         let mut stack: Vec<U256> = (0..self.get_registers().stack_len)
             .map(|i| crate::witness::util::stack_peek(self.get_generation_state(), i).unwrap())

--- a/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/account_code.rs
@@ -270,7 +270,7 @@ fn test_extcodesize() -> Result<()> {
     let code = random_code();
     let account = test_account(&code);
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], None, &None);
     let address: Address = thread_rng().gen();
     // Prepare the interpreter by inserting the account in the state trie.
     prepare_interpreter(&mut interpreter, address, &account)?;
@@ -305,7 +305,7 @@ fn test_extcodecopy() -> Result<()> {
     let code = random_code();
     let account = test_account(&code);
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], None, &None);
     let address: Address = thread_rng().gen();
     // Prepare the interpreter by inserting the account in the state trie.
     prepare_interpreter(&mut interpreter, address, &account)?;
@@ -489,7 +489,7 @@ fn sstore() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None, &None);
 
     // Pre-initialize the accessed addresses list.
     let init_accessed_addresses = KERNEL.global_labels["init_access_lists"];
@@ -583,7 +583,7 @@ fn sload() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None, &None);
 
     // Pre-initialize the accessed addresses list.
     let init_accessed_addresses = KERNEL.global_labels["init_access_lists"];

--- a/evm_arithmetization/src/cpu/kernel/tests/add11.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/add11.rs
@@ -197,8 +197,13 @@ fn test_add11_yml() {
 
     let initial_stack = vec![];
     let initial_offset = KERNEL.global_labels["init"];
-    let mut interpreter: Interpreter<F> =
-        Interpreter::new_with_generation_inputs(initial_offset, initial_stack, &inputs, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new_with_generation_inputs(
+        initial_offset,
+        initial_stack,
+        &inputs,
+        None,
+        &None,
+    );
 
     interpreter.set_is_kernel(true);
     interpreter.run().expect("Proving add11 failed.");
@@ -374,8 +379,13 @@ fn test_add11_yml_with_exception() {
 
     let initial_stack = vec![];
     let initial_offset = KERNEL.global_labels["init"];
-    let mut interpreter: Interpreter<F> =
-        Interpreter::new_with_generation_inputs(initial_offset, initial_stack, &inputs, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new_with_generation_inputs(
+        initial_offset,
+        initial_stack,
+        &inputs,
+        None,
+        &None,
+    );
 
     interpreter.set_is_kernel(true);
     interpreter

--- a/evm_arithmetization/src/cpu/kernel/tests/balance.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/balance.rs
@@ -26,7 +26,7 @@ fn test_balance() -> Result<()> {
     let balance = U256(rng.gen());
     let account = test_account(balance);
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], None, &None);
     let address: Address = rng.gen();
     // Prepare the interpreter by inserting the account in the state trie.
     prepare_interpreter(&mut interpreter, address, &account)?;

--- a/evm_arithmetization/src/cpu/kernel/tests/bignum/mod.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/bignum/mod.rs
@@ -100,7 +100,7 @@ fn run_test(fn_label: &str, memory: Vec<U256>, stack: Vec<U256>) -> Result<(Vec<
     initial_stack.push(retdest);
     initial_stack.reverse();
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(fn_label, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(fn_label, initial_stack, None, &None);
     interpreter.set_current_general_memory(memory);
     interpreter.run()?;
 

--- a/evm_arithmetization/src/cpu/kernel/tests/blobhash.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/blobhash.rs
@@ -19,7 +19,7 @@ fn test_valid_blobhash() -> Result<()> {
     let index = 3;
     let target_hash = versioned_hashes[index];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(blobhash_label, vec![], None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(blobhash_label, vec![], None, &None);
     interpreter
         .generation_state
         .memory
@@ -60,7 +60,7 @@ fn test_invalid_blobhash() -> Result<()> {
     let index = 7;
     let target_hash = U256::zero(); // out of bound indexing yields 0.
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(blobhash_label, vec![], None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(blobhash_label, vec![], None, &None);
     interpreter
         .generation_state
         .memory

--- a/evm_arithmetization/src/cpu/kernel/tests/block_hash.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/block_hash.rs
@@ -20,7 +20,8 @@ fn test_correct_block_hash() -> Result<()> {
 
     let hashes: Vec<U256> = vec![U256::from_big_endian(&thread_rng().gen::<H256>().0); 257];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(blockhash_label, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(blockhash_label, initial_stack, None, &None);
     interpreter.set_memory_segment(Segment::BlockHashes, hashes[0..256].to_vec());
     interpreter.set_global_metadata_field(GlobalMetadata::BlockCurrentHash, hashes[256]);
     interpreter.set_global_metadata_field(GlobalMetadata::BlockNumber, 256.into());
@@ -49,7 +50,8 @@ fn test_big_index_block_hash() -> Result<()> {
 
     let hashes: Vec<U256> = vec![U256::from_big_endian(&thread_rng().gen::<H256>().0); 257];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(blockhash_label, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(blockhash_label, initial_stack, None, &None);
     interpreter.set_memory_segment(Segment::BlockHashes, hashes[0..256].to_vec());
     interpreter.set_global_metadata_field(GlobalMetadata::BlockCurrentHash, hashes[256]);
     interpreter.set_global_metadata_field(GlobalMetadata::BlockNumber, cur_block_number.into());
@@ -79,7 +81,8 @@ fn test_small_index_block_hash() -> Result<()> {
 
     let hashes: Vec<U256> = vec![U256::from_big_endian(&thread_rng().gen::<H256>().0); 257];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(blockhash_label, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(blockhash_label, initial_stack, None, &None);
     interpreter.set_memory_segment(Segment::BlockHashes, hashes[0..256].to_vec());
     interpreter.set_global_metadata_field(GlobalMetadata::BlockCurrentHash, hashes[256]);
     interpreter.set_global_metadata_field(GlobalMetadata::BlockNumber, cur_block_number.into());
@@ -107,7 +110,8 @@ fn test_block_hash_with_overflow() -> Result<()> {
 
     let hashes: Vec<U256> = vec![U256::from_big_endian(&thread_rng().gen::<H256>().0); 257];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(blockhash_label, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(blockhash_label, initial_stack, None, &None);
     interpreter.set_memory_segment(Segment::BlockHashes, hashes[0..256].to_vec());
     interpreter.set_global_metadata_field(GlobalMetadata::BlockCurrentHash, hashes[256]);
     interpreter.set_global_metadata_field(GlobalMetadata::BlockNumber, cur_block_number.into());

--- a/evm_arithmetization/src/cpu/kernel/tests/bls381.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/bls381.rs
@@ -117,7 +117,8 @@ fn test_kzg_peval_precompile() -> Result<()> {
         stack.reverse();
 
         let verify_kzg_proof = KERNEL.global_labels["verify_kzg_proof"];
-        let mut interpreter: Interpreter<F> = Interpreter::new(verify_kzg_proof, stack, None);
+        let mut interpreter: Interpreter<F> =
+            Interpreter::new(verify_kzg_proof, stack, None, &None);
         interpreter.halt_offsets = vec![
             KERNEL.global_labels["store_kzg_verification"],
             KERNEL.global_labels["fault_exception"],

--- a/evm_arithmetization/src/cpu/kernel/tests/bn254.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/bn254.rs
@@ -325,7 +325,8 @@ fn test_ecpairing_precompile_invalid_input() -> Result<()> {
     stack.reverse();
 
     for bytes in ECPAIRING_PRECOMPILE_INVALID_INPUTS.iter() {
-        let mut interpreter: Interpreter<F> = Interpreter::new(pairing_label, stack.clone(), None);
+        let mut interpreter: Interpreter<F> =
+            Interpreter::new(pairing_label, stack.clone(), None, &None);
         let preloaded_memory = vec![
             U256::from_big_endian(&bytes[0..32]),    // Px
             U256::from_big_endian(&bytes[32..64]),   // Py

--- a/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
@@ -19,7 +19,7 @@ fn test_init_access_lists() -> Result<()> {
 
     // Check the initial state of the access list in the kernel.
     let initial_stack = vec![0xdeadbeefu32.into()];
-    let mut interpreter = Interpreter::<F>::new(init_label, initial_stack, None);
+    let mut interpreter = Interpreter::<F>::new(init_label, initial_stack, None, &None);
     interpreter.run()?;
 
     assert!(interpreter.stack().is_empty());
@@ -64,7 +64,7 @@ fn test_list_iterator() -> Result<()> {
     let init_label = KERNEL.global_labels["init_access_lists"];
 
     let initial_stack = vec![0xdeadbeefu32.into()];
-    let mut interpreter = Interpreter::<F>::new(init_label, initial_stack, None);
+    let mut interpreter = Interpreter::<F>::new(init_label, initial_stack, None, &None);
     interpreter.run()?;
 
     // test the list iterator
@@ -90,7 +90,7 @@ fn test_insert_address() -> Result<()> {
 
     // Test for address already in list.
     let initial_stack = vec![0xdeadbeefu32.into()];
-    let mut interpreter = Interpreter::<F>::new(init_label, initial_stack, None);
+    let mut interpreter = Interpreter::<F>::new(init_label, initial_stack, None, &None);
     interpreter.run()?;
 
     let insert_accessed_addresses = KERNEL.global_labels["insert_accessed_addresses"];
@@ -127,7 +127,7 @@ fn test_insert_accessed_addresses() -> Result<()> {
 
     // Test for address already in list.
     let initial_stack = vec![0xdeadbeefu32.into()];
-    let mut interpreter = Interpreter::<F>::new(init_access_lists, initial_stack, None);
+    let mut interpreter = Interpreter::<F>::new(init_access_lists, initial_stack, None, &None);
     interpreter.run()?;
 
     let insert_accessed_addresses = KERNEL.global_labels["insert_accessed_addresses"];
@@ -214,7 +214,7 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
 
     // Test for address already in list.
     let initial_stack = vec![0xdeadbeefu32.into()];
-    let mut interpreter = Interpreter::<F>::new(init_access_lists, initial_stack, None);
+    let mut interpreter = Interpreter::<F>::new(init_access_lists, initial_stack, None, &None);
     interpreter.run()?;
 
     let insert_accessed_storage_keys = KERNEL.global_labels["insert_accessed_storage_keys"];

--- a/evm_arithmetization/src/cpu/kernel/tests/core/create_addresses.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/create_addresses.rs
@@ -20,7 +20,8 @@ fn test_get_create_address() -> Result<()> {
     let expected_addr = U256::from_big_endian(&hex!("3f09c73a5ed19289fb9bdc72f1742566df146f56"));
 
     let initial_stack = vec![retaddr, nonce, sender];
-    let mut interpreter: Interpreter<F> = Interpreter::new(get_create_address, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(get_create_address, initial_stack, None, &None);
     interpreter.run()?;
 
     assert_eq!(interpreter.stack(), &[expected_addr]);
@@ -107,7 +108,7 @@ fn test_get_create2_address() -> Result<()> {
     {
         let initial_stack = vec![retaddr, salt, U256::from(code_hash.0), sender];
         let mut interpreter: Interpreter<F> =
-            Interpreter::new(get_create2_address, initial_stack, None);
+            Interpreter::new(get_create2_address, initial_stack, None, &None);
         interpreter.run()?;
 
         assert_eq!(interpreter.stack(), &[expected_addr]);

--- a/evm_arithmetization/src/cpu/kernel/tests/core/intrinsic_gas.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/intrinsic_gas.rs
@@ -17,13 +17,14 @@ fn test_intrinsic_gas() -> Result<()> {
     // Contract creation transaction.
     let initial_stack = vec![0xdeadbeefu32.into()];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new(intrinsic_gas, initial_stack.clone(), None);
+        Interpreter::new(intrinsic_gas, initial_stack.clone(), None, &None);
     interpreter.set_global_metadata_field(GlobalMetadata::ContractCreation, U256::one());
     interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![(GAS_TX + GAS_TXCREATE).into()]);
 
     // Message transaction.
-    let mut interpreter: Interpreter<F> = Interpreter::new(intrinsic_gas, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(intrinsic_gas, initial_stack, None, &None);
     interpreter.set_txn_field(NormalizedTxnField::To, 123.into());
     interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![GAS_TX.into()]);

--- a/evm_arithmetization/src/cpu/kernel/tests/core/jumpdest_analysis.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/jumpdest_analysis.rs
@@ -86,7 +86,7 @@ fn test_jumpdest_analysis() -> Result<()> {
             .chain(std::iter::once(true)),
     );
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(jumpdest_analysis, vec![], None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(jumpdest_analysis, vec![], None, &None);
     let code_len = code.len();
 
     interpreter.set_code(CONTEXT, code);
@@ -173,7 +173,7 @@ fn test_packed_verification() -> Result<()> {
         U256::one(),
     ];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new(write_table_if_jumpdest, initial_stack.clone(), None);
+        Interpreter::new(write_table_if_jumpdest, initial_stack.clone(), None, &None);
     interpreter.set_code(CONTEXT, code.clone());
     interpreter.generation_state.jumpdest_table = Some(HashMap::from([(3, vec![1, 33])]));
 
@@ -186,7 +186,7 @@ fn test_packed_verification() -> Result<()> {
     for i in 1..=32 {
         code[i] += 1;
         let mut interpreter: Interpreter<F> =
-            Interpreter::new(write_table_if_jumpdest, initial_stack.clone(), None);
+            Interpreter::new(write_table_if_jumpdest, initial_stack.clone(), None, &None);
         interpreter.set_code(CONTEXT, code.clone());
         interpreter.generation_state.jumpdest_table = Some(HashMap::from([(3, vec![1, 33])]));
 
@@ -235,7 +235,8 @@ fn test_verify_non_jumpdest() -> Result<()> {
     // jumpdest
     for i in 8..code_len - 1 {
         code[i] += 1;
-        let mut interpreter: Interpreter<F> = Interpreter::new(verify_non_jumpdest, vec![], None);
+        let mut interpreter: Interpreter<F> =
+            Interpreter::new(verify_non_jumpdest, vec![], None, &None);
         interpreter.generation_state.registers.context = CONTEXT;
 
         interpreter.set_code(CONTEXT, code.clone());

--- a/evm_arithmetization/src/cpu/kernel/tests/ecc/curve_ops.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/ecc/curve_ops.rs
@@ -185,7 +185,7 @@ mod bn {
 
             let mut initial_stack = u256ify(["0xdeadbeef"])?;
             initial_stack.push(k);
-            let mut int: Interpreter<F> = Interpreter::new(glv, initial_stack, None);
+            let mut int: Interpreter<F> = Interpreter::new(glv, initial_stack, None, &None);
             int.run()?;
 
             assert_eq!(line, int.stack());
@@ -203,7 +203,7 @@ mod bn {
             "0x10d7cf0621b6e42c1dbb421f5ef5e1936ca6a87b38198d1935be31e28821d171",
             "0x11b7d55f16aaac07de9a0ed8ac2e8023570dbaa78571fc95e553c4b3ba627689",
         ])?;
-        let mut int: Interpreter<F> = Interpreter::new(precompute, initial_stack, None);
+        let mut int: Interpreter<F> = Interpreter::new(precompute, initial_stack, None, &None);
         int.run()?;
 
         let mut computed_table = Vec::new();
@@ -356,7 +356,7 @@ mod secp {
 
             let mut initial_stack = u256ify(["0xdeadbeef"])?;
             initial_stack.push(k);
-            let mut int: Interpreter<F> = Interpreter::new(glv, initial_stack, None);
+            let mut int: Interpreter<F> = Interpreter::new(glv, initial_stack, None, &None);
             int.run()?;
 
             assert_eq!(line, int.stack());

--- a/evm_arithmetization/src/cpu/kernel/tests/exp.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/exp.rs
@@ -17,7 +17,7 @@ fn test_exp() -> Result<()> {
 
     // Random input
     let initial_stack = vec![0xDEADBEEFu32.into(), b, a];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack.clone(), None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack.clone(), None, &None);
 
     let stack_with_kernel = run_interpreter::<F>(exp, initial_stack)?.stack();
 

--- a/evm_arithmetization/src/cpu/kernel/tests/init_exc_stop.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/init_exc_stop.rs
@@ -104,8 +104,13 @@ fn test_init_exc_stop() {
     };
     let initial_stack = vec![];
     let initial_offset = KERNEL.global_labels["init"];
-    let mut interpreter: Interpreter<F> =
-        Interpreter::new_with_generation_inputs(initial_offset, initial_stack, &inputs, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new_with_generation_inputs(
+        initial_offset,
+        initial_stack,
+        &inputs,
+        None,
+        &None,
+    );
     interpreter.halt_offsets = vec![KERNEL.global_labels["main"]];
     interpreter.set_is_kernel(true);
     interpreter.run().expect("Running dummy init failed.");

--- a/evm_arithmetization/src/cpu/kernel/tests/log.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/log.rs
@@ -26,7 +26,7 @@ fn test_log_0() -> Result<()> {
         U256::from_big_endian(&address.to_fixed_bytes()),
     ];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack, None, &None);
     interpreter.set_global_metadata_field(GlobalMetadata::LogsLen, 0.into());
     interpreter.set_global_metadata_field(GlobalMetadata::LogsDataLen, 0.into());
 
@@ -70,7 +70,7 @@ fn test_log_2() -> Result<()> {
         U256::from_big_endian(&address.to_fixed_bytes()),
     ];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack, None, &None);
     interpreter.set_global_metadata_field(GlobalMetadata::LogsLen, 2.into());
     interpreter.set_global_metadata_field(GlobalMetadata::LogsDataLen, 5.into());
 
@@ -134,7 +134,7 @@ fn test_log_4() -> Result<()> {
         U256::from_big_endian(&address.to_fixed_bytes()),
     ];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack, None, &None);
     interpreter.set_global_metadata_field(GlobalMetadata::LogsLen, 2.into());
     interpreter.set_global_metadata_field(GlobalMetadata::LogsDataLen, 5.into());
 
@@ -197,7 +197,7 @@ fn test_log_5() -> Result<()> {
         U256::from_big_endian(&address.to_fixed_bytes()),
     ];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(logs_entry, initial_stack, None, &None);
     interpreter.set_global_metadata_field(GlobalMetadata::LogsLen, 0.into());
     interpreter.set_global_metadata_field(GlobalMetadata::LogsDataLen, 0.into());
 

--- a/evm_arithmetization/src/cpu/kernel/tests/mcopy.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mcopy.rs
@@ -22,7 +22,7 @@ fn test_mcopy(
     let kexit_info = U256::from(0xdeadbeefu32) + (U256::from(u64::from(true)) << 32);
     let initial_stack = vec![size.into(), offset.into(), dest_offset.into(), kexit_info];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(sys_mcopy, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(sys_mcopy, initial_stack, None, &None);
     interpreter.set_context_metadata_field(
         0,
         ContextMetadata::GasLimit,

--- a/evm_arithmetization/src/cpu/kernel/tests/mod.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mod.rs
@@ -59,7 +59,7 @@ pub(crate) fn run_interpreter<F: RichField>(
     initial_offset: usize,
     initial_stack: Vec<U256>,
 ) -> anyhow::Result<Interpreter<F>> {
-    let mut interpreter = Interpreter::new(initial_offset, initial_stack, None);
+    let mut interpreter = Interpreter::new(initial_offset, initial_stack, None, &None);
     interpreter.run()?;
     Ok(interpreter)
 }
@@ -78,7 +78,7 @@ pub(crate) fn run_interpreter_with_memory<F: RichField>(
     let label = KERNEL.global_labels[&memory_init.label];
     let mut stack = memory_init.stack;
     stack.reverse();
-    let mut interpreter = Interpreter::new(label, stack, None);
+    let mut interpreter = Interpreter::new(label, stack, None, &None);
     for (pointer, data) in memory_init.memory {
         for (i, term) in data.iter().enumerate() {
             interpreter.generation_state.memory.set(

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/delete.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/delete.rs
@@ -103,7 +103,7 @@ fn test_state_trie(
     let mpt_hash_state_trie = KERNEL.global_labels["mpt_hash_state_trie"];
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None, &None);
 
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/hash.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/hash.rs
@@ -113,7 +113,7 @@ fn test_state_trie(trie_inputs: TrieInputs) -> Result<()> {
     let mpt_hash_state_trie = KERNEL.global_labels["mpt_hash_state_trie"];
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None, &None);
 
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/hex_prefix.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/hex_prefix.rs
@@ -16,7 +16,7 @@ fn hex_prefix_even_nonterminated() -> Result<()> {
     let num_nibbles = 6.into();
     let rlp_pos = U256::from(Segment::RlpRaw as usize);
     let initial_stack = vec![retdest, terminated, packed_nibbles, num_nibbles, rlp_pos];
-    let mut interpreter: Interpreter<F> = Interpreter::new(hex_prefix, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(hex_prefix, initial_stack, None, &None);
     interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![rlp_pos + U256::from(5)]);
 
@@ -44,7 +44,7 @@ fn hex_prefix_odd_terminated() -> Result<()> {
     let num_nibbles = 5.into();
     let rlp_pos = U256::from(Segment::RlpRaw as usize);
     let initial_stack = vec![retdest, terminated, packed_nibbles, num_nibbles, rlp_pos];
-    let mut interpreter: Interpreter<F> = Interpreter::new(hex_prefix, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(hex_prefix, initial_stack, None, &None);
     interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![rlp_pos + U256::from(4)]);
 
@@ -71,7 +71,7 @@ fn hex_prefix_odd_terminated_tiny() -> Result<()> {
     let num_nibbles = 1.into();
     let rlp_pos = U256::from(Segment::RlpRaw as usize + 2);
     let initial_stack = vec![retdest, terminated, packed_nibbles, num_nibbles, rlp_pos];
-    let mut interpreter: Interpreter<F> = Interpreter::new(hex_prefix, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(hex_prefix, initial_stack, None, &None);
     interpreter.run()?;
     assert_eq!(
         interpreter.stack(),

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/insert.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/insert.rs
@@ -178,7 +178,7 @@ fn test_state_trie(
     let check_state_trie = KERNEL.global_labels["check_final_state_trie"];
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None, &None);
 
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/linked_list.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/linked_list.rs
@@ -30,7 +30,7 @@ fn init_logger() {
 fn test_init_linked_lists() -> Result<()> {
     init_logger();
 
-    let interpreter = Interpreter::<F>::new(0, vec![], None);
+    let interpreter = Interpreter::<F>::new(0, vec![], None, &None);
 
     // Check the initial accounts linked list
     let acc_addr_list: Vec<U256> = (0..4)
@@ -78,7 +78,7 @@ fn test_init_linked_lists() -> Result<()> {
 fn test_list_iterator() -> Result<()> {
     init_logger();
 
-    let interpreter = Interpreter::<F>::new(0, vec![], None);
+    let interpreter = Interpreter::<F>::new(0, vec![], None, &None);
 
     // test the list iterator
     let accounts_mem = interpreter
@@ -133,7 +133,7 @@ fn test_list_iterator() -> Result<()> {
 fn test_insert_account() -> Result<()> {
     init_logger();
 
-    let mut interpreter = Interpreter::<F>::new(0, vec![], None);
+    let mut interpreter = Interpreter::<F>::new(0, vec![], None, &None);
 
     // Initialize the accounts linked list.
     let init_accounts_ll = vec![
@@ -215,7 +215,7 @@ fn test_insert_account() -> Result<()> {
 fn test_insert_storage() -> Result<()> {
     init_logger();
 
-    let mut interpreter = Interpreter::<F>::new(0, vec![], None);
+    let mut interpreter = Interpreter::<F>::new(0, vec![], None, &None);
 
     // Initialize the storage linked list.
     let init_storage_ll = vec![
@@ -306,7 +306,7 @@ fn test_insert_storage() -> Result<()> {
 fn test_insert_and_delete_accounts() -> Result<()> {
     init_logger();
 
-    let mut interpreter = Interpreter::<F>::new(0, vec![], None);
+    let mut interpreter = Interpreter::<F>::new(0, vec![], None, &None);
 
     // Initialize the accounts linked list.
     let init_accounts_ll = vec![
@@ -490,7 +490,7 @@ fn test_insert_and_delete_accounts() -> Result<()> {
 fn test_insert_and_delete_storage() -> Result<()> {
     init_logger();
 
-    let mut interpreter = Interpreter::<F>::new(0, vec![], None);
+    let mut interpreter = Interpreter::<F>::new(0, vec![], None, &None);
 
     // Initialize the storage linked list.
     let init_storage_ll = vec![

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/load.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/load.rs
@@ -25,7 +25,7 @@ fn load_all_mpts_empty() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None, &None);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
@@ -62,7 +62,7 @@ fn load_all_mpts_leaf() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None, &None);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
@@ -114,7 +114,7 @@ fn load_all_mpts_hash() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None, &None);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
@@ -152,7 +152,7 @@ fn load_all_mpts_empty_branch() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None, &None);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
@@ -204,7 +204,7 @@ fn load_all_mpts_ext_to_leaf() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None, &None);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 
@@ -256,7 +256,7 @@ fn load_mpt_txn_trie() -> Result<()> {
     };
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None, &None);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 

--- a/evm_arithmetization/src/cpu/kernel/tests/mpt/read.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/mpt/read.rs
@@ -21,7 +21,7 @@ fn mpt_read() -> Result<()> {
     let mpt_read = KERNEL.global_labels["mpt_read"];
 
     let initial_stack = vec![];
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None, &None);
     initialize_mpts(&mut interpreter, &trie_inputs);
     assert_eq!(interpreter.stack(), vec![]);
 

--- a/evm_arithmetization/src/cpu/kernel/tests/packing.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/packing.rs
@@ -16,7 +16,8 @@ fn test_mstore_unpacking() -> Result<()> {
     let addr = (Segment::TxnData as u64).into();
     let initial_stack = vec![retdest, len, value, addr];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(mstore_unpacking, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(mstore_unpacking, initial_stack, None, &None);
 
     interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![addr + U256::from(4)]);

--- a/evm_arithmetization/src/cpu/kernel/tests/receipt.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/receipt.rs
@@ -49,7 +49,8 @@ fn test_process_receipt() -> Result<()> {
         leftover_gas,
         success,
     ];
-    let mut interpreter: Interpreter<F> = Interpreter::new(process_receipt, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(process_receipt, initial_stack, None, &None);
     interpreter.set_memory_segment(
         Segment::LogsData,
         vec![
@@ -137,7 +138,8 @@ fn test_receipt_encoding() -> Result<()> {
     // Address at which the encoding is written.
     let rlp_addr = U256::from(Segment::RlpRaw as usize);
     let initial_stack: Vec<U256> = vec![retdest, 0.into(), 0.into(), rlp_addr];
-    let mut interpreter: Interpreter<F> = Interpreter::new(encode_receipt, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(encode_receipt, initial_stack, None, &None);
 
     // Write data to memory.
     let expected_bloom_bytes = vec![
@@ -257,7 +259,7 @@ fn test_receipt_bloom_filter() -> Result<()> {
     // Set logs memory and initialize TxnBloom and BlockBloom segments.
     let initial_stack: Vec<U256> = vec![retdest];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(logs_bloom, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(logs_bloom, initial_stack, None, &None);
     let mut logs = vec![
         0.into(), // unused
         addr,
@@ -419,7 +421,7 @@ fn test_mpt_insert_receipt() -> Result<()> {
     receipt.push(num_logs.into()); // num_logs
     receipt.extend(logs_0.clone());
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], None, &None);
     initialize_mpts(&mut interpreter, &trie_inputs);
 
     // If TrieData is empty, we need to push 0 because the first value is always 0.
@@ -578,7 +580,7 @@ fn test_bloom_two_logs() -> Result<()> {
         ]
         .into(),
     ];
-    let mut interpreter: Interpreter<F> = Interpreter::new(logs_bloom, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(logs_bloom, initial_stack, None, &None);
     interpreter.set_memory_segment(Segment::TxnBloom, vec![0.into(); 256]); // Initialize transaction Bloom filter.
     interpreter.set_memory_segment(Segment::LogsData, logs);
     interpreter.set_memory_segment(Segment::Logs, vec![0.into(), 4.into()]);

--- a/evm_arithmetization/src/cpu/kernel/tests/rlp/decode.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/rlp/decode.rs
@@ -15,7 +15,7 @@ fn test_decode_rlp_string_len_short() -> Result<()> {
         U256::from(Segment::RlpRaw as usize + 2),
     ];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new(decode_rlp_string_len, initial_stack, None);
+        Interpreter::new(decode_rlp_string_len, initial_stack, None, &None);
 
     // A couple dummy bytes, followed by "0x70" which is its own encoding.
     interpreter.set_rlp_memory(vec![123, 234, 0x70]);
@@ -36,7 +36,7 @@ fn test_decode_rlp_string_len_medium() -> Result<()> {
         U256::from(Segment::RlpRaw as usize + 2),
     ];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new(decode_rlp_string_len, initial_stack, None);
+        Interpreter::new(decode_rlp_string_len, initial_stack, None, &None);
 
     // A couple dummy bytes, followed by the RLP encoding of "1 2 3 4 5".
     interpreter.set_rlp_memory(vec![123, 234, 0x85, 1, 2, 3, 4, 5]);
@@ -57,7 +57,7 @@ fn test_decode_rlp_string_len_long() -> Result<()> {
         U256::from(Segment::RlpRaw as usize + 2),
     ];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new(decode_rlp_string_len, initial_stack, None);
+        Interpreter::new(decode_rlp_string_len, initial_stack, None, &None);
 
     // The RLP encoding of the string "1 2 3 ... 56".
     interpreter.set_rlp_memory(vec![
@@ -79,7 +79,7 @@ fn test_decode_rlp_list_len_short() -> Result<()> {
 
     let initial_stack = vec![0xDEADBEEFu32.into(), U256::from(Segment::RlpRaw as usize)];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new(decode_rlp_list_len, initial_stack, None);
+        Interpreter::new(decode_rlp_list_len, initial_stack, None, &None);
 
     // The RLP encoding of [1, 2, [3, 4]].
     interpreter.set_rlp_memory(vec![0xc5, 1, 2, 0xc2, 3, 4]);
@@ -97,7 +97,7 @@ fn test_decode_rlp_list_len_long() -> Result<()> {
 
     let initial_stack = vec![0xDEADBEEFu32.into(), U256::from(Segment::RlpRaw as usize)];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new(decode_rlp_list_len, initial_stack, None);
+        Interpreter::new(decode_rlp_list_len, initial_stack, None, &None);
 
     // The RLP encoding of [1, ..., 56].
     interpreter.set_rlp_memory(vec![
@@ -118,7 +118,8 @@ fn test_decode_rlp_scalar() -> Result<()> {
     let decode_rlp_scalar = KERNEL.global_labels["decode_rlp_scalar"];
 
     let initial_stack = vec![0xDEADBEEFu32.into(), U256::from(Segment::RlpRaw as usize)];
-    let mut interpreter: Interpreter<F> = Interpreter::new(decode_rlp_scalar, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(decode_rlp_scalar, initial_stack, None, &None);
 
     // The RLP encoding of "12 34 56".
     interpreter.set_rlp_memory(vec![0x83, 0x12, 0x34, 0x56]);

--- a/evm_arithmetization/src/cpu/kernel/tests/rlp/encode.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/rlp/encode.rs
@@ -14,7 +14,8 @@ fn test_encode_rlp_scalar_small() -> Result<()> {
     let scalar = 42.into();
     let pos = U256::from(Segment::RlpRaw as usize + 2);
     let initial_stack = vec![retdest, scalar, pos];
-    let mut interpreter: Interpreter<F> = Interpreter::new(encode_rlp_scalar, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(encode_rlp_scalar, initial_stack, None, &None);
 
     interpreter.run()?;
     let expected_stack = vec![pos + U256::from(1)]; // pos' = pos + rlp_len = 2 + 1
@@ -37,7 +38,8 @@ fn test_encode_rlp_scalar_medium() -> Result<()> {
     let scalar = 0x12345.into();
     let pos = U256::from(Segment::RlpRaw as usize + 2);
     let initial_stack = vec![retdest, scalar, pos];
-    let mut interpreter: Interpreter<F> = Interpreter::new(encode_rlp_scalar, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(encode_rlp_scalar, initial_stack, None, &None);
 
     interpreter.run()?;
     let expected_stack = vec![pos + U256::from(4)]; // pos' = pos + rlp_len = 2 + 4
@@ -60,7 +62,8 @@ fn test_encode_rlp_160() -> Result<()> {
     let string = 0x12345.into();
     let pos = U256::from(Segment::RlpRaw as usize);
     let initial_stack = vec![retdest, string, pos, U256::from(20)];
-    let mut interpreter: Interpreter<F> = Interpreter::new(encode_rlp_fixed, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(encode_rlp_fixed, initial_stack, None, &None);
 
     interpreter.run()?;
     let expected_stack = vec![pos + U256::from(1 + 20)]; // pos'
@@ -80,7 +83,8 @@ fn test_encode_rlp_256() -> Result<()> {
     let string = 0x12345.into();
     let pos = U256::from(Segment::RlpRaw as usize);
     let initial_stack = vec![retdest, string, pos, U256::from(32)];
-    let mut interpreter: Interpreter<F> = Interpreter::new(encode_rlp_fixed, initial_stack, None);
+    let mut interpreter: Interpreter<F> =
+        Interpreter::new(encode_rlp_fixed, initial_stack, None, &None);
 
     interpreter.run()?;
     let expected_stack = vec![pos + U256::from(1 + 32)]; // pos'
@@ -101,7 +105,7 @@ fn test_prepend_rlp_list_prefix_small() -> Result<()> {
     let end_pos = U256::from(Segment::RlpRaw as usize + 9 + 5);
     let initial_stack = vec![retdest, start_pos, end_pos];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new(prepend_rlp_list_prefix, initial_stack, None);
+        Interpreter::new(prepend_rlp_list_prefix, initial_stack, None, &None);
     interpreter.set_rlp_memory(vec![
         // Nine 0s to leave room for the longest possible RLP list prefix.
         0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -131,7 +135,7 @@ fn test_prepend_rlp_list_prefix_large() -> Result<()> {
     let end_pos = U256::from(Segment::RlpRaw as usize + 9 + 60);
     let initial_stack = vec![retdest, start_pos, end_pos];
     let mut interpreter: Interpreter<F> =
-        Interpreter::new(prepend_rlp_list_prefix, initial_stack, None);
+        Interpreter::new(prepend_rlp_list_prefix, initial_stack, None, &None);
 
     #[rustfmt::skip]
     interpreter.set_rlp_memory(vec![

--- a/evm_arithmetization/src/cpu/kernel/tests/rlp/num_bytes.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/rlp/num_bytes.rs
@@ -11,7 +11,7 @@ fn test_num_bytes_0() -> Result<()> {
     let retdest = 0xDEADBEEFu32.into();
     let x = 0.into();
     let initial_stack = vec![retdest, x];
-    let mut interpreter: Interpreter<F> = Interpreter::new(num_bytes, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(num_bytes, initial_stack, None, &None);
 
     interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![1.into()]);
@@ -25,7 +25,7 @@ fn test_num_bytes_small() -> Result<()> {
     let retdest = 0xDEADBEEFu32.into();
     let x = 42.into();
     let initial_stack = vec![retdest, x];
-    let mut interpreter: Interpreter<F> = Interpreter::new(num_bytes, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(num_bytes, initial_stack, None, &None);
 
     interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![1.into()]);
@@ -39,7 +39,7 @@ fn test_num_bytes_medium() -> Result<()> {
     let retdest = 0xDEADBEEFu32.into();
     let x = 0xAABBCCDDu32.into();
     let initial_stack = vec![retdest, x];
-    let mut interpreter: Interpreter<F> = Interpreter::new(num_bytes, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(num_bytes, initial_stack, None, &None);
 
     interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![4.into()]);

--- a/evm_arithmetization/src/cpu/kernel/tests/signed_syscalls.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/signed_syscalls.rs
@@ -118,7 +118,7 @@ fn run_test(fn_label: &str, expected_fn: fn(U256, U256) -> U256, opname: &str) {
     for &x in &inputs {
         for &y in &inputs {
             let stack = vec![retdest, y, x];
-            let mut interpreter: Interpreter<F> = Interpreter::new(fn_label, stack, None);
+            let mut interpreter: Interpreter<F> = Interpreter::new(fn_label, stack, None, &None);
             interpreter.run().unwrap();
             assert_eq!(interpreter.stack_len(), 1usize, "unexpected stack size");
             let output = interpreter

--- a/evm_arithmetization/src/cpu/kernel/tests/transaction_parsing/parse_type_0_txn.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/transaction_parsing/parse_type_0_txn.rs
@@ -29,7 +29,7 @@ fn process_type_0_txn() -> Result<()> {
     // rlp.encode(signed_txn).hex()
     let txn = hex!("f861050a8255f0940000000000000000000000000000000000000000648242421ca07c5c61ed975ebd286f6b027b8c504842e50a47d318e1e801719dd744fe93e6c6a01e7b5119b57dd54e175ff2f055c91f3ab1b53eba0b2c184f347cdff0e745aca2").to_vec();
 
-    let mut interpreter = Interpreter::<F>::new(0, vec![], None);
+    let mut interpreter = Interpreter::<F>::new(0, vec![], None, &None);
     prepare_interpreter_for_txn_parsing(
         &mut interpreter,
         KERNEL.global_labels["process_type_0_txn"],
@@ -77,7 +77,7 @@ fn process_type_0_txn_invalid_sig() -> Result<()> {
     // It should fail according to EIP-2 (`s` must be no greater than `N/2`).
     let txn = hex!("f861050a8255f0940000000000000000000000000000000000000000648242421ca07c5c61ed975ebd286f6b027b8c504842e50a47d318e1e801719dd744fe93e6c6a0e184aee64a822ab1e8a00d0faa36e0c408f99e2ca41c87ec8b557e9be8f0949f").to_vec();
 
-    let mut interpreter = Interpreter::<F>::new(0, vec![], None);
+    let mut interpreter = Interpreter::<F>::new(0, vec![], None, &None);
     prepare_interpreter_for_txn_parsing(
         &mut interpreter,
         KERNEL.global_labels["process_type_1_txn"],

--- a/evm_arithmetization/src/cpu/kernel/tests/transaction_parsing/parse_type_1_txn.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/transaction_parsing/parse_type_1_txn.rs
@@ -47,7 +47,7 @@ fn process_type_1_txn() -> Result<()> {
     // encode(signed_tx).hex()[4::] # We don't need the initial RLP prefix.
     let txn = hex!("01f867820539018203e882520894000000000000000000000000000000000000000201824242c080a0e0c03d1aae7278dffd6c864231a5bb571d7ee3ececd3718b26d3d8554b4987f5a02dfb1aeea35ba8c5191abb6efdae6f73c052209fc6a598025b7292db470d9450").to_vec();
 
-    let mut interpreter = Interpreter::<F>::new(0, vec![], None);
+    let mut interpreter = Interpreter::<F>::new(0, vec![], None, &None);
     prepare_interpreter_for_txn_parsing(
         &mut interpreter,
         KERNEL.global_labels["process_type_1_txn"],
@@ -95,7 +95,7 @@ fn process_type_1_txn_invalid_sig() -> Result<()> {
     // It should fail according to EIP-2 (`s` must be no greater than `N/2`).
     let txn = hex!("01f867820539018203e882520894000000000000000000000000000000000000000201824242c080a0e0c03d1aae7278dffd6c864231a5bb571d7ee3ececd3718b26d3d8554b4987f5a0d204e5115ca4573ae6e544910251908afa5cbc46e8a30839645fcbb18928acf1").to_vec();
 
-    let mut interpreter = Interpreter::<F>::new(0, vec![], None);
+    let mut interpreter = Interpreter::<F>::new(0, vec![], None, &None);
     prepare_interpreter_for_txn_parsing(
         &mut interpreter,
         KERNEL.global_labels["process_type_1_txn"],

--- a/evm_arithmetization/src/cpu/kernel/tests/transaction_parsing/parse_type_2_txn.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/transaction_parsing/parse_type_2_txn.rs
@@ -48,7 +48,7 @@ fn process_type_2_txn() -> Result<()> {
     // encode(signed_tx).hex()[4::] # We don't need the initial RLP prefix.
     let txn =  hex!("02f86a820539018203e88201f482520894000000000000000000000000000000000000000201824242c080a06312f059f931a9cf9e9ef4648b14fff1d6f88fbc1aed5ebcb1138f50e295a6b3a0252349ddb42d28b1b2b7c749370867047c8c33d4a0ada8ff7f0d5b71bea862ab").to_vec();
 
-    let mut interpreter = Interpreter::<F>::new(0, vec![], None);
+    let mut interpreter = Interpreter::<F>::new(0, vec![], None, &None);
     prepare_interpreter_for_txn_parsing(
         &mut interpreter,
         KERNEL.global_labels["process_type_2_txn"],
@@ -96,7 +96,7 @@ fn process_type_2_txn_invalid_sig() -> Result<()> {
     // It should fail according to EIP-2 (`s` must be no greater than `N/2`).
     let txn = hex!("f86a820539018203e88201f482520894000000000000000000000000000000000000000201824242c080a06312f059f931a9cf9e9ef4648b14fff1d6f88fbc1aed5ebcb1138f50e295a6b3a0dadcb6224bd2d74e4d4838b6c8f798fa3e22a9120e9af73c40c5031b118dde96").to_vec();
 
-    let mut interpreter = Interpreter::<F>::new(0, vec![], None);
+    let mut interpreter = Interpreter::<F>::new(0, vec![], None, &None);
     prepare_interpreter_for_txn_parsing(
         &mut interpreter,
         KERNEL.global_labels["process_type_2_txn"],

--- a/evm_arithmetization/src/cpu/kernel/tests/transaction_parsing/parse_type_3_txn.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/transaction_parsing/parse_type_3_txn.rs
@@ -23,7 +23,7 @@ fn process_type_3_txn() -> Result<()> {
         code_hash: H256::default(),
     };
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], None, &None);
     // Prepare the interpreter by inserting the sender account in the state trie.
     prepare_interpreter(&mut interpreter, sender_address, &sender_account)?;
 
@@ -114,7 +114,7 @@ fn process_type_3_txn_invalid_sig() -> Result<()> {
         code_hash: H256::default(),
     };
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, vec![], None, &None);
     // Prepare the interpreter by inserting the sender account in the state trie.
     prepare_interpreter(&mut interpreter, sender_address, &sender_account)?;
 
@@ -124,7 +124,7 @@ fn process_type_3_txn_invalid_sig() -> Result<()> {
     // It should fail according to EIP-2 (`s` must be no greater than `N/2`).
     let txn = hex!("03f8b1820539018203e88201f482520894000000000000000000000000000000000000000201824242c08203e8f842a00101010101010101010101010101010101010101010101010101010101010101a0010101010101010101010101010101010101010101010101010101010101010180a076e2a81a28e69fb1e96f5e9470b454b80663197b416c3783be98a6b5bd162b21a0e5e7d285c7907e4342338eb4d4b7e4866633b5fc0893c1fa4105226ffafb8908").to_vec();
 
-    let mut interpreter = Interpreter::<F>::new(0, vec![], None);
+    let mut interpreter = Interpreter::<F>::new(0, vec![], None, &None);
     prepare_interpreter_for_txn_parsing(
         &mut interpreter,
         KERNEL.global_labels["process_type_3_txn"],

--- a/evm_arithmetization/src/cpu/kernel/tests/transient_storage.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/transient_storage.rs
@@ -58,7 +58,7 @@ fn test_tstore() -> Result<()> {
         kexit_info,
     ];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(sys_tstore, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(sys_tstore, initial_stack, None, &None);
     initialize_interpreter(&mut interpreter, 100.into());
 
     interpreter.run()?;
@@ -104,7 +104,7 @@ fn test_tstore_tload() -> Result<()> {
         kexit_info,
     ];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(sys_tstore, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(sys_tstore, initial_stack, None, &None);
     initialize_interpreter(&mut interpreter, 200.into());
 
     interpreter.run()?;
@@ -162,7 +162,7 @@ fn test_many_tstore_many_tload() -> Result<()> {
         kexit_info,
     ];
 
-    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None);
+    let mut interpreter: Interpreter<F> = Interpreter::new(0, initial_stack, None, &None);
     initialize_interpreter(&mut interpreter, (10 * 200).into());
 
     for i in 0..10 {
@@ -235,7 +235,7 @@ fn test_revert() -> Result<()> {
     });
 
     let sys_tstore = TEST_KERNEL.global_labels["sys_tstore"];
-    let mut interpreter = Interpreter::<F>::new(sys_tstore, vec![], None);
+    let mut interpreter = Interpreter::<F>::new(sys_tstore, vec![], None, &None);
     interpreter.generation_state =
         GenerationState::<F>::new(&GenerationInputs::default(), &TEST_KERNEL.code).unwrap();
     initialize_interpreter(&mut interpreter, (20 * 100).into());

--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -54,6 +54,7 @@ use crate::recursive_verifier::{
     recursive_stark_circuit, set_final_public_value_targets, set_public_value_targets,
     PlonkWrapperCircuit, PublicInputs, StarkWrapperCircuit,
 };
+use crate::structlog::zerostructlog::ZeroStructLog;
 use crate::util::h256_limbs;
 use crate::verifier::initial_memory_merkle_cap;
 
@@ -1906,13 +1907,14 @@ where
         config: &StarkConfig,
         generation_inputs: GenerationInputs<F>,
         max_cpu_len_log: usize,
+        struct_logs: Option<Vec<Option<Vec<ZeroStructLog>>>>,
         timing: &mut TimingTree,
         abort_signal: Option<Arc<AtomicBool>>,
     ) -> anyhow::Result<Vec<ProverOutputData<F, C, D>>> {
         features_check(&generation_inputs.clone().trim());
 
         let segment_iterator =
-            SegmentDataIterator::<F>::new(&generation_inputs, Some(max_cpu_len_log));
+            SegmentDataIterator::<F>::new(&generation_inputs, Some(max_cpu_len_log), &struct_logs);
 
         let mut proofs = vec![];
 
@@ -3024,7 +3026,7 @@ mod tests {
         // Generate a dummy payload for testing
         let payload = empty_payload()?;
         let max_cpu_len_log = Some(7);
-        let mut segment_iterator = SegmentDataIterator::<F>::new(&payload, max_cpu_len_log);
+        let mut segment_iterator = SegmentDataIterator::<F>::new(&payload, max_cpu_len_log, &None);
         let (_, mut segment_data) = segment_iterator.next().unwrap()?;
 
         let opcode_counts = &segment_data.opcode_counts;

--- a/evm_arithmetization/src/generation/segments.rs
+++ b/evm_arithmetization/src/generation/segments.rs
@@ -12,6 +12,7 @@ use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::interpreter::{set_registers_and_run, ExtraSegmentData, Interpreter};
 use crate::generation::state::State;
 use crate::generation::{collect_debug_tries, debug_inputs, ErrorWithTries, GenerationInputs};
+use crate::structlog::zerostructlog::ZeroStructLog;
 use crate::witness::memory::MemoryState;
 use crate::witness::operation::Operation;
 use crate::witness::state::RegistersState;
@@ -100,7 +101,11 @@ pub struct SegmentError {
 }
 
 impl<F: RichField> SegmentDataIterator<F> {
-    pub fn new(inputs: &GenerationInputs<F>, max_cpu_len_log: Option<usize>) -> Self {
+    pub fn new(
+        inputs: &GenerationInputs<F>,
+        max_cpu_len_log: Option<usize>,
+        struct_logs: &Option<Vec<Option<Vec<ZeroStructLog>>>>,
+    ) -> Self {
         debug_inputs(inputs);
 
         let interpreter = Interpreter::<F>::new_with_generation_inputs(
@@ -108,6 +113,7 @@ impl<F: RichField> SegmentDataIterator<F> {
             vec![],
             inputs,
             max_cpu_len_log,
+            struct_logs,
         );
 
         Self {

--- a/evm_arithmetization/src/lib.rs
+++ b/evm_arithmetization/src/lib.rs
@@ -266,6 +266,7 @@ pub mod memory;
 pub mod memory_continuation;
 #[cfg(feature = "cdk_erigon")]
 pub mod poseidon;
+pub mod structlog;
 
 // Proving system components
 pub mod all_stark;

--- a/evm_arithmetization/src/structlog.rs
+++ b/evm_arithmetization/src/structlog.rs
@@ -1,0 +1,159 @@
+use alloy::primitives::B256;
+use alloy::providers::ext::DebugApi;
+use alloy::providers::Provider;
+use alloy::rpc::types::trace::geth::{GethDebugTracingOptions, GethDefaultTracingOptions};
+use alloy::transports::RpcError;
+use alloy::transports::Transport;
+use alloy::transports::TransportErrorKind;
+use zerostructlog::{normalize_structlog, ZeroStructLog};
+
+/// Pass `true` for the components needed.
+fn structlog_tracing_options(stack: bool, memory: bool, storage: bool) -> GethDebugTracingOptions {
+    GethDebugTracingOptions {
+        config: GethDefaultTracingOptions {
+            disable_stack: Some(!stack),
+            // needed for CREATE2
+            disable_memory: Some(!memory),
+            disable_storage: Some(!storage),
+            ..GethDefaultTracingOptions::default()
+        },
+        tracer: None,
+        ..GethDebugTracingOptions::default()
+    }
+}
+
+// Gets the lightest possible structlog for transcation `tx_hash`.
+pub async fn get_structlog_for_debug<ProviderT, TransportT>(
+    provider: &ProviderT,
+    tx_hash: &B256,
+) -> Result<Option<Vec<ZeroStructLog>>, RpcError<TransportErrorKind>>
+where
+    ProviderT: Provider<TransportT>,
+    TransportT: Transport + Clone,
+{
+    let light_structlog_trace = provider
+        .debug_trace_transaction(*tx_hash, structlog_tracing_options(true, false, false))
+        .await?;
+
+    let structlogs: Option<Vec<ZeroStructLog>> = normalize_structlog(light_structlog_trace);
+
+    Ok(structlogs)
+}
+
+pub mod zerostructlog {
+    use std::collections::BTreeMap;
+
+    use alloy::rpc::types::trace::geth::{DefaultFrame, GethTrace, StructLog};
+    use alloy_primitives::{Bytes, B256, U256};
+    use serde::{Deserialize, Serialize};
+    use serde_json::Value;
+
+    /// Geth Default struct log trace frame
+    ///
+    /// <https://github.com/ethereum/go-ethereum/blob/a9ef135e2dd53682d106c6a2aede9187026cc1de/eth/tracers/logger/logger.go#L406-L411>
+    #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub(crate) struct ZeroDefaultFrame {
+        /// Whether the transaction failed
+        pub failed: bool,
+        /// How much gas was used.
+        pub gas: u64,
+        /// Output of the transaction
+        #[serde(serialize_with = "alloy_serde::serialize_hex_string_no_prefix")]
+        pub return_value: Bytes,
+        /// Recorded traces of the transaction
+        pub struct_logs: Vec<ZeroStructLog>,
+    }
+
+    /// Represents a struct log entry in a trace
+    ///
+    /// <https://github.com/ethereum/go-ethereum/blob/366d2169fbc0e0f803b68c042b77b6b480836dbc/eth/tracers/logger/logger.go#L413-L426>
+    #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct ZeroStructLog {
+        /// program counter
+        pub pc: u64,
+        /// opcode to be executed
+        pub op: String,
+        /// remaining gas
+        pub gas: u64,
+        /// cost for executing op
+        #[serde(rename = "gasCost")]
+        pub gas_cost: u64,
+        /// Current call depth
+        pub depth: u64,
+        /// Error message if any
+        #[serde(default)]
+        pub error: Option<String>,
+        /// EVM stack
+        #[serde(default)]
+        pub stack: Option<Vec<U256>>,
+        /// Last call's return data. Enabled via enableReturnData
+        #[serde(default, rename = "returnData")]
+        pub return_data: Option<Bytes>,
+        /// ref <https://github.com/ethereum/go-ethereum/blob/366d2169fbc0e0f803b68c042b77b6b480836dbc/eth/tracers/logger/logger.go#L450-L452>
+        #[serde(default)]
+        pub memory: Option<Vec<String>>,
+        /// Size of memory.
+        #[serde(default, rename = "memSize")]
+        pub memory_size: Option<u64>,
+        /// Storage slots of current contract read from and written to. Only
+        /// emitted for SLOAD and SSTORE. Disabled via disableStorage
+        #[serde(default)]
+        pub storage: Option<BTreeMap<B256, B256>>,
+        /// Refund counter
+        #[serde(default, rename = "refund")]
+        pub refund_counter: Option<u64>,
+    }
+
+    impl From<StructLog> for ZeroStructLog {
+        fn from(struct_log: StructLog) -> Self {
+            ZeroStructLog {
+                pc: struct_log.pc,
+                op: struct_log.op,
+                gas: struct_log.gas,
+                gas_cost: struct_log.gas_cost,
+                depth: struct_log.depth,
+                error: struct_log.error,
+                stack: struct_log.stack,
+                return_data: struct_log.return_data,
+                memory: struct_log.memory,
+                memory_size: struct_log.memory_size,
+                storage: struct_log.storage,
+                refund_counter: struct_log.refund_counter,
+            }
+        }
+    }
+
+    pub fn try_reserialize(structlog_object: &Value) -> anyhow::Result<DefaultFrame> {
+        let mut a = serde_json::to_string(structlog_object)?;
+        a = a.replace("\"error\":{},", "");
+
+        let b = serde_json::from_str::<DefaultFrame>(&a)?;
+        let d: DefaultFrame = b.try_into()?;
+        Ok(d)
+    }
+
+    pub(crate) fn normalize_structlog(
+        unnormalized_structlog: GethTrace,
+    ) -> Option<Vec<ZeroStructLog>> {
+        match unnormalized_structlog {
+            GethTrace::Default(structlog_frame) => {
+                let all_struct_logs = structlog_frame
+                    .struct_logs
+                    .into_iter()
+                    .map(|log| ZeroStructLog::from(log))
+                    .collect::<Vec<ZeroStructLog>>();
+                Some(all_struct_logs)
+            }
+            GethTrace::JS(structlog_js_object) => {
+                try_reserialize(&structlog_js_object).ok().map(|s| {
+                    s.struct_logs
+                        .into_iter()
+                        .map(|log| ZeroStructLog::from(log))
+                        .collect::<Vec<ZeroStructLog>>()
+                })
+            }
+            _ => None,
+        }
+    }
+}

--- a/evm_arithmetization/src/witness/errors.rs
+++ b/evm_arithmetization/src/witness/errors.rs
@@ -16,6 +16,7 @@ pub enum ProgramError {
     IntegerTooLarge,
     ProverInputError(ProverInputError),
     UnknownContractCode,
+    StructLogDebuggerError,
 }
 
 #[allow(clippy::enum_variant_names)]

--- a/evm_arithmetization/src/witness/operation.rs
+++ b/evm_arithmetization/src/witness/operation.rs
@@ -15,10 +15,10 @@ use crate::cpu::columns::CpuColumnsView;
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::assembler::BYTES_PER_OFFSET;
 use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
-use crate::cpu::kernel::constants::txn_fields::NormalizedTxnField;
 use crate::cpu::simple_logic::eq_iszero::generate_pinv_diff;
 use crate::cpu::stack::MAX_USER_STACK_SIZE;
 use crate::extension_tower::BN_BASE;
+use crate::generation::state::State;
 use crate::memory::segments::Segment;
 use crate::util::u256_to_usize;
 use crate::witness::errors::MemoryError::VirtTooLarge;
@@ -851,14 +851,16 @@ pub(crate) fn generate_exit_kernel<F: RichField, T: Transition<F>>(
     // If we are in debug mode and the next operation is in user mode, update the
     // `gas` field so we can check against struct logs.
     if !is_kernel_mode {
-        let get_field = |field: NormalizedTxnField| {
-            state.get_generation_state().memory.contexts[0].segments[Segment::TxnFields.unscale()]
-                .get(field.unscale())
-                .as_usize()
-        };
-        let intrinsic_gas = get_field(NormalizedTxnField::IntrinsicGas);
-        let max_gas = get_field(NormalizedTxnField::GasLimit);
-        let txn_gas = max_gas - intrinsic_gas - gas_used_val as usize;
+        let gas_limit_address = MemoryAddress::new(
+            state.get_registers().context,
+            Segment::ContextMetadata,
+            ContextMetadata::GasLimit.unscale(), // context offsets are already scaled
+        );
+        let init_gas_limit = state
+            .get_mut_generation_state()
+            .get_from_memory(gas_limit_address)
+            .as_usize();
+        let txn_gas = init_gas_limit - gas_used_val as usize;
 
         state.update_struct_logs_gas(txn_gas);
     }

--- a/evm_arithmetization/tests/add11_yml.rs
+++ b/evm_arithmetization/tests/add11_yml.rs
@@ -220,6 +220,7 @@ fn add11_yml() -> anyhow::Result<()> {
         &config,
         inputs,
         max_cpu_len_log,
+        None,
         &mut timing,
         None,
     )?;

--- a/evm_arithmetization/tests/erc20.rs
+++ b/evm_arithmetization/tests/erc20.rs
@@ -205,6 +205,7 @@ fn test_erc20() -> anyhow::Result<()> {
         &config,
         inputs,
         max_cpu_len_log,
+        None,
         &mut timing,
         None,
     )?;

--- a/evm_arithmetization/tests/erc721.rs
+++ b/evm_arithmetization/tests/erc721.rs
@@ -209,6 +209,7 @@ fn test_erc721() -> anyhow::Result<()> {
         &config,
         inputs,
         max_cpu_len_log,
+        None,
         &mut timing,
         None,
     )?;

--- a/evm_arithmetization/tests/global_exit_root.rs
+++ b/evm_arithmetization/tests/global_exit_root.rs
@@ -123,6 +123,7 @@ fn test_global_exit_root() -> anyhow::Result<()> {
         &config,
         inputs,
         max_cpu_len_log,
+        None,
         &mut timing,
         None,
     )?;

--- a/evm_arithmetization/tests/log_opcode.rs
+++ b/evm_arithmetization/tests/log_opcode.rs
@@ -276,6 +276,7 @@ fn test_log_opcodes() -> anyhow::Result<()> {
         &config,
         inputs,
         max_cpu_len_log,
+        None,
         &mut timing,
         None,
     )?;

--- a/evm_arithmetization/tests/selfdestruct.rs
+++ b/evm_arithmetization/tests/selfdestruct.rs
@@ -180,6 +180,7 @@ fn test_selfdestruct() -> anyhow::Result<()> {
         &config,
         inputs,
         max_cpu_len_log,
+        None,
         &mut timing,
         None,
     )?;

--- a/evm_arithmetization/tests/simple_transfer.rs
+++ b/evm_arithmetization/tests/simple_transfer.rs
@@ -172,6 +172,7 @@ fn test_simple_transfer() -> anyhow::Result<()> {
         &config,
         inputs,
         max_cpu_len_log,
+        None,
         &mut timing,
         None,
     )?;

--- a/evm_arithmetization/tests/two_to_one_block.rs
+++ b/evm_arithmetization/tests/two_to_one_block.rs
@@ -111,9 +111,9 @@ fn get_test_block_proof(
 
     let timing = &mut TimingTree::new(&format!("Blockproof {timestamp}"), log::Level::Info);
     let dummy0_proof0 =
-        all_circuits.prove_all_segments(all_stark, config, dummy0, 20, timing, None)?;
+        all_circuits.prove_all_segments(all_stark, config, dummy0, 20, None, timing, None)?;
     let dummy1_proof =
-        all_circuits.prove_all_segments(all_stark, config, dummy1, 20, timing, None)?;
+        all_circuits.prove_all_segments(all_stark, config, dummy1, 20, None, timing, None)?;
 
     let inputs0_proof =
         all_circuits.prove_segment_aggregation(&dummy0_proof0[0], &dummy0_proof0[1])?;

--- a/evm_arithmetization/tests/withdrawals.rs
+++ b/evm_arithmetization/tests/withdrawals.rs
@@ -115,6 +115,7 @@ fn test_withdrawals() -> anyhow::Result<()> {
         &config,
         inputs,
         max_cpu_len_log,
+        None,
         &mut timing,
         None,
     )?;

--- a/trace_decoder/benches/block_processing.rs
+++ b/trace_decoder/benches/block_processing.rs
@@ -37,6 +37,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     trace_decoder::entrypoint(
                         block_trace,
                         other_data,
+                        None,
                         batch_size,
                         &mut DummyObserver::new(),
                     )

--- a/trace_decoder/src/interface.rs
+++ b/trace_decoder/src/interface.rs
@@ -5,8 +5,11 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use ethereum_types::{Address, U256};
-use evm_arithmetization::proof::{BlockHashes, BlockMetadata};
 use evm_arithmetization::ConsolidatedHash;
+use evm_arithmetization::{
+    proof::{BlockHashes, BlockMetadata},
+    structlog::zerostructlog::ZeroStructLog,
+};
 use keccak_hash::H256;
 use mpt_trie::partial_trie::HashedPartialTrie;
 use serde::{Deserialize, Serialize};
@@ -111,6 +114,10 @@ pub struct TxnMeta {
 
     /// Gas used by this txn (Note: not cumulative gas used).
     pub gas_used: u64,
+
+    /// Optional logs for a transaction's user code. Used for debugging purposes
+    /// only.
+    pub struct_log: Option<Vec<ZeroStructLog>>,
 }
 
 /// A "trace" specific to an account for a txn.

--- a/trace_decoder/tests/common/mod.rs
+++ b/trace_decoder/tests/common/mod.rs
@@ -61,6 +61,7 @@ impl Case {
         let BlockProverInput {
             block_trace,
             other_data,
+            struct_logs: _,
         } = bpis.remove(0);
         anyhow::Ok(Case {
             name: base.file_name().context("inconsistent base name")?.into(),

--- a/trace_decoder/tests/consistent-with-header.rs
+++ b/trace_decoder/tests/consistent-with-header.rs
@@ -24,9 +24,10 @@ fn main() -> anyhow::Result<()> {
         } in cases()?
         {
             trials.push(Trial::test(format!("{name}@{batch_size}"), move || {
-                let gen_inputs = trace_decoder::entrypoint(
+                let (gen_inputs, _) = trace_decoder::entrypoint(
                     trace,
                     other.clone(),
+                    None,
                     batch_size,
                     &mut DummyObserver::new(),
                 )

--- a/trace_decoder/tests/simulate-execution.rs
+++ b/trace_decoder/tests/simulate-execution.rs
@@ -20,18 +20,23 @@ fn main() -> anyhow::Result<()> {
             other,
         } in cases()?
         {
-            let gen_inputs =
-                trace_decoder::entrypoint(trace, other, batch_size, &mut DummyObserver::new())
-                    .context(format!(
-                        "error in `trace_decoder` for {name} at batch size {batch_size}"
-                    ))?;
+            let (gen_inputs, _) = trace_decoder::entrypoint(
+                trace,
+                other,
+                None,
+                batch_size,
+                &mut DummyObserver::new(),
+            )
+            .context(format!(
+                "error in `trace_decoder` for {name} at batch size {batch_size}"
+            ))?;
             for (ix, gi) in gen_inputs.into_iter().enumerate() {
                 trials.push(Trial::test(
                     format!("{name}@{batch_size}/{ix}"),
                     move || {
                         evm_arithmetization::prover::testing::simulate_execution_all_segments::<
                             GoldilocksField,
-                        >(gi, 19)
+                        >(gi, 19, None)
                         .map_err(|e| format!("{e:?}"))?; // get the full error chain
                         Ok(())
                     },

--- a/zero/Cargo.toml
+++ b/zero/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 __compat_primitive_types.workspace = true
 alloy.workspace = true
 alloy-compat = "0.1.0"
+alloy-primitives.workspace = true
 anyhow.workspace = true
 async-stream.workspace = true
 axum.workspace = true

--- a/zero/src/bin/leader/client.rs
+++ b/zero/src/bin/leader/client.rs
@@ -39,7 +39,7 @@ pub(crate) async fn client_main(
     use futures::StreamExt;
 
     let test_only = leader_config.prover_config.test_only;
-
+    let get_struct_logs = leader_config.prover_config.get_struct_logs;
     let cached_provider = Arc::new(zero::provider::CachedProvider::new(
         build_http_retry_provider(
             rpc_params.rpc_url.clone(),
@@ -92,6 +92,7 @@ pub(crate) async fn client_main(
             block_id,
             leader_config.checkpoint_block_number,
             rpc_params.rpc_type,
+            get_struct_logs,
         )
         .await?;
         block_tx

--- a/zero/src/bin/trie_diff.rs
+++ b/zero/src/bin/trie_diff.rs
@@ -84,9 +84,10 @@ async fn main() -> Result<()> {
             .b_meta
             .block_number
             .low_u64();
-        let block_generation_inputs = trace_decoder::entrypoint(
+        let (block_generation_inputs, opt_struct_logs) = trace_decoder::entrypoint(
             block_prover_input.block_trace.clone(),
             block_prover_input.other_data.clone(),
+            block_prover_input.struct_logs.clone(),
             prover_config.batch_size,
             &mut observer,
         )?;
@@ -97,19 +98,36 @@ async fn main() -> Result<()> {
         );
 
         info!("Running trie diff simulation for block {block_number} ...");
-        let simulation = Directive::map(
-            IndexedStream::from(
-                block_generation_inputs
-                    .clone()
-                    .into_iter()
-                    .enumerate()
-                    .zip(repeat(prover_config.max_cpu_len_log))
-                    .map(|((batch_index, inputs), max_cpu_len_log)| {
-                        (inputs, max_cpu_len_log, batch_index)
-                    }),
-            ),
-            &seg_ops,
-        );
+        let simulation = if let Some(struct_logs) = opt_struct_logs {
+            Directive::map(
+                IndexedStream::from(
+                    block_generation_inputs
+                        .clone()
+                        .into_iter()
+                        .enumerate()
+                        .zip(repeat(prover_config.max_cpu_len_log))
+                        .zip(struct_logs)
+                        .map(|(((batch_index, inputs), max_cpu_len_log), struct_log)| {
+                            (inputs, max_cpu_len_log, batch_index, Some(struct_log))
+                        }),
+                ),
+                &seg_ops,
+            )
+        } else {
+            Directive::map(
+                IndexedStream::from(
+                    block_generation_inputs
+                        .clone()
+                        .into_iter()
+                        .enumerate()
+                        .zip(repeat(prover_config.max_cpu_len_log))
+                        .map(|((batch_index, inputs), max_cpu_len_log)| {
+                            (inputs, max_cpu_len_log, batch_index, None)
+                        }),
+                ),
+                &seg_ops,
+            )
+        };
 
         if let Err(e2) = simulation
             .run(&runtime)

--- a/zero/src/prover/cli.rs
+++ b/zero/src/prover/cli.rs
@@ -47,6 +47,9 @@ pub struct CliProverConfig {
     /// be greater than zero.
     #[arg(long, default_value_t = 16)]
     block_pool_size: usize,
+    /// If true, returns the struct_logs along with the generation data.
+    #[arg(long, help_heading = HELP_HEADING, default_value_t = false)]
+    get_struct_logs: bool,
 }
 
 impl From<CliProverConfig> for super::ProverConfig {
@@ -60,6 +63,7 @@ impl From<CliProverConfig> for super::ProverConfig {
             keep_intermediate_proofs: cli.keep_intermediate_proofs,
             block_batch_size: cli.block_batch_size,
             block_pool_size: cli.block_pool_size,
+            get_struct_logs: cli.get_struct_logs,
             save_tries_on_error: false,
         }
     }

--- a/zero/src/rpc/jerigon.rs
+++ b/zero/src/rpc/jerigon.rs
@@ -1,5 +1,10 @@
+use std::ops::Deref;
+
+use alloy::rpc::types::{Block, BlockTransactionsKind};
 use alloy::{providers::Provider, rpc::types::eth::BlockId, transports::Transport};
 use anyhow::Context as _;
+use evm_arithmetization::structlog::get_structlog_for_debug;
+use evm_arithmetization::structlog::zerostructlog::ZeroStructLog;
 use serde::Deserialize;
 use serde_json::json;
 use trace_decoder::{BlockTrace, BlockTraceTriePreImages, CombinedPreImages, TxnInfo};
@@ -20,6 +25,7 @@ pub async fn block_prover_input<ProviderT, TransportT>(
     cached_provider: std::sync::Arc<CachedProvider<ProviderT, TransportT>>,
     target_block_id: BlockId,
     checkpoint_block_number: u64,
+    get_struct_logs: bool,
 ) -> anyhow::Result<BlockProverInput>
 where
     ProviderT: Provider<TransportT>,
@@ -33,7 +39,10 @@ where
             "debug_traceBlockByNumber".into(),
             (target_block_id, json!({"tracer": "zeroTracer"})),
         )
-        .await?;
+        .await?
+        .into_iter()
+        .map(|ztr| ztr.result)
+        .collect::<Vec<_>>();
 
     // Grab block witness info (packed as combined trie pre-images)
 
@@ -43,9 +52,17 @@ where
         .raw_request::<_, String>("eth_getWitness".into(), vec![target_block_id])
         .await?;
 
+    let block = cached_provider
+        .get_block(target_block_id, BlockTransactionsKind::Full)
+        .await?;
+
+    let struct_logs = if get_struct_logs {
+        Some(process_txns(&block, cached_provider.get_provider().await?.deref()).await?)
+    } else {
+        None
+    };
     let other_data =
         fetch_other_block_data(cached_provider, target_block_id, checkpoint_block_number).await?;
-
     // Assemble
     Ok(BlockProverInput {
         block_trace: BlockTrace {
@@ -53,9 +70,30 @@ where
                 compact: hex::decode(block_witness.strip_prefix("0x").unwrap_or(&block_witness))
                     .context("invalid hex returned from call to eth_getWitness")?,
             }),
-            txn_info: tx_results.into_iter().map(|it| it.result).collect(),
+            txn_info: tx_results,
             code_db: Default::default(),
         },
         other_data,
+        struct_logs,
     })
+}
+
+async fn process_txns<ProviderT, TransportT>(
+    block: &Block,
+    provider: &ProviderT,
+) -> anyhow::Result<Vec<Option<Vec<ZeroStructLog>>>>
+where
+    ProviderT: Provider<TransportT>,
+    TransportT: Transport + Clone,
+{
+    let all_txns = block
+        .transactions
+        .as_transactions()
+        .context("No transactions in block")?;
+    let mut struct_logs = Vec::with_capacity(all_txns.len());
+    for tx in all_txns {
+        struct_logs.push(get_structlog_for_debug(provider, &tx.hash).await?);
+    }
+
+    Ok(struct_logs)
 }

--- a/zero/src/rpc/mod.rs
+++ b/zero/src/rpc/mod.rs
@@ -46,6 +46,7 @@ pub async fn block_prover_input<ProviderT, TransportT>(
     block_id: BlockId,
     checkpoint_block_number: u64,
     rpc_type: RpcType,
+    get_struct_logs: bool,
 ) -> Result<BlockProverInput, anyhow::Error>
 where
     ProviderT: Provider<TransportT>,
@@ -53,10 +54,22 @@ where
 {
     match rpc_type {
         RpcType::Jerigon => {
-            jerigon::block_prover_input(cached_provider, block_id, checkpoint_block_number).await
+            jerigon::block_prover_input(
+                cached_provider,
+                block_id,
+                checkpoint_block_number,
+                get_struct_logs,
+            )
+            .await
         }
         RpcType::Native => {
-            native::block_prover_input(cached_provider, block_id, checkpoint_block_number).await
+            native::block_prover_input(
+                cached_provider,
+                block_id,
+                checkpoint_block_number,
+                get_struct_logs,
+            )
+            .await
         }
     }
 }

--- a/zero/src/rpc/native/txn.rs
+++ b/zero/src/rpc/native/txn.rs
@@ -21,6 +21,7 @@ use alloy::{
 };
 use anyhow::Context as _;
 use compat::Compat;
+use evm_arithmetization::structlog::{get_structlog_for_debug, zerostructlog::ZeroStructLog};
 use futures::stream::{FuturesOrdered, TryStreamExt};
 use trace_decoder::{ContractCodeUsage, TxnInfo, TxnMeta, TxnTrace};
 
@@ -63,7 +64,7 @@ where
     ProviderT: Provider<TransportT>,
     TransportT: Transport + Clone,
 {
-    let (tx_receipt, pre_trace, diff_trace) = fetch_tx_data(provider, &tx.hash).await?;
+    let (tx_receipt, pre_trace, diff_trace, struct_log) = fetch_tx_data(provider, &tx.hash).await?;
     let tx_status = tx_receipt.status();
     let tx_receipt = tx_receipt.map_inner(rlp::map_receipt_envelope);
     let access_list = parse_access_list(tx.access_list.as_ref());
@@ -72,6 +73,7 @@ where
         byte_code: <Ethereum as Network>::TxEnvelope::try_from(tx.clone())?.encoded_2718(),
         new_receipt_trie_node_byte: alloy::rlp::encode(tx_receipt.inner),
         gas_used: tx_receipt.gas_used as u64,
+        struct_log,
     };
 
     let (code_db, mut tx_traces) = match (pre_trace, diff_trace) {
@@ -103,7 +105,15 @@ where
 async fn fetch_tx_data<ProviderT, TransportT>(
     provider: &ProviderT,
     tx_hash: &B256,
-) -> anyhow::Result<(<Ethereum as Network>::ReceiptResponse, GethTrace, GethTrace), anyhow::Error>
+) -> anyhow::Result<
+    (
+        <Ethereum as Network>::ReceiptResponse,
+        GethTrace,
+        GethTrace,
+        Option<Vec<ZeroStructLog>>,
+    ),
+    anyhow::Error,
+>
 where
     ProviderT: Provider<TransportT>,
     TransportT: Transport + Clone,
@@ -111,14 +121,20 @@ where
     let tx_receipt_fut = provider.get_transaction_receipt(*tx_hash);
     let pre_trace_fut = provider.debug_trace_transaction(*tx_hash, prestate_tracing_options(false));
     let diff_trace_fut = provider.debug_trace_transaction(*tx_hash, prestate_tracing_options(true));
+    let struct_logs_fut = get_structlog_for_debug(provider, tx_hash);
 
-    let (tx_receipt, pre_trace, diff_trace) =
-        futures::try_join!(tx_receipt_fut, pre_trace_fut, diff_trace_fut,)?;
+    let (tx_receipt, pre_trace, diff_trace, struct_logs) = futures::try_join!(
+        tx_receipt_fut,
+        pre_trace_fut,
+        diff_trace_fut,
+        struct_logs_fut
+    )?;
 
     Ok((
         tx_receipt.context("Transaction receipt not found.")?,
         pre_trace,
         diff_trace,
+        struct_logs,
     ))
 }
 


### PR DESCRIPTION
This PR aims at handling #221 .

It adds a flag `--get-struct-logs` to get the transaction `StructLogs` when fetching generation inputs. Then, during interpreter execution, if running in debugger mode and `StructLog`s are available, it checks at each step the PC, opcode, gas, stack and possible errors against the `StructLog`s. 

(Helped debug failing block 678.)