### PR TITLE
Fix check against 0xEF byte in contract creation.

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/process_txn.asm
@@ -188,11 +188,15 @@ global process_contract_creation_txn_after_constructor:
 
     ISZERO %jumpi(contract_creation_fault_3)
 
-    // EIP-3541: Reject new contract code starting with the 0xEF byte
+    // EIP-3541: Reject new contract code starting with the 0xEF byte, if code_size > 0
+    %returndatasize // size of the code 
+    DUP1 ISZERO
+    // stack: code_size == 0, code_size, leftover_gas, new_ctx, address, retdest, success
+    %jumpi(process_contract_creation_txn_after_ef_check)
+    // stack: code_size, leftover_gas, new_ctx, address, retdest, success
     PUSH 0 %mload_current(@SEGMENT_RETURNDATA) %eq_const(0xEF) %jumpi(contract_creation_fault_3_zero_leftover)
 
-    // stack: leftover_gas, new_ctx, address, retdest, success
-    %returndatasize // Size of the code.
+process_contract_creation_txn_after_ef_check:
     // stack: code_size, leftover_gas, new_ctx, address, retdest, success
     DUP1 %gt_const(@MAX_CODE_SIZE) %jumpi(contract_creation_fault_4)
     // stack: code_size, leftover_gas, new_ctx, address, retdest, success
@@ -487,8 +491,8 @@ contract_creation_fault_3:
 
 contract_creation_fault_3_zero_leftover:
     %revert_checkpoint
-    // stack: leftover_gas, new_ctx, address, retdest, success
-    %pop3
+    // stack: code_size, leftover_gas, new_ctx, address, retdest, success
+    %pop4
     PUSH 0 // leftover gas
     // stack: leftover_gas, retdest, success
     %pay_coinbase_and_refund_sender


### PR DESCRIPTION
In some transactions, the kernel might process a transaction with contract creation and empty code. In `process_contract_creation_txn_after_constructor`, there is a check that the first byte is not `0xef`. The check works for empty contracts in the non-batched case since `SEGMENT_RETURNDATA` is empty in that case. However, in the batched case, the first byte might come from a previous transaction, if the current contract is empty. 

This PR addresses this issue by only checking the first byte when `code_size > 0`.