### PR TITLE
feat: github proving benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,8 +49,9 @@ jobs:
           PERF_TIME=`cat output.log | grep "seconds time elapsed" |  tail -1 | awk '{ print ($1)}'`
           PERF_USER_TIME=`cat output.log | grep "seconds user" |  tail -1 | awk '{ print ($1)}'`
           PERF_SYS_TIME=`cat output.log | grep "seconds sys" |  tail -1 | awk '{ print ($1)}'`
-          cat output.log
-          echo "RUN_ID=${{ github.run_id }} MEASURED_PROVING_TIME_SEC=$MEASURED_PROVING_TIME_SEC PERF_TIME=$PERF_TIME PERF_USER_TIME=$PERF_USER_TIME PERF_SYS_TIME=$PERF_SYS_TIME FILE=$BENCHMARK_WITNESS"
+          echo "RUN_ID=${{ github.run_id }} MEASURED_PROVING_TIME_SEC=$MEASURED_PROVING_TIME_SEC \
+            PERF_TIME=$PERF_TIME PERF_USER_TIME=$PERF_USER_TIME \
+            PERF_SYS_TIME=$PERF_SYS_TIME FILE=$BENCHMARK_WITNESS"
           printf '%12s     %-12s     %-24s    %-20s    %-20s    %-20s    %-s\n' \
             `date --utc +%y-%m-%d-%H:%M:%S` ${{ github.run_id }} \
             $MEASURED_PROVING_TIME_SEC $PERF_TIME $PERF_USER_TIME \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,8 @@ on:
       - "**"
 
 env:
-  BENCHMARK_WITNESS: artifacts/witness_b1000_b1019.json
+  #BENCHMARK_WITNESS: artifacts/witness_b1000_b1019.json
+  BENCHMARK_WITNESS: artifacts/witness_b19807080.json
 
 jobs:
   benchmark_proving:
@@ -41,7 +42,6 @@ jobs:
           if_no_artifact_found: ignore
 
       - name: Run the script
-        # TODO - run the benchmark with 20 blocks file
         run: |
           echo "Benchmarking proving with $BENCHMARK_WITNESS"
           ./scripts/benchmark_input.sh $BENCHMARK_WITNESS | tee benchmark_output.log
@@ -49,6 +49,8 @@ jobs:
           PERF_TIME=`cat output.log | grep "seconds time elapsed" |  tail -1 | awk '{ print ($1)}'`
           PERF_USER_TIME=`cat output.log | grep "seconds user" |  tail -1 | awk '{ print ($1)}'`
           PERF_SYS_TIME=`cat output.log | grep "seconds sys" |  tail -1 | awk '{ print ($1)}'`
+          cat output.log
+          echo "RUN_ID=${{ github.run_id }} MEASURED_PROVING_TIME_SEC=$MEASURED_PROVING_TIME_SEC PERF_TIME=$PERF_TIME PERF_USER_TIME=$PERF_USER_TIME PERF_SYS_TIME=$PERF_SYS_TIME FILE=$BENCHMARK_WITNESS"
           printf '%12s     %-12s     %-24s    %-20s    %-20s    %-20s    %-s\n' \
             `date --utc +%y-%m-%d-%H:%M:%S` ${{ github.run_id }} \
             $MEASURED_PROVING_TIME_SEC $PERF_TIME $PERF_USER_TIME \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build the project
         run: |
           RUSTFLAGS='-C target-cpu=native -Zlinker-features=-lld -Copt-level=3' cargo build --release
-          sudo echo 0 > /proc/sys/kernel/perf_event_paranoid
+          sudo sysctl kernel.perf_event_paranoid=0
 
       - name: Download previous results
         uses: dawidd6/action-download-artifact@v6
@@ -47,8 +47,9 @@ jobs:
           PERF_TIME=`cat output.log | grep "seconds time elapsed" |  tail -1 | awk '{ print ($1)}'`
           PERF_USER_TIME=`cat output.log | grep "seconds user" |  tail -1 | awk '{ print ($1)}'`
           PERF_SYS_TIME=`cat output.log | grep "seconds sys" |  tail -1 | awk '{ print ($1)}'`
