### PR TITLE
fix: check gas before perform op

### DIFF
--- a/evm_arithmetization/src/witness/transition.rs
+++ b/evm_arithmetization/src/witness/transition.rs
@@ -345,14 +345,6 @@ where
     where
         Self: Sized,
     {
-        self.perform_op(op, row)?;
-        self.incr_pc(match op {
-            Operation::Syscall(_, _, _) | Operation::ExitKernel => 0,
-            Operation::Push(n) => n as usize + 1,
-            Operation::Jump | Operation::Jumpi => 0,
-            _ => 1,
-        });
-
         self.incr_gas(gas_to_charge(op));
         let registers = self.get_registers();
         let gas_limit_address = MemoryAddress::new(
@@ -372,6 +364,14 @@ where
                 Err(_) => return Err(ProgramError::IntegerTooLarge),
             }
         }
+
+        self.perform_op(op, row)?;
+        self.incr_pc(match op {
+            Operation::Syscall(_, _, _) | Operation::ExitKernel => 0,
+            Operation::Push(n) => n as usize + 1,
+            Operation::Jump | Operation::Jumpi => 0,
+            _ => 1,
+        });
 
         Ok(op)
     }


### PR DESCRIPTION
 This is an quick attempt to fix the bug identified in block `19794433` tx `0xb487d37c4f13407af55797add295c127f19ea6c823b8ba4e53fe1a3457d902c9` where JUMPS get executed despite of Out-of-Gas condition.
 
I am going to add a regression test as part of this PR.
 
 Offending instruction from RPC structlog:
 
 ```
 {
  "step": 1198,
  "curr_depth": 2,
  "tx_hash": "0xb487d37c4f13407af55797add295c127f19ea6c823b8ba4e53fe1a3457d902c9",
  "code_hash": "0xb9c1c929064cd21734c102a698e68bf617feefcfa5a9f62407c45401546736bf",
  "ctx": 2,
  "pc": 563,
  "pc_hex": "00000233",
  "gas": 2,
  "gas_cost": 10,
  "op": "JUMPI",
  "entry": "StructLog { pc: 563, op: \"JUMPI\", gas: 2, gas_cost: 10, depth: 2, error: None, stack: Some([599290589, 10000, 46305234306404416513646796018318532483072908513802138792889746402715613072618, 131758842981497199554169577046225233044076042219, 294, 131758842981497199554169577046225233044076042219, 128, 10000, 0, 0, 288, 0, 1, 567]), return_data: None, memory: None, memory_size: None, storage: None, refund_counter: None }"
}
 ```