### PR TITLE
Bump plonky2 (serialization fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,7 +3644,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 [[package]]
 name = "plonky2"
 version = "0.2.2"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8463effe0dd1472a52906cd12ffb047885db42ee#8463effe0dd1472a52906cd12ffb047885db42ee"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520#07c20447bfcdada6bd479bd8a13af26082923520"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3655,7 +3655,7 @@ dependencies = [
  "log",
  "num",
  "plonky2_field",
- "plonky2_maybe_rayon 0.2.0 (git+https://github.com/0xPolygonZero/plonky2.git?rev=8463effe0dd1472a52906cd12ffb047885db42ee)",
+ "plonky2_maybe_rayon 0.2.0 (git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520)",
  "plonky2_util",
  "rand",
  "rand_chacha",
@@ -3668,7 +3668,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.2.2"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8463effe0dd1472a52906cd12ffb047885db42ee#8463effe0dd1472a52906cd12ffb047885db42ee"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520#07c20447bfcdada6bd479bd8a13af26082923520"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
@@ -3692,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.2.0"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8463effe0dd1472a52906cd12ffb047885db42ee#8463effe0dd1472a52906cd12ffb047885db42ee"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520#07c20447bfcdada6bd479bd8a13af26082923520"
 dependencies = [
  "rayon",
 ]
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.2.0"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8463effe0dd1472a52906cd12ffb047885db42ee#8463effe0dd1472a52906cd12ffb047885db42ee"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520#07c20447bfcdada6bd479bd8a13af26082923520"
 
 [[package]]
 name = "plotters"
@@ -4661,7 +4661,7 @@ checksum = "8acdd7dbfcfb5dd6e46c63512508bf71c2043f70b8f143813ad75cb5e8a589f2"
 [[package]]
 name = "starky"
 version = "0.4.0"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=8463effe0dd1472a52906cd12ffb047885db42ee#8463effe0dd1472a52906cd12ffb047885db42ee"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520#07c20447bfcdada6bd479bd8a13af26082923520"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4670,8 +4670,9 @@ dependencies = [
  "log",
  "num-bigint",
  "plonky2",
- "plonky2_maybe_rayon 0.2.0 (git+https://github.com/0xPolygonZero/plonky2.git?rev=8463effe0dd1472a52906cd12ffb047885db42ee)",
+ "plonky2_maybe_rayon 0.2.0 (git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520)",
  "plonky2_util",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,7 +3644,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 [[package]]
 name = "plonky2"
 version = "0.2.2"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520#07c20447bfcdada6bd479bd8a13af26082923520"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=2488cdacd49ede15737bc1172546d82e9521b79b#2488cdacd49ede15737bc1172546d82e9521b79b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3655,7 +3655,7 @@ dependencies = [
  "log",
  "num",
  "plonky2_field",
- "plonky2_maybe_rayon 0.2.0 (git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520)",
+ "plonky2_maybe_rayon 0.2.0 (git+https://github.com/0xPolygonZero/plonky2.git?rev=2488cdacd49ede15737bc1172546d82e9521b79b)",
  "plonky2_util",
  "rand",
  "rand_chacha",
@@ -3668,7 +3668,7 @@ dependencies = [
 [[package]]
 name = "plonky2_field"
 version = "0.2.2"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520#07c20447bfcdada6bd479bd8a13af26082923520"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=2488cdacd49ede15737bc1172546d82e9521b79b#2488cdacd49ede15737bc1172546d82e9521b79b"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
@@ -3692,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "plonky2_maybe_rayon"
 version = "0.2.0"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520#07c20447bfcdada6bd479bd8a13af26082923520"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=2488cdacd49ede15737bc1172546d82e9521b79b#2488cdacd49ede15737bc1172546d82e9521b79b"
 dependencies = [
  "rayon",
 ]
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.2.0"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520#07c20447bfcdada6bd479bd8a13af26082923520"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=2488cdacd49ede15737bc1172546d82e9521b79b#2488cdacd49ede15737bc1172546d82e9521b79b"
 
 [[package]]
 name = "plotters"
@@ -4661,7 +4661,7 @@ checksum = "8acdd7dbfcfb5dd6e46c63512508bf71c2043f70b8f143813ad75cb5e8a589f2"
 [[package]]
 name = "starky"
 version = "0.4.0"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520#07c20447bfcdada6bd479bd8a13af26082923520"
+source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=2488cdacd49ede15737bc1172546d82e9521b79b#2488cdacd49ede15737bc1172546d82e9521b79b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4670,7 +4670,7 @@ dependencies = [
  "log",
  "num-bigint",
  "plonky2",
- "plonky2_maybe_rayon 0.2.0 (git+https://github.com/0xPolygonZero/plonky2.git?rev=07c20447bfcdada6bd479bd8a13af26082923520)",
+ "plonky2_maybe_rayon 0.2.0 (git+https://github.com/0xPolygonZero/plonky2.git?rev=2488cdacd49ede15737bc1172546d82e9521b79b)",
  "plonky2_util",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,11 +111,10 @@ zk_evm_proc_macro = { path = "proc_macro", version = "0.1.0" }
 zero = { path = "zero", default-features = false }
 
 # plonky2-related dependencies
-# TODO(Robin): Change to main branch revision before merge
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "07c20447bfcdada6bd479bd8a13af26082923520" }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "2488cdacd49ede15737bc1172546d82e9521b79b" }
 plonky2_maybe_rayon = "0.2.0"
-plonky2_util = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "07c20447bfcdada6bd479bd8a13af26082923520" }
-starky = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "07c20447bfcdada6bd479bd8a13af26082923520" }
+plonky2_util = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "2488cdacd49ede15737bc1172546d82e9521b79b" }
+starky = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "2488cdacd49ede15737bc1172546d82e9521b79b" }
 
 [workspace.lints.clippy]
 too_long_first_doc_paragraph = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,10 +111,11 @@ zk_evm_proc_macro = { path = "proc_macro", version = "0.1.0" }
 zero = { path = "zero", default-features = false }
 
 # plonky2-related dependencies
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "8463effe0dd1472a52906cd12ffb047885db42ee" }
+# TODO(Robin): Change to main branch revision before merge
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "07c20447bfcdada6bd479bd8a13af26082923520" }
 plonky2_maybe_rayon = "0.2.0"
-plonky2_util = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "8463effe0dd1472a52906cd12ffb047885db42ee" }
-starky = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "8463effe0dd1472a52906cd12ffb047885db42ee" }
+plonky2_util = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "07c20447bfcdada6bd479bd8a13af26082923520" }
+starky = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "07c20447bfcdada6bd479bd8a13af26082923520" }
 
 [workspace.lints.clippy]
 too_long_first_doc_paragraph = "allow"

--- a/evm_arithmetization/src/all_stark.rs
+++ b/evm_arithmetization/src/all_stark.rs
@@ -129,8 +129,6 @@ impl Table {
     }
 }
 
-/// The total number of CTLs used by the zkEVM.
-pub(crate) const NUM_CTLS: usize = if cfg!(feature = "cdk_erigon") { 13 } else { 10 };
 /// The position of the Memory CTL within all CTLs of the zkEVM.
 pub(crate) const MEMORY_CTL_IDX: usize = 6;
 