-          printf 'TIME OF TEST          RUN ID           WALL CLOCK TIME(s)   PERF TIME(s)      PERF USER TIME(s)  PERF SYS TIME(s)  WITNESS FILE\n' > proving_benchmark_results.txt
-          printf '%12s     %-12s     %-12s         %-12s      %-12s      %-12s    %-s\n' `date --utc +%y-%m-%d-%H:%M:%S` ${{ github.run_id }} $MEASURED_PROVING_TIME_SEC $PERF_TIME $PERF_USER_TIME $PERF_SYS_TIME $BENCHMARK_WITNESS >> proving_benchmark_results.txt
+          printf 'TIME OF TEST          RUN ID           WALL CLOCK TIME(s)          PERF WALL TIME(s)       PERF USER TIME(s)       PERF SYS TIME(s)        WITNESS FILE\n' > proving_benchmark_results.txt
+          printf '%12s     %-12s     %-24s    %-20s    %-20s    %-20s    %-s\n' `date --utc +%y-%m-%d-%H:%M:%S` ${{ github.run_id }} \
+               $MEASURED_PROVING_TIME_SEC $PERF_TIME $PERF_USER_TIME $PERF_SYS_TIME $BENCHMARK_WITNESS >> proving_benchmark_results.txt
 
       - name: Upload new results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,33 @@
+name: Benchmark proving
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+  #TODO REMOVE PR EXECUTION
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  benchmark_proving:
+    name: Benchmark proving for representative blocks
+    runs-on: zero-reg
+    timeout-minutes: 200 # TBD
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Build the project
+        run: |
+          RUSTFLAGS='-C target-cpu=native -Zlinker-features=-lld' cargo build --release
+          sudo su -c "echo 0 > /proc/sys/kernel/perf_event_paranoid"
+
+      - name: Run the script
+        # TODO - run the benchmark with 20 blocks file
+        run: |  
+          ./scripts/benchmark_input.sh artifacts/witness_b19807080.json

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,10 @@
+---   # Proof generation benchmarking workflow
+
 name: Benchmark proving
 
 on:
   schedule:
-    - cron: '0 4 * * *'
+    - cron: "0 4 * * *"
   workflow_dispatch:
     branches:
       - "**"
@@ -17,7 +19,7 @@ jobs:
   benchmark_proving:
     name: Benchmark proving for representative blocks
     runs-on: zero-reg
-    timeout-minutes: 900 # Timeout TBD
+    timeout-minutes: 900  # Timeout TBD
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -28,7 +30,6 @@ jobs:
         run: |
           RUSTFLAGS='-C target-cpu=native -Zlinker-features=-lld -Copt-level=3' cargo build --release
           sudo sysctl kernel.perf_event_paranoid=0
-#          printf 'TIME OF TEST          RUN ID           WALL CLOCK TIME(s)          PERF WALL TIME(s)       PERF USER TIME(s)       PERF SYS TIME(s)        WITNESS FILE\n' > proving_benchmark_results.txt
 
       - name: Download previous results
         uses: dawidd6/action-download-artifact@v6
@@ -41,23 +42,24 @@ jobs:
 
       - name: Run the script
         # TODO - run the benchmark with 20 blocks file
-        run: |  
+        run: |
           echo "Benchmarking proving with $BENCHMARK_WITNESS"
           ./scripts/benchmark_input.sh $BENCHMARK_WITNESS | tee benchmark_output.log
           MEASURED_PROVING_TIME_SEC=`cat benchmark_output.log | grep 'Proving duration:' | tail -1 | awk '{ print $3}'`
           PERF_TIME=`cat output.log | grep "seconds time elapsed" |  tail -1 | awk '{ print ($1)}'`
           PERF_USER_TIME=`cat output.log | grep "seconds user" |  tail -1 | awk '{ print ($1)}'`
           PERF_SYS_TIME=`cat output.log | grep "seconds sys" |  tail -1 | awk '{ print ($1)}'`
