### PR TITLE
Fix contract call reversion 

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/call.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/call.asm
@@ -91,7 +91,7 @@ global sys_callcode:
           (new_ctx, args_offset, args_size, new_ctx, kexit_info, callgas, address, value, args_offset, args_size, ret_offset, ret_size)
     %copy_mem_to_calldata
     // stack: new_ctx, kexit_info, callgas, address, value, args_offset, args_size, ret_offset, ret_size
-    DUP5 %address %address %transfer_eth %jumpi(call_insufficient_balance)
+    DUP5 %address DUP1 %transfer_eth %jumpi(call_insufficient_balance)
     // stack: new_ctx, kexit_info, callgas, address, value, args_offset, args_size, ret_offset, ret_size
     DUP3 %set_new_ctx_gas_limit
     // stack: new_ctx, kexit_info, callgas, address, value, args_offset, args_size, ret_offset, ret_size

--- a/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
@@ -323,8 +323,10 @@ process_message_txn_after_call_contd:
 
 process_message_txn_fail:
     // stack: leftover_gas, new_ctx, retdest, success, leftover_gas
-    // Transfer value back to the caller.
+
+    // Revert txn execution, then transfer value back to the caller.
     %revert_checkpoint
+
     %mload_txn_field(@TXN_FIELD_VALUE) ISZERO %jumpi(process_message_txn_after_call_contd)
     %mload_txn_field(@TXN_FIELD_VALUE)
     %mload_txn_field(@TXN_FIELD_ORIGIN)

--- a/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
@@ -246,6 +246,8 @@ global process_message_txn:
     // stack: code_empty, retdest
     %jumpi(process_message_txn_return)
 
+    %checkpoint
+
     // Otherwise, load to's code and execute it in a new context.
     // stack: retdest
     %create_context
@@ -322,6 +324,7 @@ process_message_txn_after_call_contd:
 process_message_txn_fail:
     // stack: leftover_gas, new_ctx, retdest, success, leftover_gas
     // Transfer value back to the caller.
+    %revert_checkpoint
     %mload_txn_field(@TXN_FIELD_VALUE) ISZERO %jumpi(process_message_txn_after_call_contd)
     %mload_txn_field(@TXN_FIELD_VALUE)
     %mload_txn_field(@TXN_FIELD_ORIGIN)


### PR DESCRIPTION
Contract creations mark a checkpoint prior deployment, but regular contract calls do not, which can cause discrepancies in final state tries upon reversion if the recipient does not have enough funds to send back the initial txn amount to the sender. This unfortunately wasn't caught with the original Eth test suite because `TO` targets were always funded enough at the start.

This added checkpoint now makes sure every transfers are being reverted, before sending the initial value back to the initial.



@praetoriansentry 3.5/5