### PR TITLE
Fix: call failure gas refund to caller

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
@@ -323,7 +323,10 @@ process_message_txn_fail:
     // stack: leftover_gas, new_ctx, retdest, success, leftover_gas
     // Transfer value back to the caller.
     %mload_txn_field(@TXN_FIELD_VALUE) ISZERO %jumpi(process_message_txn_after_call_contd)
+    %mload_txn_field(@TXN_FIELD_TO)
+    %balance
     %mload_txn_field(@TXN_FIELD_VALUE)
+    %min
     %mload_txn_field(@TXN_FIELD_ORIGIN)
     %mload_txn_field(@TXN_FIELD_TO)
     %transfer_eth %jumpi(panic)

--- a/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
@@ -326,7 +326,7 @@ process_message_txn_fail:
     %mload_txn_field(@TXN_FIELD_TO)
     %balance
     %mload_txn_field(@TXN_FIELD_VALUE)
-    %min
+    %min // min(to_balance, original_value)
     %mload_txn_field(@TXN_FIELD_ORIGIN)
     %mload_txn_field(@TXN_FIELD_TO)
     %transfer_eth %jumpi(panic)

--- a/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
@@ -327,10 +327,15 @@ process_message_txn_fail:
     %balance
     %mload_txn_field(@TXN_FIELD_VALUE)
     %min // min(to_balance, original_value)
+    DUP1 ISZERO %jumpi(process_message_txn_after_call_contd_with_pop)
     %mload_txn_field(@TXN_FIELD_ORIGIN)
     %mload_txn_field(@TXN_FIELD_TO)
     %transfer_eth %jumpi(panic)
     %jump(process_message_txn_after_call_contd)
+
+process_message_txn_after_call_contd_with_pop:
+    // stack: 0, leftover_gas, new_ctx, retdest, success, leftover_gas
+    POP %jump(process_message_txn_after_call_contd)
 
 %macro pay_coinbase_and_refund_sender
     // stack: leftover_gas


### PR DESCRIPTION
Upon CALL failure, we refund the amount initially sent to the caller. However, during the call frame, the target `to` may have spent it all, being unable to refund fully the initial `amount`.

We need to call `%min(initial_amount, current_balance)` and withdraw this instead. This edge case unfortunately wasn't caught by the Ethereum test suite but got triggered in John's test (block 978, txn 43). Will consider adding it as regression payload once the whole block is passing.

3/N @praetoriansentry 