@@ -423,18 +421,4 @@ fn ctl_poseidon_general_output<F: Field>() -> CrossTableLookup<F> {
         vec![cpu_stark::ctl_poseidon_general_output()],
         poseidon_stark::ctl_looked_general_output(),
     )
-}
-
-#[cfg(test)]
-mod tests {
-    use plonky2::field::goldilocks_field::GoldilocksField;
-
-    use super::*;
-
-    type F = GoldilocksField;
-
-    #[test]
-    fn check_num_ctls() {
-        assert_eq!(all_cross_table_lookups::<F>().len(), NUM_CTLS);
-    }
 }

--- a/evm_arithmetization/src/all_stark.rs
+++ b/evm_arithmetization/src/all_stark.rs
@@ -129,6 +129,11 @@ impl Table {
     }
 }
 
+/// The total number of CTLs used by the zkEVM.
+pub(crate) const NUM_CTLS: usize = if cfg!(feature = "cdk_erigon") { 13 } else { 10 };
+/// The position of the Memory CTL within all CTLs of the zkEVM.
+pub(crate) const MEMORY_CTL_IDX: usize = 6;
+
 /// Returns all the `CrossTableLookups` used for proving the EVM.
 pub(crate) fn all_cross_table_lookups<F: Field>() -> Vec<CrossTableLookup<F>> {
     vec![

--- a/evm_arithmetization/src/all_stark.rs
+++ b/evm_arithmetization/src/all_stark.rs
@@ -129,6 +129,8 @@ impl Table {
     }
 }
 
+/// The total number of CTLs used by the zkEVM.
+pub(crate) const NUM_CTLS: usize = if cfg!(feature = "cdk_erigon") { 13 } else { 10 };
 /// The position of the Memory CTL within all CTLs of the zkEVM.
 pub(crate) const MEMORY_CTL_IDX: usize = 6;
 
@@ -421,4 +423,18 @@ fn ctl_poseidon_general_output<F: Field>() -> CrossTableLookup<F> {
         vec![cpu_stark::ctl_poseidon_general_output()],
         poseidon_stark::ctl_looked_general_output(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use plonky2::field::goldilocks_field::GoldilocksField;
+
+    use super::*;
+
+    type F = GoldilocksField;
+
+    #[test]
+    fn check_num_ctls() {
+        assert_eq!(all_cross_table_lookups::<F>().len(), NUM_CTLS);
+    }
 }

--- a/evm_arithmetization/src/all_stark.rs
+++ b/evm_arithmetization/src/all_stark.rs
@@ -424,3 +424,17 @@ fn ctl_poseidon_general_output<F: Field>() -> CrossTableLookup<F> {
         poseidon_stark::ctl_looked_general_output(),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use plonky2::field::goldilocks_field::GoldilocksField;
+
+    use super::*;
+
+    type F = GoldilocksField;
+
+    #[test]
+    fn check_num_ctls() {
+        assert_eq!(all_cross_table_lookups::<F>().len(), NUM_CTLS);
+    }
+}

--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -37,7 +37,8 @@ use starky::proof::StarkProofWithMetadata;
 use starky::stark::Stark;
 
 use crate::all_stark::{
-    all_cross_table_lookups, AllStark, Table, KECCAK_TABLES_INDICES, MEMORY_CTL_IDX, NUM_TABLES,
+    all_cross_table_lookups, AllStark, Table, KECCAK_TABLES_INDICES, MEMORY_CTL_IDX, NUM_CTLS,
+    NUM_TABLES,
 };
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::generation::segments::{GenerationSegmentData, SegmentDataIterator};
@@ -998,7 +999,9 @@ where
 
         // Extra sums to add to the looked last value.
         // Only necessary for the Memory values.
-        let mut extra_looking_sums = HashMap::new();
+        let mut extra_looking_sums = HashMap::from_iter(
+            (0..NUM_CTLS).map(|i| (i, vec![builder.zero(); stark_config.num_challenges])),
+        );
 
         // Memory
         extra_looking_sums.insert(

--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -37,7 +37,8 @@ use starky::proof::StarkProofWithMetadata;
 use starky::stark::Stark;
 
 use crate::all_stark::{
-    all_cross_table_lookups, AllStark, Table, KECCAK_TABLES_INDICES, NUM_TABLES,
+    all_cross_table_lookups, AllStark, Table, KECCAK_TABLES_INDICES, MEMORY_CTL_IDX, NUM_CTLS,
+    NUM_TABLES,
 };
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::generation::segments::{GenerationSegmentData, SegmentDataIterator};
@@ -998,19 +999,23 @@ where
 
         // Extra sums to add to the looked last value.
         // Only necessary for the Memory values.
-        let mut extra_looking_sums =
-            vec![vec![builder.zero(); stark_config.num_challenges]; NUM_TABLES];
+        let mut extra_looking_sums = HashMap::from_iter(
+            (0..NUM_CTLS).map(|i| (i, vec![builder.zero(); stark_config.num_challenges])),
+        );
 
         // Memory
-        extra_looking_sums[*Table::Memory] = (0..stark_config.num_challenges)
-            .map(|c| {
-                get_memory_extra_looking_sum_circuit(
-                    &mut builder,
-                    &public_values,
-                    ctl_challenges.challenges[c],
-                )
-            })
-            .collect_vec();
+        extra_looking_sums.insert(
+            MEMORY_CTL_IDX,
+            (0..stark_config.num_challenges)
+                .map(|c| {
+                    get_memory_extra_looking_sum_circuit(
+                        &mut builder,
+                        &public_values,
+                        ctl_challenges.challenges[c],
+                    )
+                })
+                .collect_vec(),
+        );
 
         // Ensure that when Keccak tables are skipped, the Keccak tables' ctl_zs_first
         // are all zeros.
@@ -1026,7 +1031,7 @@ where
             &mut builder,
             all_cross_table_lookups(),
             pis.map(|p| p.ctl_zs_first),
-            Some(&extra_looking_sums),
+            &extra_looking_sums,
             stark_config,
         );
 
@@ -2013,11 +2018,11 @@ where
                 let dummy_proof_data = self.table_dummy_proofs[table]
                     .as_ref()
                     .ok_or_else(|| anyhow::format_err!("No dummy_proof_data"))?;
-                root_inputs.set_target(self.root.index_verifier_data[table], F::ZERO);
+                root_inputs.set_target(self.root.index_verifier_data[table], F::ZERO)?;
                 root_inputs.set_proof_with_pis_target(
                     &self.root.proof_with_pis[table],
                     &dummy_proof_data.proof,
-                );
+                )?;
             } else {
                 let stark_proof = &all_proof.multi_proof.stark_proofs[table]
                     .as_ref()
@@ -2042,9 +2047,9 @@ where
                 root_inputs.set_target(
                     self.root.index_verifier_data[table],
                     F::from_canonical_usize(index_verifier_data),
-                );
+                )?;
                 root_inputs
