### PR TITLE
Fix max_cpu_len_log

### DIFF
--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -185,14 +185,18 @@ pub(crate) trait State<F: RichField> {
     {
         let halt_offsets = self.get_halt_offsets();
 
-        let cycle_limit = max_cpu_len_log.map(|max_len_log| {
-            let target_len = 1 << max_len_log;
-            if target_len > NUM_EXTRA_CYCLES_AFTER {
-                target_len - NUM_EXTRA_CYCLES_AFTER
-            } else {
-                target_len
+        if let Some(max_len_log) = max_cpu_len_log {
+            if (1 << max_len_log) < NUM_EXTRA_CYCLES_AFTER {
+                bail!(
+                    "Target length (2^{}) is less than NUM_EXTRA_CYCLES_AFTER ({})",
+                    max_len_log,
+                    NUM_EXTRA_CYCLES_AFTER
+                );
             }
-        });
+        }
+
+        let cycle_limit =
+            max_cpu_len_log.map(|max_len_log| (1 << max_len_log) - NUM_EXTRA_CYCLES_AFTER);
 
         let mut final_registers = RegistersState::default();
         let mut running = true;

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -185,8 +185,15 @@ pub(crate) trait State<F: RichField> {
     {
         let halt_offsets = self.get_halt_offsets();
 
-        let cycle_limit =
-            max_cpu_len_log.map(|max_len_log| (1 << max_len_log) - NUM_EXTRA_CYCLES_AFTER);
+        let cycle_limit = max_cpu_len_log.map(|max_len_log| {
+            let target_len = 1 << max_len_log;
+            let min_len = NUM_EXTRA_CYCLES_AFTER.next_power_of_two();
+            if target_len > min_len {
+                target_len - NUM_EXTRA_CYCLES_AFTER
+            } else {
+                target_len
+            }
+        });
 
         let mut final_registers = RegistersState::default();
         let mut running = true;

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -187,8 +187,7 @@ pub(crate) trait State<F: RichField> {
 
         let cycle_limit = max_cpu_len_log.map(|max_len_log| {
             let target_len = 1 << max_len_log;
-            let min_len = NUM_EXTRA_CYCLES_AFTER.next_power_of_two();
-            if target_len > min_len {
+            if target_len > NUM_EXTRA_CYCLES_AFTER {
                 target_len - NUM_EXTRA_CYCLES_AFTER
             } else {
                 target_len

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -186,13 +186,12 @@ pub(crate) trait State<F: RichField> {
         let halt_offsets = self.get_halt_offsets();
 
         if let Some(max_len_log) = max_cpu_len_log {
-            if (1 << max_len_log) < NUM_EXTRA_CYCLES_AFTER {
-                bail!(
-                    "Target length (2^{}) is less than NUM_EXTRA_CYCLES_AFTER ({})",
-                    max_len_log,
-                    NUM_EXTRA_CYCLES_AFTER
-                );
-            }
+            assert!(
+                (1 << max_len_log) >= NUM_EXTRA_CYCLES_AFTER,
+                "Target length (2^{}) is less than NUM_EXTRA_CYCLES_AFTER ({})",
+                max_len_log,
+                NUM_EXTRA_CYCLES_AFTER
+            );
         }
 
         let cycle_limit =


### PR DESCRIPTION
Address the ‘attempt to subtract with overflow’ issue that occurs when `max_cpu_len_log` is set to a small value (less than 7).

This PR will also help with the empty segment test, where we aim to use the minimal number of CPU cycles in the segment.