-          printf '%12s     %-12s     %-24s    %-20s    %-20s    %-20s    %-s\n' `date --utc +%y-%m-%d-%H:%M:%S` ${{ github.run_id }} \
-               $MEASURED_PROVING_TIME_SEC $PERF_TIME $PERF_USER_TIME $PERF_SYS_TIME $BENCHMARK_WITNESS >> proving_benchmark_results.txt
+          printf '%12s     %-12s     %-24s    %-20s    %-20s    %-20s    %-s\n' \
+            `date --utc +%y-%m-%d-%H:%M:%S` ${{ github.run_id }} \
+            $MEASURED_PROVING_TIME_SEC $PERF_TIME $PERF_USER_TIME \
+            $PERF_SYS_TIME $BENCHMARK_WITNESS >> proving_benchmark_results.txt
 
       - name: Upload new results
         uses: actions/upload-artifact@v4
         with:
           name: proving_benchmark
-          path: | 
+          path: |
             ./proving_benchmark_results.txt
             ./output.log
           retention-days: 90
           overwrite: true
-

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,9 @@ on:
   workflow_dispatch:
     branches:
       - "**"
-
+  pull_request:
+    branches:
+      - "**"
 
 env:
   BENCHMARK_WITNESS: artifacts/witness_b19807080.json
@@ -25,6 +27,7 @@ jobs:
       - name: Build the project
         run: |
           RUSTFLAGS='-C target-cpu=native -Zlinker-features=-lld -Copt-level=3' cargo build --release
+          sudo echo 0 > /proc/sys/kernel/perf_event_paranoid
 
       - name: Download previous results
         uses: dawidd6/action-download-artifact@v6
@@ -40,8 +43,12 @@ jobs:
         run: |  
           echo "Benchmarking proving with $BENCHMARK_WITNESS"
           ./scripts/benchmark_input.sh $BENCHMARK_WITNESS | tee benchmark_output.log
-          MEASURED_PROVING_TIME_SEC=`cat benchmark_output.log | grep 'Proving duration:' | tail -1 | awk '{ print int($3)}'`
-          printf '%s      sec: %10s    %s\n' `date --utc +%y-%m-%d-%H:%M:%S` $MEASURED_PROVING_TIME_SEC $BENCHMARK_WITNESS >> proving_benchmark_results.txt
+          MEASURED_PROVING_TIME_SEC=`cat benchmark_output.log | grep 'Proving duration:' | tail -1 | awk '{ print $3}'`
+          PERF_TIME=`cat output.log | grep "seconds time elapsed" |  tail -1 | awk '{ print ($1)}'`
+          PERF_USER_TIME=`cat output.log | grep "seconds user" |  tail -1 | awk '{ print ($1)}'`
+          PERF_SYS_TIME=`cat output.log | grep "seconds sys" |  tail -1 | awk '{ print ($1)}'`
+          printf 'TIME OF TEST          RUN ID           WALL CLOCK TIME(s)   PERF TIME(s)      PERF USER TIME(s)  PERF SYS TIME(s)  WITNESS FILE\n' > proving_benchmark_results.txt
+          printf '%12s     %-12s     %-12s         %-12s      %-12s      %-12s    %-s\n' `date --utc +%y-%m-%d-%H:%M:%S` ${{ github.run_id }} $MEASURED_PROVING_TIME_SEC $PERF_TIME $PERF_USER_TIME $PERF_SYS_TIME $BENCHMARK_WITNESS >> proving_benchmark_results.txt
 
       - name: Upload new results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,13 +8,9 @@ on:
   workflow_dispatch:
     branches:
       - "**"
-  pull_request:
-    branches:
-      - "**"
 
 env:
-  #BENCHMARK_WITNESS: artifacts/witness_b1000_b1019.json
-  BENCHMARK_WITNESS: artifacts/witness_b19807080.json
+  BENCHMARK_WITNESS: artifacts/witness_b1000_b1019.json
 
 jobs:
   benchmark_proving:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch:
+    branches:
+      - "**"
   #TODO REMOVE PR EXECUTION
   push:
     branches: [develop, main]
@@ -11,11 +13,14 @@ on:
     branches:
       - "**"
 
+env:
+  BENCHMARK_WITNESS: artifacts/witness_b19807080.json
+
 jobs:
   benchmark_proving:
     name: Benchmark proving for representative blocks
     runs-on: zero-reg
-    timeout-minutes: 200 # TBD
+    timeout-minutes: 200 # Timeout TBD
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -24,10 +29,36 @@ jobs:
 
       - name: Build the project
         run: |
-          RUSTFLAGS='-C target-cpu=native -Zlinker-features=-lld' cargo build --release
-          sudo su -c "echo 0 > /proc/sys/kernel/perf_event_paranoid"
+          RUSTFLAGS='-C target-cpu=native -Zlinker-features=-lld -Copt-level=3' cargo build --release
+
+      - name: Download previous results
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: benchmark.yml
+          workflow_conclusion: success
+          name: proving_benchmark
+          path: ./
+          if_no_artifact_found: ignore
+
+      - name: Initialise the results file if necessary
+        run: |
+          ls -la ./
+          cat ./proving_benchmark_results.txt
+          printf '                                 TIME                           \n'  > ./proving_benchmark_results.txt
 
       - name: Run the script
         # TODO - run the benchmark with 20 blocks file
         run: |  
-          ./scripts/benchmark_input.sh artifacts/witness_b19807080.json
+          echo "Benchmarking proving with $BENCHMARK_WITNESS"
+          ./scripts/benchmark_input.sh $BENCHMARK_WITNESS | tee benchmark_output.log
+          MEASURED_PROVING_TIME_SEC=`cat benchmark_output.log | grep 'Proving duration:' | tail -1 | awk '{ print int($3)}'`
+          printf '%s      sec: %10s    %s\n' `date --utc +%y-%m-%d-%H:%M:%S` $MEASURED_PROVING_TIME_SEC $BENCHMARK_WITNESS >> proving_benchmark_results.txt
+
+      - name: Upload new results
+        uses: actions/upload-artifact@v4
+        with:
+          name: proving_benchmark
+          path: ./proving_benchmark_results.txt
+          retention-days: 90
+          overwrite: true
+

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           RUSTFLAGS='-C target-cpu=native -Zlinker-features=-lld -Copt-level=3' cargo build --release
           sudo sysctl kernel.perf_event_paranoid=0
+#          printf 'TIME OF TEST          RUN ID           WALL CLOCK TIME(s)          PERF WALL TIME(s)       PERF USER TIME(s)       PERF SYS TIME(s)        WITNESS FILE\n' > proving_benchmark_results.txt
 
       - name: Download previous results
         uses: dawidd6/action-download-artifact@v6
@@ -47,7 +48,6 @@ jobs:
           PERF_TIME=`cat output.log | grep "seconds time elapsed" |  tail -1 | awk '{ print ($1)}'`
           PERF_USER_TIME=`cat output.log | grep "seconds user" |  tail -1 | awk '{ print ($1)}'`
           PERF_SYS_TIME=`cat output.log | grep "seconds sys" |  tail -1 | awk '{ print ($1)}'`
-          printf 'TIME OF TEST          RUN ID           WALL CLOCK TIME(s)          PERF WALL TIME(s)       PERF USER TIME(s)       PERF SYS TIME(s)        WITNESS FILE\n' > proving_benchmark_results.txt
           printf '%12s     %-12s     %-24s    %-20s    %-20s    %-20s    %-s\n' `date --utc +%y-%m-%d-%H:%M:%S` ${{ github.run_id }} \
                $MEASURED_PROVING_TIME_SEC $PERF_TIME $PERF_USER_TIME $PERF_SYS_TIME $BENCHMARK_WITNESS >> proving_benchmark_results.txt
 