-                    .set_proof_with_pis_target(&self.root.proof_with_pis[table], &shrunk_proof);
+                    .set_proof_with_pis_target(&self.root.proof_with_pis[table], &shrunk_proof)?;
             }
 
             check_abort_signal(abort_signal.clone())?;
@@ -2053,7 +2058,7 @@ where
         root_inputs.set_verifier_data_target(
             &self.root.cyclic_vk,
             &self.segment_aggregation.circuit.verifier_only,
-        );
+        )?;
 
         set_public_value_targets(
             &mut root_inputs,
@@ -2064,7 +2069,7 @@ where
             anyhow::Error::msg("Invalid conversion when setting public values targets.")
         })?;
 
-        root_inputs.set_bool_target(self.root.use_keccak_tables, all_proof.use_keccak_tables);
+        root_inputs.set_bool_target(self.root.use_keccak_tables, all_proof.use_keccak_tables)?;
 
         let root_proof = self.root.circuit.prove(root_inputs)?;
 
@@ -2141,11 +2146,11 @@ where
                 let dummy_proof = self.table_dummy_proofs[table]
                     .as_ref()
                     .ok_or_else(|| anyhow::format_err!("Unable to get dummpy proof"))?;
-                root_inputs.set_target(self.root.index_verifier_data[table], F::ZERO);
+                root_inputs.set_target(self.root.index_verifier_data[table], F::ZERO)?;
                 root_inputs.set_proof_with_pis_target(
                     &self.root.proof_with_pis[table],
                     &dummy_proof.proof,
-                );
+                )?;
             } else {
                 let (table_circuit, index_verifier_data) = &table_circuits[table]
                     .as_ref()
@@ -2153,14 +2158,14 @@ where
                 root_inputs.set_target(
                     self.root.index_verifier_data[table],
                     F::from_canonical_u8(*index_verifier_data),
-                );
+                )?;
                 let stark_proof = all_proof.multi_proof.stark_proofs[table]
                     .as_ref()
                     .ok_or_else(|| anyhow::format_err!("Unable to get stark proof"))?;
                 let shrunk_proof =
                     table_circuit.shrink(stark_proof, &all_proof.multi_proof.ctl_challenges)?;
                 root_inputs
-                    .set_proof_with_pis_target(&self.root.proof_with_pis[table], &shrunk_proof);
+                    .set_proof_with_pis_target(&self.root.proof_with_pis[table], &shrunk_proof)?;
             }
 
             check_abort_signal(abort_signal.clone())?;
@@ -2169,7 +2174,7 @@ where
         root_inputs.set_verifier_data_target(
             &self.root.cyclic_vk,
             &self.segment_aggregation.circuit.verifier_only,
-        );
+        )?;
 
         set_public_value_targets(
             &mut root_inputs,
@@ -2180,7 +2185,7 @@ where
             anyhow::Error::msg("Invalid conversion when setting public values targets.")
         })?;
 
-        root_inputs.set_bool_target(self.root.use_keccak_tables, all_proof.use_keccak_tables);
+        root_inputs.set_bool_target(self.root.use_keccak_tables, all_proof.use_keccak_tables)?;
 
         let root_proof = self.root.circuit.prove(root_inputs)?;
 
@@ -2229,7 +2234,7 @@ where
             &self.segment_aggregation.circuit,
             &mut agg_inputs,
             lhs_proof,
-        );
+        )?;
 
         // If rhs is dummy, the rhs proof is also set to be the lhs.
         let real_rhs_proof = if rhs_is_dummy { lhs_proof } else { rhs_proof };
@@ -2241,12 +2246,12 @@ where
             &self.segment_aggregation.circuit,
             &mut agg_inputs,
             real_rhs_proof,
-        );
+        )?;
 
         agg_inputs.set_verifier_data_target(
             &self.segment_aggregation.cyclic_vk,
             &self.segment_aggregation.circuit.verifier_only,
-        );
+        )?;
 
         // Aggregates both `PublicValues` from the provided proofs into a single one.
         let lhs_public_values = &lhs.proof_with_pvs.public_values;
@@ -2339,7 +2344,7 @@ where
             &self.batch_aggregation.circuit,
             &mut batch_inputs,
             &lhs.intern,
-        );
+        )?;
 
         Self::set_dummy_if_necessary(
             &self.batch_aggregation.rhs,
@@ -2347,12 +2352,12 @@ where
             &self.batch_aggregation.circuit,
             &mut batch_inputs,
             &rhs.intern,
-        );
+        )?;
 
         batch_inputs.set_verifier_data_target(
             &self.batch_aggregation.cyclic_vk,
             &self.batch_aggregation.circuit.verifier_only,
-        );
+        )?;
 
         let lhs_pvs = &lhs.public_values;
         let batch_public_values = PublicValues {
@@ -2393,20 +2398,20 @@ where
         circuit: &CircuitData<F, C, D>,
         agg_inputs: &mut PartialWitness<F>,
         proof: &ProofWithPublicInputs<F, C, D>,
-    ) {
-        agg_inputs.set_bool_target(agg_child.is_agg, is_agg);
-        agg_inputs.set_bool_target(agg_child.is_dummy, is_dummy);
+    ) -> anyhow::Result<()> {
+        agg_inputs.set_bool_target(agg_child.is_agg, is_agg)?;
+        agg_inputs.set_bool_target(agg_child.is_dummy, is_dummy)?;
         if is_agg {
-            agg_inputs.set_proof_with_pis_target(&agg_child.agg_proof, proof);
+            agg_inputs.set_proof_with_pis_target(&agg_child.agg_proof, proof)?;
         } else {
             Self::set_dummy_proof_with_cyclic_vk_pis(
                 circuit,
                 agg_inputs,
                 &agg_child.agg_proof,
                 proof,
-            );
+            )?;
         }
-        agg_inputs.set_proof_with_pis_target(&agg_child.real_proof, proof);
+        agg_inputs.set_proof_with_pis_target(&agg_child.real_proof, proof)
     }
 
     /// Create a final block proof, once all transactions of a given block have
@@ -2438,10 +2443,10 @@ where
         block_inputs.set_bool_target(
             self.block.has_parent_block,
             opt_parent_block_proof.is_some(),
-        );
+        )?;
         if let Some(parent_block_proof) = opt_parent_block_proof {
             block_inputs
-                .set_proof_with_pis_target(&self.block.parent_block_proof, parent_block_proof);
+                .set_proof_with_pis_target(&self.block.parent_block_proof, parent_block_proof)?;
         } else {
             if agg_root_proof.public_values.trie_roots_before.state_root
                 != agg_root_proof
@@ -2584,13 +2589,14 @@ where
                     &self.block.circuit.verifier_only,
                     nonzero_pis,
                 ),
-            );
+            )?;
         }
 
-        block_inputs.set_proof_with_pis_target(&self.block.agg_root_proof, &agg_root_proof.intern);
+        block_inputs
+            .set_proof_with_pis_target(&self.block.agg_root_proof, &agg_root_proof.intern)?;
 
         block_inputs
