### PR TITLE
fix: reset global metadata fields in memory post txn processing

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/main.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/main.asm
@@ -258,6 +258,7 @@ global check_final_state_trie:
 %macro reinitialize_memory_pre_txn
     // Reinitialize accessed addresses and storage keys lists
     %init_access_lists
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_TOUCHED_ADDRESSES_LEN)
 
     // Reinitialize transient storage
     %init_transient_storage_len
@@ -272,6 +273,7 @@ global check_final_state_trie:
     PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_JOURNAL_DATA_LEN)
     PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_REFUND_COUNTER)
     PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_SELFDESTRUCT_LIST_LEN)
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_CREATED_CONTRACTS_LEN)
 
     // Reinitialize `chain_id` for legacy transactions and `to` transaction field
     PUSH 0 %mstore_txn_field(@TXN_FIELD_CHAIN_ID_PRESENT)

--- a/evm_arithmetization/src/cpu/kernel/constants/global_metadata.rs
+++ b/evm_arithmetization/src/cpu/kernel/constants/global_metadata.rs
@@ -65,8 +65,6 @@ pub(crate) enum GlobalMetadata {
     AccessedStorageKeysLen,
     /// Length of the self-destruct list.
     SelfDestructListLen,
-    /// Length of the bloom entry buffer.
-    BloomEntryLen,
 
     /// Length of the journal.
     JournalLen,
@@ -118,7 +116,7 @@ pub(crate) enum GlobalMetadata {
 }
 
 impl GlobalMetadata {
-    pub(crate) const COUNT: usize = 55;
+    pub(crate) const COUNT: usize = 54;
 
     /// Unscales this virtual offset by their respective `Segment` value.
     pub(crate) const fn unscale(&self) -> usize {
@@ -157,7 +155,6 @@ impl GlobalMetadata {
             Self::AccessedAddressesLen,
             Self::AccessedStorageKeysLen,
             Self::SelfDestructListLen,
-            Self::BloomEntryLen,
             Self::JournalLen,
             Self::JournalDataLen,
             Self::CurrentCheckpoint,
@@ -219,7 +216,6 @@ impl GlobalMetadata {
             Self::AccessedAddressesLen => "GLOBAL_METADATA_ACCESSED_ADDRESSES_LEN",
             Self::AccessedStorageKeysLen => "GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN",
             Self::SelfDestructListLen => "GLOBAL_METADATA_SELFDESTRUCT_LIST_LEN",
-            Self::BloomEntryLen => "GLOBAL_METADATA_BLOOM_ENTRY_LEN",
             Self::JournalLen => "GLOBAL_METADATA_JOURNAL_LEN",
             Self::JournalDataLen => "GLOBAL_METADATA_JOURNAL_DATA_LEN",
             Self::CurrentCheckpoint => "GLOBAL_METADATA_CURRENT_CHECKPOINT",


### PR DESCRIPTION
Also deletes an unused global metadata

6.5/N @praetoriansentry 