@@ -55,7 +55,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: proving_benchmark
-          path: ./proving_benchmark_results.txt
+          path: | 
+            ./proving_benchmark_results.txt
+            ./output.log
           retention-days: 90
           overwrite: true
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,12 +6,7 @@ on:
   workflow_dispatch:
     branches:
       - "**"
-  #TODO REMOVE PR EXECUTION
-  push:
-    branches: [develop, main]
-  pull_request:
-    branches:
-      - "**"
+
 
 env:
   BENCHMARK_WITNESS: artifacts/witness_b19807080.json
@@ -39,12 +34,6 @@ jobs:
           name: proving_benchmark
           path: ./
           if_no_artifact_found: ignore
-
-      - name: Initialise the results file if necessary
-        run: |
-          ls -la ./
-          cat ./proving_benchmark_results.txt
-          printf '                                 TIME                           \n'  > ./proving_benchmark_results.txt
 
       - name: Run the script
         # TODO - run the benchmark with 20 blocks file

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,16 +16,16 @@ jobs:
   benchmark_proving:
     name: Benchmark proving for representative blocks
     runs-on: zero-reg
-    timeout-minutes: 900  # Timeout TBD
+    timeout-minutes: 300
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build the project
         run: |
-          RUSTFLAGS='-C target-cpu=native -Zlinker-features=-lld -Copt-level=3' cargo build --release
+          RUSTFLAGS='-C target-cpu=native -Zlinker-features=-lld' cargo build --release
           sudo sysctl kernel.perf_event_paranoid=0
 
       - name: Download previous results

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,13 +11,13 @@ on:
       - "**"
 
 env:
-  BENCHMARK_WITNESS: artifacts/witness_b19807080.json
+  BENCHMARK_WITNESS: artifacts/witness_b1000_b1019.json
 
 jobs:
   benchmark_proving:
     name: Benchmark proving for representative blocks
     runs-on: zero-reg
-    timeout-minutes: 200 # Timeout TBD
+    timeout-minutes: 900 # Timeout TBD
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/scripts/benchmark_input.sh
+++ b/scripts/benchmark_input.sh
@@ -39,7 +39,7 @@ if [[ $INPUT_FILE == "" ]]; then
 fi
 
 start_time=$(date +%s%N)
-"${REPO_ROOT}/target/release/leader" --runtime in-memory --load-strategy monolithic --block-batch-size $BLOCK_BATCH_SIZE \
+perf stat -e cycles "${REPO_ROOT}/target/release/leader" --runtime in-memory --load-strategy monolithic --block-batch-size $BLOCK_BATCH_SIZE \
  --proof-output-dir $PROOF_OUTPUT_DIR stdio < $INPUT_FILE &> $OUTPUT_LOG
 end_time=$(date +%s%N)
 

--- a/scripts/benchmark_input.sh
+++ b/scripts/benchmark_input.sh
@@ -43,7 +43,7 @@ perf stat -e cycles "${REPO_ROOT}/target/release/leader" --runtime in-memory --l
 end_time=$(date +%s%N)
 
 set +o pipefail
-grep "Successfully wrote to disk proof file" "$OUT_LOG_PATH" | awk '{print $NF}' | tee "$PROOFS_FILE_LIST"
+grep "Successfully wrote to disk proof file" "$OUTPUT_LOG" | awk '{print $NF}' | tee "$PROOFS_FILE_LIST"
 if [ ! -s "$PROOFS_FILE_LIST" ]; then
 	# Some error occurred, display the logs and exit.
 	cat "$OUTPUT_LOG"