-            .set_verifier_data_target(&self.block.cyclic_vk, &self.block.circuit.verifier_only);
+            .set_verifier_data_target(&self.block.cyclic_vk, &self.block.circuit.verifier_only)?;
 
         // This is basically identical to this block public values, apart from the
         // `trie_roots_before` that may come from the previous proof, if any.
@@ -2649,13 +2655,15 @@ where
     )> {
         let mut block_wrapper_inputs = PartialWitness::new();
 
-        block_wrapper_inputs
-            .set_proof_with_pis_target(&self.block_wrapper.parent_block_proof, &block_proof.intern);
+        block_wrapper_inputs.set_proof_with_pis_target(
+            &self.block_wrapper.parent_block_proof,
+            &block_proof.intern,
+        )?;
 
         block_wrapper_inputs.set_verifier_data_target(
             &self.block_wrapper.cyclic_vk, // dummy
             &self.block_wrapper.circuit.verifier_only,
-        );
+        )?;
 
         let final_pvs = block_proof.public_values.clone().into();
         set_final_public_value_targets(
@@ -2709,7 +2717,7 @@ where
             &self.two_to_one_block.circuit,
             &mut witness,
             lhs,
-        );
+        )?;
 
         Self::set_dummy_if_necessary(
             &self.two_to_one_block.rhs,
@@ -2717,15 +2725,14 @@ where
             &self.two_to_one_block.circuit,
             &mut witness,
             rhs,
-        );
+        )?;
 
         witness.set_verifier_data_target(
             &self.two_to_one_block.cyclic_vk,
             &self.two_to_one_block.circuit.verifier_only,
-        );
+        )?;
 
-        let proof = self.two_to_one_block.circuit.prove(witness)?;
-        Ok(proof)
+        self.two_to_one_block.circuit.prove(witness)
     }
 
     /// Verifies an existing block aggregation proof.
@@ -2756,7 +2763,7 @@ where
         witness: &mut PartialWitness<F>,
         agg_proof_with_pis: &ProofWithPublicInputsTarget<D>,
         base_proof_with_pis: &ProofWithPublicInputs<F, C, D>,
-    ) {
+    ) -> anyhow::Result<()> {
         let ProofWithPublicInputs {
             proof: base_proof,
             public_inputs: _,
@@ -2767,7 +2774,7 @@ where
         } = agg_proof_with_pis;
 
         // The proof remains the same.
-        witness.set_proof_target(agg_proof_targets, base_proof);
+        witness.set_proof_target(agg_proof_targets, base_proof)?;
 
         let cyclic_verifying_data = &circuit_agg.verifier_only;
         let mut cyclic_vk = cyclic_verifying_data.circuit_digest.to_vec();
@@ -2778,8 +2785,10 @@ where
 
         // Set dummy public inputs.
         for (&pi_t, pi) in agg_pi_targets.iter().zip_eq(dummy_pis) {
-            witness.set_target(pi_t, pi);
+            witness.set_target(pi_t, pi)?;
         }
+
+        Ok(())
     }
 
     /// If the [`AggregationChild`] is a base proof and not an aggregation
@@ -2794,19 +2803,19 @@ where
         circuit: &CircuitData<F, C, D>,
         agg_inputs: &mut PartialWitness<F>,
         proof: &ProofWithPublicInputs<F, C, D>,
-    ) {
-        agg_inputs.set_bool_target(agg_child.is_agg, is_agg);
+    ) -> anyhow::Result<()> {
+        agg_inputs.set_bool_target(agg_child.is_agg, is_agg)?;
         if is_agg {
-            agg_inputs.set_proof_with_pis_target(&agg_child.agg_proof, proof);
+            agg_inputs.set_proof_with_pis_target(&agg_child.agg_proof, proof)?;
         } else {
             Self::set_dummy_proof_with_cyclic_vk_pis(
                 circuit,
                 agg_inputs,
                 &agg_child.agg_proof,
                 proof,
-            );
+            )?;
         }
-        agg_inputs.set_proof_with_pis_target(&agg_child.base_proof, proof);
+        agg_inputs.set_proof_with_pis_target(&agg_child.base_proof, proof)
     }
 }
 

--- a/evm_arithmetization/src/fixed_recursive_verifier.rs
+++ b/evm_arithmetization/src/fixed_recursive_verifier.rs
@@ -37,8 +37,7 @@ use starky::proof::StarkProofWithMetadata;
 use starky::stark::Stark;
 
 use crate::all_stark::{
-    all_cross_table_lookups, AllStark, Table, KECCAK_TABLES_INDICES, MEMORY_CTL_IDX, NUM_CTLS,
-    NUM_TABLES,
+    all_cross_table_lookups, AllStark, Table, KECCAK_TABLES_INDICES, MEMORY_CTL_IDX, NUM_TABLES,
 };
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::generation::segments::{GenerationSegmentData, SegmentDataIterator};
@@ -999,9 +998,7 @@ where
 
         // Extra sums to add to the looked last value.
         // Only necessary for the Memory values.
-        let mut extra_looking_sums = HashMap::from_iter(
-            (0..NUM_CTLS).map(|i| (i, vec![builder.zero(); stark_config.num_challenges])),
-        );
+        let mut extra_looking_sums = HashMap::new();
 
         // Memory
         extra_looking_sums.insert(

--- a/evm_arithmetization/src/recursive_verifier.rs
+++ b/evm_arithmetization/src/recursive_verifier.rs
@@ -156,7 +156,7 @@ where
             &self.stark_proof_target,
             &proof_with_metadata.proof,
             self.zero_target,
-        );
+        )?;
 
         for (challenge_target, challenge) in self
             .ctl_challenges_target
@@ -164,14 +164,14 @@ where
             .iter()
             .zip(&ctl_challenges.challenges)
         {
-            inputs.set_target(challenge_target.beta, challenge.beta);
-            inputs.set_target(challenge_target.gamma, challenge.gamma);
+            inputs.set_target(challenge_target.beta, challenge.beta)?;
+            inputs.set_target(challenge_target.gamma, challenge.gamma)?;
         }
 
         inputs.set_target_arr(
             self.init_challenger_state_target.as_ref(),
             proof_with_metadata.init_challenger_state.as_ref(),
-        );
+        )?;
 
         self.circuit.prove(inputs)
     }
@@ -199,7 +199,7 @@ where
         proof: &ProofWithPublicInputs<F, C, D>,
     ) -> Result<ProofWithPublicInputs<F, C, D>> {
         let mut inputs = PartialWitness::new();
-        inputs.set_proof_with_pis_target(&self.proof_with_pis_target, proof);
+        inputs.set_proof_with_pis_target(&self.proof_with_pis_target, proof)?;
         self.circuit.prove(inputs)
     }
 }
@@ -842,12 +842,12 @@ where
         witness,
         &public_values_target.trie_roots_before,
         &public_values.trie_roots_before,
