### PR TITLE
fix: missing code read in state write

### DIFF
--- a/trace_decoder/src/core.rs
+++ b/trace_decoder/src/core.rs
@@ -40,6 +40,12 @@ pub fn entrypoint(
         code_db,
         txn_info,
     } = trace;
+
+    let fatal_missing_code = match trie_pre_images {
+        BlockTraceTriePreImages::Separate(_) => FatalMissingCode(true),
+        BlockTraceTriePreImages::Combined(_) => FatalMissingCode(false),
+    };
+
     let (state, storage, mut code) = start(trie_pre_images)?;
     code.extend(code_db);
 
@@ -68,6 +74,7 @@ pub fn entrypoint(
         &b_meta,
         ger_data,
         withdrawals,
+        fatal_missing_code,
         observer,
     )?;
 
@@ -270,6 +277,14 @@ pub struct IntraBlockTries<StateTrieT> {
     pub receipt: ReceiptTrie,
 }
 
+/// Hacky handling of possibly missing contract bytecode in `Hash2Code` inner
+/// map.
+/// Allows incomplete payloads fetched with the zero tracer to skip these
+/// silently.
+// TODO(Nashtare): https://github.com/0xPolygonZero/zk_evm/issues/700
+#[derive(Copy, Clone)]
+pub struct FatalMissingCode(pub bool);
+
 /// Does the main work mentioned in the [module documentation](super).
 #[allow(clippy::too_many_arguments)]
 fn middle<StateTrieT: StateTrie + Clone>(
@@ -285,6 +300,7 @@ fn middle<StateTrieT: StateTrie + Clone>(
     ger_data: Option<(H256, H256)>,
     // added to final batch
     mut withdrawals: Vec<(Address, U256)>,
+    fatal_missing_code: FatalMissingCode,
     // called with the untrimmed tries after each batch
     observer: &mut impl Observer<StateTrieT>,
 ) -> anyhow::Result<Vec<Batch<StateTrieT>>> {
@@ -433,9 +449,20 @@ fn middle<StateTrieT: StateTrie + Clone>(
                     acct.code_hash = code_usage
                         .map(|it| match it {
                             ContractCodeUsage::Read(hash) => {
-                                let _ = code
-                                    .get(hash)
-                                    .map(|bytecode| batch_contract_code.insert(bytecode));
+                                // TODO(Nashtare): https://github.com/0xPolygonZero/zk_evm/issues/700
+                                // This is a bug in the zero tracer, which shouldn't be giving us
+                                // this read at all. Workaround for now.
+                                match (fatal_missing_code, code.get(hash)) {
+                                    (FatalMissingCode(true), None) => {
+                                        bail!("no code for hash {hash:x}")
+                                    }
+                                    (_, Some(byte_code)) => {
+                                        batch_contract_code.insert(byte_code);
+                                    }
+                                    (_, None) => {
+                                        log::warn!("no code for {hash:x}")
+                                    }
+                                }
 
                                 anyhow::Ok(hash)
                             }
@@ -770,11 +797,8 @@ impl Hash2Code {
         this.insert(vec![]);
         this
     }
-    pub fn get(&mut self, hash: H256) -> anyhow::Result<Vec<u8>> {
-        match self.inner.get(&hash) {
-            Some(code) => Ok(code.clone()),
-            None => bail!("no code for hash {:x}", hash),
-        }
+    pub fn get(&mut self, hash: H256) -> Option<Vec<u8>> {
+        self.inner.get(&hash).cloned()
     }
     pub fn insert(&mut self, code: Vec<u8>) {
         self.inner.insert(keccak_hash::keccak(&code), code);

--- a/trace_decoder/src/core.rs
+++ b/trace_decoder/src/core.rs
@@ -433,7 +433,10 @@ fn middle<StateTrieT: StateTrie + Clone>(
                     acct.code_hash = code_usage
                         .map(|it| match it {
                             ContractCodeUsage::Read(hash) => {
-                                batch_contract_code.insert(code.get(hash)?);
+                                let _ = code
+                                    .get(hash)
+                                    .map(|bytecode| batch_contract_code.insert(bytecode));
+
                                 anyhow::Ok(hash)
                             }
                             ContractCodeUsage::Write(bytes) => {

--- a/trace_decoder/src/core.rs
+++ b/trace_decoder/src/core.rs
@@ -176,7 +176,7 @@ fn start(
                         .map(|v| (k, v))
                 })
                 .collect::<Result<_, _>>()?;
-            (state, storage, Hash2Code::new(false))
+            (state, storage, Hash2Code::new())
         }
         BlockTraceTriePreImages::Combined(CombinedPreImages { compact }) => {
             let instructions = crate::wire::parse(&compact)
@@ -433,9 +433,9 @@ fn middle<StateTrieT: StateTrie + Clone>(
                     acct.code_hash = code_usage
                         .map(|it| match it {
                             ContractCodeUsage::Read(hash) => {
-                                if let Some(bytecode) = code.get(hash)? {
-                                    batch_contract_code.insert(bytecode);
-                                };
+                                let _ = code
+                                    .get(hash)
+                                    .map(|bytecode| batch_contract_code.insert(bytecode));
 
                                 anyhow::Ok(hash)
                             }
@@ -760,29 +760,20 @@ fn map_receipt_bytes(bytes: Vec<u8>) -> anyhow::Result<Vec<u8>> {
 struct Hash2Code {
     /// Key must always be [`hash`] of value.
     inner: HashMap<H256, Vec<u8>>,
-    /// Flag to allow missing values in the inner map.
-    allow_missing_code: bool,
 }
 
 impl Hash2Code {
-    pub fn new(allow_missing_code: bool) -> Self {
+    pub fn new() -> Self {
         let mut this = Self {
             inner: HashMap::new(),
-            allow_missing_code,
         };
         this.insert(vec![]);
         this
     }
-    pub fn get(&mut self, hash: H256) -> anyhow::Result<Option<Vec<u8>>> {
+    pub fn get(&mut self, hash: H256) -> anyhow::Result<Vec<u8>> {
         match self.inner.get(&hash) {
-            Some(code) => Ok(Some(code.clone())),
-            None => {
-                if self.allow_missing_code {
-                    Ok(None)
-                } else {
-                    bail!("no code for hash {:x}", hash)
-                }
-            }
+            Some(code) => Ok(code.clone()),
+            None => bail!("no code for hash {:x}", hash),
         }
     }
     pub fn insert(&mut self, code: Vec<u8>) {
@@ -800,7 +791,7 @@ impl Extend<Vec<u8>> for Hash2Code {
 
 impl FromIterator<Vec<u8>> for Hash2Code {
     fn from_iter<II: IntoIterator<Item = Vec<u8>>>(iter: II) -> Self {
-        let mut this = Self::new(true);
+        let mut this = Self::new();
         this.extend(iter);
         this
     }


### PR DESCRIPTION
We're currently erroring when missing an entry in the `Hash2Code` map. The access being done upon `state_read` in a state write, I'm wondering whether we should _always_ expect the client to provide necessary information, or if we should _allow_ missing entries.

In the current state of things, block 1034, txn 0 (`0xcfaf63b718a548069b856e8ff6b27ad69c3e8ca84ae2ab6ae67c545ecf0b642c`) is failing to parse at the decoder stage because we're missing contract bytecode associated to this txn trace:

```json
            "0xd18e94fa1353e8b3b72e64ffc4a64d28a98cdee1": {
              "code_usage": {
                "read": "0x4ab15219b84093c7fd1c51566743820f9383a50b34c3f302b5331f26a89ddc73"
              }
            },
```

However, the prover does not need it and processes the txn payload fine with the change on this branch. I think Jerigon here knows we can `skip` the actual bytecode, and hence isn't passing it to the `compact` witness (@cffls to confirm). In which case we should not `bail!` when failing to find the mapping bytecode.

Opening as discussion because I'm not clear yet as to what the assumption should be / who's responsability it should be.
Passing the block payload here (note that it's failing to run further ahead)
[b1034_dev.json](https://github.com/user-attachments/files/17251268/b1034_dev.json)

3.5/N @praetoriansentry 