--- a/scripts/benchmark_input.sh
+++ b/scripts/benchmark_input.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+set -exo pipefail
+
+# Args:
+# 1 --> Input witness json file
+
+# We're going to set the parallelism in line with the total cpu count
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    num_procs=$(sysctl -n hw.physicalcpu)
+else
+    num_procs=$(nproc)
+fi
+
+# Force the working directory to always be the `tools/` directory. 
+REPO_ROOT=$(git rev-parse --show-toplevel)
+PROOF_OUTPUT_DIR="${REPO_ROOT}/proofs"
+
+BLOCK_BATCH_SIZE="${BLOCK_BATCH_SIZE:-8}"
+echo "Block batch size: $BLOCK_BATCH_SIZE"
+
+OUTPUT_LOG="${REPO_ROOT}/output.log"
+PROOFS_FILE_LIST="${PROOF_OUTPUT_DIR}/proof_files.json"
+TEST_OUT_PATH="${REPO_ROOT}/test.out"
+
+# Configured Rayon and Tokio with rough defaults
+export RAYON_NUM_THREADS=$num_procs
+export TOKIO_WORKER_THREADS=$num_procs
+
+export RUST_MIN_STACK=33554432
+export RUST_BACKTRACE=full
+export RUST_LOG=info
+
+INPUT_FILE=$1
+
+if [[ $INPUT_FILE == "" ]]; then
+    echo "Please provide witness json input file, e.g. artifacts/witness_b19240705.json"
+    exit 1
+fi
+
+start_time=$(date +%s%N)
+perf stat -e cycles "${REPO_ROOT}/target/release/leader" --runtime in-memory --load-strategy monolithic --block-batch-size $BLOCK_BATCH_SIZE \
+ --proof-output-dir $PROOF_OUTPUT_DIR stdio < $INPUT_FILE &> $OUTPUT_LOG
+end_time=$(date +%s%N)
+
+set +o pipefail
+cat $OUTPUT_LOG | grep "Successfully wrote to disk proof file " | awk '{print $NF}' | tee $PROOFS_FILE_LIST
+if [ ! -s "$PROOFS_FILE_LIST" ]; then
+  # Some error occurred, display the logs and exit.
+  cat $OUTPUT_LOG
+  echo "Proof list not generated, some error happened. For more details check the log file $OUTPUT_LOG"
+  exit 1
+fi
+
+duration_ns=$((end_time - start_time))
+duration_sec=$(echo "$duration_ns / 1000000000" | bc -l)
+
+echo "Success!"
+echo "Proving duration:" $duration_sec " seconds"
+echo "Note, this duration is inclusive of circuit handling and overall process initialization";
+
+# Clean up in case of success
+rm $OUTPUT_LOG
+
+
+
+
+

--- a/scripts/benchmark_input.sh
+++ b/scripts/benchmark_input.sh
@@ -39,7 +39,7 @@ if [[ $INPUT_FILE == "" ]]; then
 fi
 
 start_time=$(date +%s%N)
-perf stat -e cycles "${REPO_ROOT}/target/release/leader" --runtime in-memory --load-strategy monolithic --block-batch-size $BLOCK_BATCH_SIZE \
+"${REPO_ROOT}/target/release/leader" --runtime in-memory --load-strategy monolithic --block-batch-size $BLOCK_BATCH_SIZE \
  --proof-output-dir $PROOF_OUTPUT_DIR stdio < $INPUT_FILE &> $OUTPUT_LOG
 end_time=$(date +%s%N)
 
@@ -58,9 +58,6 @@ duration_sec=$(echo "$duration_ns / 1000000000" | bc -l)
 echo "Success!"
 echo "Proving duration:" $duration_sec " seconds"
 echo "Note, this duration is inclusive of circuit handling and overall process initialization";
-
-# Clean up in case of success
-rm $OUTPUT_LOG
 
 
 


### PR DESCRIPTION
Resolves https://github.com/0xPolygonZero/zk_evm/issues/651

Here we download `proving_benchmark_results.txt` artifact form previous succesfull run.
We run the proving job with `$BENCHMARK_WITNESS` file.
We append the resulting time to the simple textual result file and upload it to artifacts repo.

Job is executed every night at 4AM and manually.