-    );
+    )?;
     set_trie_roots_target(
         witness,
         &public_values_target.trie_roots_after,
         &public_values.trie_roots_after,
-    );
+    )?;
     set_block_metadata_target(
         witness,
         &public_values_target.block_metadata,
@@ -857,7 +857,7 @@ where
         witness,
         &public_values_target.block_hashes,
         &public_values.block_hashes,
-    );
+    )?;
     set_extra_public_values_target(
         witness,
         &public_values_target.extra_block_data,
@@ -906,10 +906,12 @@ where
     H: Hasher<F>,
     W: Witness<F>,
 {
-    witness.set_target(
-        public_values_target.chain_id,
-        F::from_canonical_u64(public_values.chain_id.low_u64()),
-    );
+    witness
+        .set_target(
+            public_values_target.chain_id,
+            F::from_canonical_u64(public_values.chain_id.low_u64()),
+        )
+        .map_err(ProgramError::from)?;
 
     for (i, limb) in public_values
         .checkpoint_state_trie_root
@@ -918,14 +920,18 @@ where
         .into_iter()
         .enumerate()
     {
-        witness.set_target(
-            public_values_target.checkpoint_state_trie_root[2 * i],
-            F::from_canonical_u32(limb as u32),
-        );
-        witness.set_target(
-            public_values_target.checkpoint_state_trie_root[2 * i + 1],
-            F::from_canonical_u32((limb >> 32) as u32),
-        );
+        witness
+            .set_target(
+                public_values_target.checkpoint_state_trie_root[2 * i],
+                F::from_canonical_u32(limb as u32),
+            )
+            .map_err(ProgramError::from)?;
+        witness
+            .set_target(
+                public_values_target.checkpoint_state_trie_root[2 * i + 1],
+                F::from_canonical_u32((limb >> 32) as u32),
+            )
+            .map_err(ProgramError::from)?;
     }
 
     for (i, limb) in public_values
@@ -935,18 +941,24 @@ where
         .into_iter()
         .enumerate()
     {
-        witness.set_target(
-            public_values_target.new_state_trie_root[2 * i],
-            F::from_canonical_u32(limb as u32),
-        );
-        witness.set_target(
-            public_values_target.new_state_trie_root[2 * i + 1],
-            F::from_canonical_u32((limb >> 32) as u32),
-        );
+        witness
+            .set_target(
+                public_values_target.new_state_trie_root[2 * i],
+                F::from_canonical_u32(limb as u32),
+            )
+            .map_err(ProgramError::from)?;
+        witness
+            .set_target(
+                public_values_target.new_state_trie_root[2 * i + 1],
+                F::from_canonical_u32((limb >> 32) as u32),
+            )
+            .map_err(ProgramError::from)?;
     }
 
     for (i, limb) in public_values.new_consolidated_hash.iter().enumerate() {
-        witness.set_target(public_values_target.new_consolidated_hash[i], *limb);
+        witness
+            .set_target(public_values_target.new_consolidated_hash[i], *limb)
+            .map_err(ProgramError::from)?;
     }
 
     Ok(())
@@ -956,7 +968,8 @@ pub(crate) fn set_trie_roots_target<F, W, const D: usize>(
     witness: &mut W,
     trie_roots_target: &TrieRootsTarget,
     trie_roots: &TrieRoots,
-) where
+) -> Result<()>
+where
     F: RichField + Extendable<D>,
     W: Witness<F>,
 {
@@ -964,11 +977,11 @@ pub(crate) fn set_trie_roots_target<F, W, const D: usize>(
         witness.set_target(
             trie_roots_target.state_root[2 * i],
             F::from_canonical_u32(limb as u32),
-        );
+        )?;
         witness.set_target(
             trie_roots_target.state_root[2 * i + 1],
             F::from_canonical_u32((limb >> 32) as u32),
-        );
+        )?;
     }
 
     for (i, limb) in trie_roots
@@ -981,11 +994,11 @@ pub(crate) fn set_trie_roots_target<F, W, const D: usize>(
         witness.set_target(
             trie_roots_target.transactions_root[2 * i],
             F::from_canonical_u32(limb as u32),
-        );
+        )?;
         witness.set_target(
             trie_roots_target.transactions_root[2 * i + 1],
             F::from_canonical_u32((limb >> 32) as u32),
-        );
+        )?;
     }
 
     for (i, limb) in trie_roots
@@ -998,12 +1011,14 @@ pub(crate) fn set_trie_roots_target<F, W, const D: usize>(
         witness.set_target(
             trie_roots_target.receipts_root[2 * i],
             F::from_canonical_u32(limb as u32),
-        );
+        )?;
         witness.set_target(
             trie_roots_target.receipts_root[2 * i + 1],
             F::from_canonical_u32((limb >> 32) as u32),
-        );
+        )?;
     }
+
+    Ok(())
 }
 
 #[cfg(feature = "cdk_erigon")]
@@ -1019,7 +1034,9 @@ where
     match burn_addr_target {
         BurnAddrTarget::BurnAddr(addr_target) => {
             let burn_addr_limbs: [F; 8] = u256_limbs::<F>(burn_addr);
-            witness.set_target_arr(addr_target, &burn_addr_limbs);
+            witness
+                .set_target_arr(addr_target, &burn_addr_limbs)
+                .map_err(ProgramError::from)?;
         }
         BurnAddrTarget::Burnt() => panic!("There should be an address target set in cdk_erigon."),
     }
@@ -1040,73 +1057,105 @@ where
         u256_limbs::<F>(U256::from_big_endian(&block_metadata.block_beneficiary.0))[..5]
             .try_into()
             .unwrap();
-    witness.set_target_arr(&block_metadata_target.block_beneficiary, &beneficiary_limbs);
-    witness.set_target(
-        block_metadata_target.block_timestamp,
-        u256_to_u32(block_metadata.block_timestamp)?,
-    );
-    witness.set_target(
-        block_metadata_target.block_number,
-        u256_to_u32(block_metadata.block_number)?,
-    );
-    witness.set_target(
-        block_metadata_target.block_difficulty,
-        u256_to_u32(block_metadata.block_difficulty)?,
-    );
-    witness.set_target_arr(
-        &block_metadata_target.block_random,
-        &h256_limbs(block_metadata.block_random),
-    );
-    witness.set_target(
-        block_metadata_target.block_gaslimit,
-        u256_to_u32(block_metadata.block_gaslimit)?,
-    );
-    witness.set_target(
-        block_metadata_target.block_chain_id,
-        u256_to_u32(block_metadata.block_chain_id)?,
-    );
+    witness
+        .set_target_arr(&block_metadata_target.block_beneficiary, &beneficiary_limbs)
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(
+            block_metadata_target.block_timestamp,
+            u256_to_u32(block_metadata.block_timestamp)?,
+        )
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(
+            block_metadata_target.block_number,
+            u256_to_u32(block_metadata.block_number)?,
+        )
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(
+            block_metadata_target.block_difficulty,
+            u256_to_u32(block_metadata.block_difficulty)?,
+        )
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target_arr(
+            &block_metadata_target.block_random,
+            &h256_limbs(block_metadata.block_random),
+        )
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(
+            block_metadata_target.block_gaslimit,
+            u256_to_u32(block_metadata.block_gaslimit)?,
+        )
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(
+            block_metadata_target.block_chain_id,
+            u256_to_u32(block_metadata.block_chain_id)?,
+        )
+        .map_err(ProgramError::from)?;
     // Basefee fits in 2 limbs
     let basefee = u256_to_u64(block_metadata.block_base_fee)?;
-    witness.set_target(block_metadata_target.block_base_fee[0], basefee.0);
-    witness.set_target(block_metadata_target.block_base_fee[1], basefee.1);
-    witness.set_target(
-        block_metadata_target.block_gas_used,
-        u256_to_u32(block_metadata.block_gas_used)?,
-    );
+    witness
+        .set_target(block_metadata_target.block_base_fee[0], basefee.0)
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(block_metadata_target.block_base_fee[1], basefee.1)
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(
+            block_metadata_target.block_gas_used,
+            u256_to_u32(block_metadata.block_gas_used)?,
+        )
+        .map_err(ProgramError::from)?;
     #[cfg(feature = "eth_mainnet")]
     {
         // BlobGasUsed fits in 2 limbs
         let blob_gas_used = u256_to_u64(block_metadata.block_blob_gas_used)?;
-        witness.set_target(
-            block_metadata_target.block_blob_gas_used[0],
-            blob_gas_used.0,
-        );
-        witness.set_target(
-            block_metadata_target.block_blob_gas_used[1],
-            blob_gas_used.1,
-        );
+        witness
+            .set_target(
+                block_metadata_target.block_blob_gas_used[0],
+                blob_gas_used.0,
+            )
+            .map_err(ProgramError::from)?;
+        witness
+            .set_target(
+                block_metadata_target.block_blob_gas_used[1],
+                blob_gas_used.1,
+            )
+            .map_err(ProgramError::from)?;
         // ExcessBlobGas fits in 2 limbs
         let excess_blob_gas = u256_to_u64(block_metadata.block_excess_blob_gas)?;
-        witness.set_target(
-            block_metadata_target.block_excess_blob_gas[0],
-            excess_blob_gas.0,
-        );
-        witness.set_target(
-            block_metadata_target.block_excess_blob_gas[1],
-            excess_blob_gas.1,
-        );
+        witness
+            .set_target(
+                block_metadata_target.block_excess_blob_gas[0],
+                excess_blob_gas.0,
+            )
+            .map_err(ProgramError::from)?;
+        witness
+            .set_target(
+                block_metadata_target.block_excess_blob_gas[1],
+                excess_blob_gas.1,
+            )
+            .map_err(ProgramError::from)?;
 
-        witness.set_target_arr(
-            &block_metadata_target.parent_beacon_block_root,
-            &h256_limbs(block_metadata.parent_beacon_block_root),
-        );
+        witness
+            .set_target_arr(
+                &block_metadata_target.parent_beacon_block_root,
+                &h256_limbs(block_metadata.parent_beacon_block_root),
+            )
+            .map_err(ProgramError::from)?;
     }
 
     let mut block_bloom_limbs = [F::ZERO; 64];
     for (i, limbs) in block_bloom_limbs.chunks_exact_mut(8).enumerate() {
         limbs.copy_from_slice(&u256_limbs(block_metadata.block_bloom[i]));
     }
-    witness.set_target_arr(&block_metadata_target.block_bloom, &block_bloom_limbs);
+    witness
+        .set_target_arr(&block_metadata_target.block_bloom, &block_bloom_limbs)
+        .map_err(ProgramError::from)?;
 
     Ok(())
 }
@@ -1115,7 +1164,8 @@ pub(crate) fn set_block_hashes_target<F, W, const D: usize>(
     witness: &mut W,
     block_hashes_target: &BlockHashesTarget,
     block_hashes: &BlockHashes,
-) where
+) -> Result<()>
+where
     F: RichField + Extendable<D>,
     W: Witness<F>,
 {
@@ -1124,10 +1174,10 @@ pub(crate) fn set_block_hashes_target<F, W, const D: usize>(
         witness.set_target_arr(
             &block_hashes_target.prev_hashes[8 * i..8 * (i + 1)],
             &block_hash_limbs,
-        );
+        )?;
     }
     let cur_block_hash_limbs: [F; 8] = h256_limbs::<F>(block_hashes.cur_hash);
-    witness.set_target_arr(&block_hashes_target.cur_hash, &cur_block_hash_limbs);
+    witness.set_target_arr(&block_hashes_target.cur_hash, &cur_block_hash_limbs)
 }
 
 pub(crate) fn set_extra_public_values_target<F, W, const D: usize>(
@@ -1139,24 +1189,36 @@ where
     F: RichField + Extendable<D>,
     W: Witness<F>,
 {
-    witness.set_target_arr(
-        &ed_target.checkpoint_state_trie_root,
-        &h256_limbs::<F>(ed.checkpoint_state_trie_root),
-    );
-    witness.set_target_arr(
-        &ed_target.checkpoint_consolidated_hash,
-        &ed.checkpoint_consolidated_hash,
-    );
-    witness.set_target(
-        ed_target.txn_number_before,
-        u256_to_u32(ed.txn_number_before)?,
-    );
-    witness.set_target(
-        ed_target.txn_number_after,
-        u256_to_u32(ed.txn_number_after)?,
-    );
-    witness.set_target(ed_target.gas_used_before, u256_to_u32(ed.gas_used_before)?);
-    witness.set_target(ed_target.gas_used_after, u256_to_u32(ed.gas_used_after)?);
+    witness
+        .set_target_arr(
+            &ed_target.checkpoint_state_trie_root,
+            &h256_limbs::<F>(ed.checkpoint_state_trie_root),
+        )
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target_arr(
+            &ed_target.checkpoint_consolidated_hash,
+            &ed.checkpoint_consolidated_hash,
+        )
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(
+            ed_target.txn_number_before,
+            u256_to_u32(ed.txn_number_before)?,
+        )
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(
+            ed_target.txn_number_after,
+            u256_to_u32(ed.txn_number_after)?,
+        )
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(ed_target.gas_used_before, u256_to_u32(ed.gas_used_before)?)
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(ed_target.gas_used_after, u256_to_u32(ed.gas_used_after)?)
+        .map_err(ProgramError::from)?;
 
     Ok(())
 }
@@ -1170,12 +1232,24 @@ where
     F: RichField + Extendable<D>,
     W: Witness<F>,
 {
-    witness.set_target(rd_target.program_counter, u256_to_u32(rd.program_counter)?);
-    witness.set_target(rd_target.is_kernel, u256_to_u32(rd.is_kernel)?);
-    witness.set_target(rd_target.stack_len, u256_to_u32(rd.stack_len)?);
-    witness.set_target_arr(&rd_target.stack_top, &u256_limbs(rd.stack_top));
-    witness.set_target(rd_target.context, u256_to_u32(rd.context)?);
-    witness.set_target(rd_target.gas_used, u256_to_u32(rd.gas_used)?);
+    witness
+        .set_target(rd_target.program_counter, u256_to_u32(rd.program_counter)?)
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(rd_target.is_kernel, u256_to_u32(rd.is_kernel)?)
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(rd_target.stack_len, u256_to_u32(rd.stack_len)?)
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target_arr(&rd_target.stack_top, &u256_limbs(rd.stack_top))
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(rd_target.context, u256_to_u32(rd.context)?)
+        .map_err(ProgramError::from)?;
+    witness
+        .set_target(rd_target.gas_used, u256_to_u32(rd.gas_used)?)
+        .map_err(ProgramError::from)?;
 
     Ok(())
 }
@@ -1190,12 +1264,14 @@ where
     W: Witness<F>,
 {
     for i in 0..mc.mem_cap.len() {
-        witness.set_hash_target(
-            mc_target.mem_cap.0[i],
-            HashOut {
-                elements: mc.mem_cap[i].map(|elt| F::from_canonical_u64(elt.as_u64())),
-            },
-        );
+        witness
+            .set_hash_target(
+                mc_target.mem_cap.0[i],
+                HashOut {
+                    elements: mc.mem_cap[i].map(|elt| F::from_canonical_u64(elt.as_u64())),
+                },
+            )
+            .map_err(ProgramError::from)?;
     }
     Ok(())
 }

--- a/evm_arithmetization/src/verifier.rs
+++ b/evm_arithmetization/src/verifier.rs
@@ -93,7 +93,7 @@ pub mod testing {
     use starky::stark::Stark;
     use starky::verifier::verify_stark_proof_with_challenges;
 
-    use crate::all_stark::{Table, MEMORY_CTL_IDX};
+    use crate::all_stark::{Table, MEMORY_CTL_IDX, NUM_CTLS};
     use crate::cpu::kernel::aggregator::KERNEL;
     use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
     use crate::get_challenges::testing::AllProofChallenges;
@@ -250,7 +250,8 @@ pub mod testing {
 
         // Extra sums to add to the looked last value.
         // Only necessary for the Memory values.
-        let mut extra_looking_sums = HashMap::new();
+        let mut extra_looking_sums =
+            HashMap::from_iter((0..NUM_CTLS).map(|i| (i, vec![F::ZERO; config.num_challenges])));
 
         // Memory
         extra_looking_sums.insert(

--- a/evm_arithmetization/src/verifier.rs
+++ b/evm_arithmetization/src/verifier.rs
@@ -93,7 +93,7 @@ pub mod testing {
     use starky::stark::Stark;
     use starky::verifier::verify_stark_proof_with_challenges;
 
-    use crate::all_stark::{Table, MEMORY_CTL_IDX, NUM_CTLS};
+    use crate::all_stark::{Table, MEMORY_CTL_IDX};
     use crate::cpu::kernel::aggregator::KERNEL;
     use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
     use crate::get_challenges::testing::AllProofChallenges;
@@ -250,8 +250,7 @@ pub mod testing {
 
         // Extra sums to add to the looked last value.
         // Only necessary for the Memory values.
-        let mut extra_looking_sums =
-            HashMap::from_iter((0..NUM_CTLS).map(|i| (i, vec![F::ZERO; config.num_challenges])));
+        let mut extra_looking_sums = HashMap::new();
 
         // Memory
         extra_looking_sums.insert(

--- a/evm_arithmetization/src/witness/errors.rs
+++ b/evm_arithmetization/src/witness/errors.rs
@@ -16,6 +16,13 @@ pub enum ProgramError {
     IntegerTooLarge,
     ProverInputError(ProverInputError),
     UnknownContractCode,
+    Other(String),
+}
+
+impl From<anyhow::Error> for ProgramError {
+    fn from(e: anyhow::Error) -> Self {
+        ProgramError::Other(e.to_string())
+    }
 }
 
 #[allow(clippy::enum_variant_names)]

--- a/evm_arithmetization/tests/empty_tables.rs
+++ b/evm_arithmetization/tests/empty_tables.rs
@@ -62,6 +62,25 @@ fn empty_tables() -> anyhow::Result<()> {
         )
     );
 
+    let segment_proof = timed!(
+        timing,
+        log::Level::Info,
+        "Prove segment",
+        all_circuits.prove_segment_with_all_proofs(&proofs[0], &config, None)?
+    );
+
+    // Verify the generated segment proof
+    timed!(
+        timing,
+        log::Level::Info,
+        "Verify segment proof",
+        all_circuits.verify_root(segment_proof.proof_with_pvs.intern.clone())?
+    );
+
+    // Print timing details
+    timing.print();
+
+    // Test serialization of preprocessed circuits
     {
         let gate_serializer = DefaultGateSerializer;
         let generator_serializer = DefaultGeneratorSerializer::<C, D>::default();
@@ -88,24 +107,6 @@ fn empty_tables() -> anyhow::Result<()> {
 
         assert_eq!(all_circuits, all_circuits_from_bytes);
     }
-
-    let segment_proof = timed!(
-        timing,
-        log::Level::Info,
-        "Prove segment",
-        all_circuits.prove_segment_with_all_proofs(&proofs[0], &config, None)?
-    );
-
-    // Verify the generated segment proof
-    timed!(
-        timing,
-        log::Level::Info,
-        "Verify segment proof",
-        all_circuits.verify_root(segment_proof.proof_with_pvs.intern.clone())?
-    );
-
-    // Print timing details
-    timing.print();
 
     Ok(())
 }

--- a/evm_arithmetization/tests/empty_tables.rs
+++ b/evm_arithmetization/tests/empty_tables.rs
@@ -62,25 +62,6 @@ fn empty_tables() -> anyhow::Result<()> {
         )
     );
 
-    let segment_proof = timed!(
-        timing,
-        log::Level::Info,
-        "Prove segment",
-        all_circuits.prove_segment_with_all_proofs(&proofs[0], &config, None)?
-    );
-
-    // Verify the generated segment proof
-    timed!(
-        timing,
-        log::Level::Info,
-        "Verify segment proof",
-        all_circuits.verify_root(segment_proof.proof_with_pvs.intern.clone())?
-    );
-
-    // Print timing details
-    timing.print();
-
-    // Test serialization of preprocessed circuits
     {
         let gate_serializer = DefaultGateSerializer;
         let generator_serializer = DefaultGeneratorSerializer::<C, D>::default();
@@ -107,6 +88,24 @@ fn empty_tables() -> anyhow::Result<()> {
 
         assert_eq!(all_circuits, all_circuits_from_bytes);
     }
+
+    let segment_proof = timed!(
+        timing,
+        log::Level::Info,
+        "Prove segment",
+        all_circuits.prove_segment_with_all_proofs(&proofs[0], &config, None)?
+    );
+
+    // Verify the generated segment proof
+    timed!(
+        timing,
+        log::Level::Info,
+        "Verify segment proof",
+        all_circuits.verify_root(segment_proof.proof_with_pvs.intern.clone())?
+    );
+
+    // Print timing details
+    timing.print();
 
     Ok(())
 }

--- a/evm_arithmetization/tests/empty_tables.rs
+++ b/evm_arithmetization/tests/empty_tables.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "eth_mainnet")]
 
+use std::time::Duration;
+
 use evm_arithmetization::fixed_recursive_verifier::AllRecursiveCircuits;
 use evm_arithmetization::prover::prove;
 use evm_arithmetization::testing_utils::{init_logger, segment_with_empty_tables};
@@ -8,6 +10,7 @@ use evm_arithmetization::AllStark;
 use plonky2::field::goldilocks_field::GoldilocksField;
 use plonky2::plonk::config::PoseidonGoldilocksConfig;
 use plonky2::timed;
+use plonky2::util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer};
 use plonky2::util::timing::TimingTree;
 use starky::config::StarkConfig;
 
@@ -58,6 +61,34 @@ fn empty_tables() -> anyhow::Result<()> {
             &config,
         )
     );
+
+    {
+        let gate_serializer = DefaultGateSerializer;
+        let generator_serializer = DefaultGeneratorSerializer::<C, D>::default();
+
+        let timing = TimingTree::new("serialize AllRecursiveCircuits", log::Level::Info);
+        let all_circuits_bytes = all_circuits
+            .to_bytes(false, &gate_serializer, &generator_serializer)
+            .map_err(|_| anyhow::Error::msg("AllRecursiveCircuits serialization failed."))?;
+        timing.filter(Duration::from_millis(100)).print();
+        log::info!(
+            "AllRecursiveCircuits length: {} bytes",
+            all_circuits_bytes.len()
+        );
+
+        let timing = TimingTree::new("deserialize AllRecursiveCircuits", log::Level::Info);
+        let all_circuits_from_bytes = AllRecursiveCircuits::from_bytes(
+            &all_circuits_bytes,
+            false,
+            &gate_serializer,
+            &generator_serializer,
+        )
+        .map_err(|_| anyhow::Error::msg("AllRecursiveCircuits deserialization failed."))?;
+        timing.filter(Duration::from_millis(100)).print();
+
+        assert_eq!(all_circuits, all_circuits_from_bytes);
+    }
+
     let segment_proof = timed!(
         timing,
         log::Level::Info,

--- a/evm_arithmetization/tests/two_to_one_block.rs
+++ b/evm_arithmetization/tests/two_to_one_block.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "eth_mainnet")]
 
-use std::time::Duration;
-
 use ethereum_types::{Address, BigEndianHash, H256};
 use evm_arithmetization::fixed_recursive_verifier::{
     extract_block_final_public_values, extract_two_to_one_block_hash,
@@ -22,7 +20,6 @@ use plonky2::field::types::Field;
 use plonky2::hash::poseidon::PoseidonHash;
 use plonky2::plonk::config::{Hasher, PoseidonGoldilocksConfig};
 use plonky2::plonk::proof::ProofWithPublicInputs;
-use plonky2::util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer};
 use plonky2::util::timing::TimingTree;
 
 type F = GoldilocksField;
@@ -178,33 +175,6 @@ fn test_two_to_one_block_aggregation() -> anyhow::Result<()> {
         &[16..17, 8..9, 12..13, 8..9, 8..9, 6..7, 17..18, 16..17, 7..8],
         &config,
     );
-
-    {
-        let gate_serializer = DefaultGateSerializer;
-        let generator_serializer = DefaultGeneratorSerializer::<C, D>::default();
-
-        let timing = TimingTree::new("serialize AllRecursiveCircuits", log::Level::Info);
-        let all_circuits_bytes = all_circuits
-            .to_bytes(false, &gate_serializer, &generator_serializer)
-            .map_err(|_| anyhow::Error::msg("AllRecursiveCircuits serialization failed."))?;
-        timing.filter(Duration::from_millis(100)).print();
-        log::info!(
-            "AllRecursiveCircuits length: {} bytes",
-            all_circuits_bytes.len()
-        );
-
-        let timing = TimingTree::new("deserialize AllRecursiveCircuits", log::Level::Info);
-        let all_circuits_from_bytes = AllRecursiveCircuits::from_bytes(
-            &all_circuits_bytes,
-            false,
-            &gate_serializer,
-            &generator_serializer,
-        )
-        .map_err(|_| anyhow::Error::msg("AllRecursiveCircuits deserialization failed."))?;
-        timing.filter(Duration::from_millis(100)).print();
-
-        assert_eq!(all_circuits, all_circuits_from_bytes);
-    }
 
     let bp = some_timestamps
         .iter()

--- a/evm_arithmetization/tests/two_to_one_block.rs
+++ b/evm_arithmetization/tests/two_to_one_block.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "eth_mainnet")]
 
+use std::time::Duration;
+
 use ethereum_types::{Address, BigEndianHash, H256};
 use evm_arithmetization::fixed_recursive_verifier::{
     extract_block_final_public_values, extract_two_to_one_block_hash,
@@ -20,6 +22,7 @@ use plonky2::field::types::Field;
 use plonky2::hash::poseidon::PoseidonHash;
 use plonky2::plonk::config::{Hasher, PoseidonGoldilocksConfig};
 use plonky2::plonk::proof::ProofWithPublicInputs;
+use plonky2::util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer};
 use plonky2::util::timing::TimingTree;
 
 type F = GoldilocksField;
@@ -172,9 +175,36 @@ fn test_two_to_one_block_aggregation() -> anyhow::Result<()> {
 
     let all_circuits = AllRecursiveCircuits::new(
         &all_stark,
-        &[16..17, 8..9, 12..13, 8..9, 8..9, 6..7, 17..18, 17..18, 7..8],
+        &[16..17, 8..9, 12..13, 8..9, 8..9, 6..7, 17..18, 16..17, 7..8],
         &config,
     );
+
+    {
+        let gate_serializer = DefaultGateSerializer;
+        let generator_serializer = DefaultGeneratorSerializer::<C, D>::default();
+
+        let timing = TimingTree::new("serialize AllRecursiveCircuits", log::Level::Info);
+        let all_circuits_bytes = all_circuits
+            .to_bytes(false, &gate_serializer, &generator_serializer)
+            .map_err(|_| anyhow::Error::msg("AllRecursiveCircuits serialization failed."))?;
+        timing.filter(Duration::from_millis(100)).print();
+        log::info!(
+            "AllRecursiveCircuits length: {} bytes",
+            all_circuits_bytes.len()
+        );
+
+        let timing = TimingTree::new("deserialize AllRecursiveCircuits", log::Level::Info);
+        let all_circuits_from_bytes = AllRecursiveCircuits::from_bytes(
+            &all_circuits_bytes,
+            false,
+            &gate_serializer,
+            &generator_serializer,
+        )
+        .map_err(|_| anyhow::Error::msg("AllRecursiveCircuits deserialization failed."))?;
+        timing.filter(Duration::from_millis(100)).print();
+
+        assert_eq!(all_circuits, all_circuits_from_bytes);
+    }
 
     let bp = some_timestamps
         .iter()


### PR DESCRIPTION
We are currently having serialization issues due to the addition of `DummyProofGenerator` on the `RootCircuitData`, which is causing the prover_state to not be deserializable properly, ruining caching mechanism with persistence mode activated.

This is currently pinned to `07c20447bfcdada6bd479bd8a13af26082923520` on the plonky2 side (i.e. related branch fix), and updates the codebase with all changes related to plonky2 bump, in addition to fixing the range in `two_to_one` test and adding a serialization check consistency on the `empty_tables` test.


sibling PR: https://github.com/0xPolygonZero/plonky2/pull/1634