### PR TITLE
feat: trait World for `trace_decoder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,15 +1152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build-array"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ef4e2687af237b2646687e19a0643bc369878216122e46c3f1a01c56baa9d5"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5135,7 +5126,6 @@ dependencies = [
  "assert2",
  "bitflags 2.6.0",
  "bitvec",
- "build-array",
  "bytes",
  "camino",
  "ciborium",

--- a/trace_decoder/Cargo.toml
+++ b/trace_decoder/Cargo.toml
@@ -15,7 +15,6 @@ alloy-compat = "0.1.0"
 anyhow.workspace = true
 bitflags.workspace = true
 bitvec.workspace = true
-build-array = "0.1.2"
 bytes.workspace = true
 ciborium.workspace = true
 ciborium-io.workspace = true

--- a/trace_decoder/src/core.rs
+++ b/trace_decoder/src/core.rs
@@ -20,7 +20,7 @@ use zk_evm_common::gwei_to_wei;
 
 use crate::{
     observer::{DummyObserver, Observer},
-    tries::StateSmt,
+    world::Type2World,
 };
 use crate::{
     tries::{MptKey, ReceiptTrie, StateMpt, StorageTrie, TransactionTrie},
@@ -178,7 +178,7 @@ fn start(
     pre_images: BlockTraceTriePreImages,
     wire_disposition: WireDisposition,
 ) -> anyhow::Result<(
-    Either<StateMpt, StateSmt>,
+    Either<StateMpt, Type2World>,
     BTreeMap<H256, StorageTrie>,
     Hash2Code,
 )> {
@@ -247,7 +247,7 @@ fn start(
                     )
                 }
                 WireDisposition::Type2 => {
-                    let crate::type2::Frontend { trie, code } =
+                    let crate::type2::Frontend { world: trie, code } =
                         crate::type2::frontend(instructions)?;
                     (
                         Either::Right(trie),

--- a/trace_decoder/src/core.rs
+++ b/trace_decoder/src/core.rs
@@ -135,7 +135,7 @@ pub fn entrypoint(
                  after,
                  withdrawals,
              }| {
-                let Type1World { state, storage } = world.either_into();
+                let (state, storage) = world.either_into::<Type1World>().into_state_and_storage();
                 GenerationInputs {
                     txn_number_before: first_txn_ix.into(),
                     gas_used_before: running_gas_used.into(),
@@ -556,8 +556,6 @@ where
                                 false => world.store_int(addr, k.into_uint(), v)?,
                             }
                         }
-                        let storage_root = world.storage_root(addr)?;
-                        world.set_storage(addr, storage_root)?;
                     }
 
                     state_mask.insert(<WorldT::Key>::from(addr));
@@ -709,8 +707,6 @@ where
     scalable_trim.insert(slot);
 
     trim_state.insert(<WorldT::Key>::from(ADDRESS_SCALABLE_L2));
-    let scalable_storage_root = world.storage_root(ADDRESS_SCALABLE_L2)?;
-    world.set_storage(ADDRESS_SCALABLE_L2, scalable_storage_root)?;
 
     // Update GER contract's storage if necessary
     if let Some((root, l1blockhash)) = ger_data {
@@ -729,8 +725,6 @@ where
         ger_trim.insert(slot);
 
         trim_state.insert(<WorldT::Key>::from(GLOBAL_EXIT_ROOT_ADDRESS));
-        let ger_storage_root = world.storage_root(GLOBAL_EXIT_ROOT_ADDRESS)?;
-        world.set_storage(GLOBAL_EXIT_ROOT_ADDRESS, ger_storage_root)?;
     }
 
     Ok(())
@@ -780,8 +774,6 @@ where
         }
     }
     trim_state.insert(<WorldT::Key>::from(BEACON_ROOTS_CONTRACT_ADDRESS));
-    let beacon_storage_root = world.storage_root(BEACON_ROOTS_CONTRACT_ADDRESS)?;
-    world.set_storage(BEACON_ROOTS_CONTRACT_ADDRESS, beacon_storage_root)?;
     Ok(())
 }
 

--- a/trace_decoder/src/lib.rs
+++ b/trace_decoder/src/lib.rs
@@ -60,6 +60,7 @@ mod tries;
 mod type1;
 mod type2;
 mod wire;
+mod world;
 
 pub use core::{entrypoint, WireDisposition};
 

--- a/trace_decoder/src/lib.rs
+++ b/trace_decoder/src/lib.rs
@@ -1,8 +1,10 @@
 //! An _Ethereum Node_ executes _transactions_ in _blocks_.
 //!
 //! Execution mutates two key data structures:
-//! - [The state trie](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/#state-trie).
-//! - [The storage tries](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/#storage-trie).
+//! - [The state](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/#state-trie),
+//!   which tracks, e.g the account balance.
+//! - [The storage](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/#storage-trie),
+//!   which is a huge array of integers, per-account.
 //!
 //! Ethereum nodes expose information about the transactions over RPC, e.g:
 //! - [The specific changes to the storage tries](TxnTrace::storage_written).
@@ -13,7 +15,8 @@
 //!
 //! **Prover perfomance is a high priority.**
 //!
-//! The aformentioned trie structures may have subtries _hashed out_.
+//! The aformentioned data structures are represented as tries,
+//! which may have subtries _hashed out_.
 //! That is, any node (and its children!) may be replaced by its hash,
 //! while maintaining provability of its contents:
 //!
@@ -44,12 +47,16 @@
 /// Over RPC, ethereum nodes expose their tries as a series of binary
 /// [`wire::Instruction`]s in a node-dependant format.
 ///
-/// These are parsed into the relevant trie depending on the node:
+/// These are parsed into the relevant state and storage data structures,
+/// depending on the node:
 ///    - [`type2`], which contains an [`smt_trie`].
 ///    - [`type1`], which contains an [`mpt_trie`].
 ///
 /// After getting the tries,
 /// we can continue to do the main work of "executing" the transactions.
+///
+/// The core of this library is agnostic over the (combined)
+/// state and storage representation - see [`world::World`] for more.
 const _DEVELOPER_DOCS: () = ();
 
 mod interface;

--- a/trace_decoder/src/observer.rs
+++ b/trace_decoder/src/observer.rs
@@ -3,12 +3,12 @@ use std::marker::PhantomData;
 use ethereum_types::U256;
 
 use crate::core::IntraBlockTries;
-use crate::tries::{ReceiptTrie, TransactionTrie, World};
+use crate::tries::{ReceiptTrie, TransactionTrie};
 
 /// Observer API for the trace decoder.
 /// Observer is used to collect various debugging and metadata info
 /// from the trace decoder run.
-pub trait Observer<StateTrieT> {
+pub trait Observer<WorldT> {
     /// Collect tries after the transaction/batch execution.
     ///
     /// Passing the arguments one by one through reference, because
@@ -18,7 +18,7 @@ pub trait Observer<StateTrieT> {
         &mut self,
         block: U256,
         batch: usize,
-        state_trie: &World<StateTrieT>,
+        state_trie: &WorldT,
         transaction_trie: &TransactionTrie,
         receipt_trie: &ReceiptTrie,
     );
@@ -53,12 +53,12 @@ impl<StateTrieT> TriesObserver<StateTrieT> {
     }
 }
 
-impl<StateTrieT: Clone> Observer<StateTrieT> for TriesObserver<StateTrieT> {
+impl<WorldT: Clone> Observer<WorldT> for TriesObserver<WorldT> {
     fn collect_tries(
         &mut self,
         block: U256,
         batch: usize,
-        state_trie: &World<StateTrieT>,
+        state_trie: &WorldT,
         transaction_trie: &TransactionTrie,
         receipt_trie: &ReceiptTrie,
     ) {
@@ -95,12 +95,12 @@ impl<StateTrieT> DummyObserver<StateTrieT> {
     }
 }
 
-impl<StateTrieT> Observer<StateTrieT> for DummyObserver<StateTrieT> {
+impl<WorldT> Observer<WorldT> for DummyObserver<WorldT> {
     fn collect_tries(
         &mut self,
         _block: U256,
         _batch: usize,
-        _state_trie: &World<StateTrieT>,
+        _state_trie: &WorldT,
         _transaction_trie: &TransactionTrie,
         _receipt_trie: &ReceiptTrie,
     ) {

--- a/trace_decoder/src/observer.rs
+++ b/trace_decoder/src/observer.rs
@@ -1,10 +1,9 @@
-use std::collections::BTreeMap;
 use std::marker::PhantomData;
 
-use ethereum_types::{H256, U256};
+use ethereum_types::U256;
 
 use crate::core::IntraBlockTries;
-use crate::tries::{ReceiptTrie, StorageTrie, TransactionTrie};
+use crate::tries::{ReceiptTrie, TransactionTrie, World};
 
 /// Observer API for the trace decoder.
 /// Observer is used to collect various debugging and metadata info
@@ -19,8 +18,7 @@ pub trait Observer<StateTrieT> {
         &mut self,
         block: U256,
         batch: usize,
-        state_trie: &StateTrieT,
-        storage: &BTreeMap<H256, StorageTrie>,
+        state_trie: &World<StateTrieT>,
         transaction_trie: &TransactionTrie,
         receipt_trie: &ReceiptTrie,
     );
@@ -60,8 +58,7 @@ impl<StateTrieT: Clone> Observer<StateTrieT> for TriesObserver<StateTrieT> {
         &mut self,
         block: U256,
         batch: usize,
-        state_trie: &StateTrieT,
-        storage: &BTreeMap<H256, StorageTrie>,
+        state_trie: &World<StateTrieT>,
         transaction_trie: &TransactionTrie,
         receipt_trie: &ReceiptTrie,
     ) {
@@ -69,8 +66,7 @@ impl<StateTrieT: Clone> Observer<StateTrieT> for TriesObserver<StateTrieT> {
             block,
             batch,
             tries: IntraBlockTries {
-                state: state_trie.clone(),
-                storage: storage.clone(),
+                world: state_trie.clone(),
                 transaction: transaction_trie.clone(),
                 receipt: receipt_trie.clone(),
             },
@@ -104,8 +100,7 @@ impl<StateTrieT> Observer<StateTrieT> for DummyObserver<StateTrieT> {
         &mut self,
         _block: U256,
         _batch: usize,
-        _state_trie: &StateTrieT,
-        _storage: &BTreeMap<H256, StorageTrie>,
+        _state_trie: &World<StateTrieT>,
         _transaction_trie: &TransactionTrie,
         _receipt_trie: &ReceiptTrie,
     ) {

--- a/trace_decoder/src/tries.rs
+++ b/trace_decoder/src/tries.rs
@@ -492,10 +492,9 @@ impl StorageTrie {
     pub fn get(&mut self, key: &MptKey) -> Option<&[u8]> {
         self.untyped.get(key.into_nibbles())
     }
-    pub fn insert(&mut self, key: MptKey, value: Vec<u8>) -> anyhow::Result<Option<Vec<u8>>> {
-        let prev = self.get(&key).map(Vec::from);
+    pub fn insert(&mut self, key: MptKey, value: Vec<u8>) -> anyhow::Result<()> {
         self.untyped.insert(key.into_nibbles(), value)?;
-        Ok(prev)
+        Ok(())
     }
     pub fn insert_hash(&mut self, key: MptKey, hash: H256) -> anyhow::Result<()> {
         self.untyped.insert(key.into_nibbles(), hash)?;

--- a/trace_decoder/src/tries.rs
+++ b/trace_decoder/src/tries.rs
@@ -11,6 +11,21 @@ use evm_arithmetization::generation::mpt::AccountRlp;
 use mpt_trie::partial_trie::{HashedPartialTrie, Node, OnOrphanedHashNode, PartialTrie as _};
 use u4::{AsNibbles, U4};
 
+#[derive(Clone, Debug)]
+pub struct World<StateTrieT> {
+    pub state: StateTrieT,
+    pub storage: BTreeMap<H256, StorageTrie>,
+}
+impl<T> World<T> {
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> World<U> {
+        let Self { state, storage } = self;
+        World {
+            state: f(state),
+            storage,
+        }
+    }
+}
+
 /// See <https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie>.
 ///
 /// Portions of the trie may be _hashed out_: see [`Self::insert_hash`].

--- a/trace_decoder/src/tries.rs
+++ b/trace_decoder/src/tries.rs
@@ -221,6 +221,12 @@ where
     }
 }
 
+impl<T> From<TypedMpt<T>> for HashedPartialTrie {
+    fn from(value: TypedMpt<T>) -> Self {
+        value.inner
+    }
+}
+
 /// Bounded sequence of [`U4`],
 /// used as a key for [`TypedMpt`].
 ///
@@ -515,7 +521,7 @@ pub trait StateTrie {
 /// See <https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/#state-trie>
 #[derive(Debug, Clone, Default)]
 pub struct StateMpt {
-    typed: TypedMpt<AccountRlp>,
+    pub typed: TypedMpt<AccountRlp>,
 }
 
 impl StateMpt {

--- a/trace_decoder/src/tries.rs
+++ b/trace_decoder/src/tries.rs
@@ -12,7 +12,7 @@ use mpt_trie::partial_trie::{HashedPartialTrie, Node, OnOrphanedHashNode, Partia
 use u4::{AsNibbles, U4};
 
 /// Bounded sequence of [`U4`],
-/// used as a key for [`TypedMpt`].
+/// used as a key for [MPT](HashedPartialTrie) types in this module.
 ///
 /// Semantically equivalent to [`mpt_trie::nibbles::Nibbles`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -93,7 +93,7 @@ fn mpt_key_into_hash() {
 }
 
 /// Bounded sequence of bits,
-/// used as a key for [`StateSmt`].
+/// used as a key for SMT tries.
 ///
 /// Semantically equivalent to [`smt_trie::bits::Bits`].
 #[derive(Clone, Copy)]

--- a/trace_decoder/src/type2.rs
+++ b/trace_decoder/src/type2.rs
@@ -33,7 +33,7 @@ pub fn frontend(instructions: impl IntoIterator<Item = Instruction>) -> anyhow::
 
 /// Node in a binary (SMT) tree.
 ///
-/// This is an intermediary type on the way to [`StateSmt`].
+/// This is an intermediary type on the way to [`Type2World`].
 enum Node {
     Branch(EitherOrBoth<Box<Self>>),
     Hash([u8; 32]),

--- a/trace_decoder/src/world.rs
+++ b/trace_decoder/src/world.rs
@@ -341,7 +341,11 @@ impl World for Type2World {
     }
 }
 
-#[derive(Default)]
+// Having optional fields here is an odd decision,
+// but without the distinction,
+// the wire tests fail.
+// This may be a bug in the SMT library.
+#[derive(Default, Clone, Debug)]
 pub struct Type2Entry {
     pub balance: Option<U256>,
     pub nonce: Option<U256>,
@@ -350,12 +354,16 @@ pub struct Type2Entry {
     pub storage: BTreeMap<U256, U256>,
 }
 
+// This is a buffered version
+#[derive(Clone, Debug)]
 pub struct Type2World {
     accounts: BTreeMap<Address, Type2Entry>,
     hashed_out: BTreeMap<SmtKey, H256>,
 }
 
 impl Type2World {
+    /// # Panics
+    /// - On untrusted inputs: https://github.com/0xPolygonZero/zk_evm/issues/348
     pub fn as_smt(&self) -> smt_trie::smt::Smt<smt_trie::db::MemoryDb> {
         let mut smt = smt_trie::smt::Smt::<smt_trie::db::MemoryDb>::default();
 

--- a/trace_decoder/src/world.rs
+++ b/trace_decoder/src/world.rs
@@ -363,7 +363,7 @@ pub struct Type2World {
 
 impl Type2World {
     /// # Panics
-    /// - On untrusted inputs: https://github.com/0xPolygonZero/zk_evm/issues/348
+    /// - On untrusted inputs: <https://github.com/0xPolygonZero/zk_evm/issues/348>.
     pub fn as_smt(&self) -> smt_trie::smt::Smt<smt_trie::db::MemoryDb> {
         let mut smt = smt_trie::smt::Smt::<smt_trie::db::MemoryDb>::default();
 

--- a/trace_decoder/src/world.rs
+++ b/trace_decoder/src/world.rs
@@ -18,12 +18,10 @@ pub(crate) trait World {
     fn update_nonce(&mut self, address: Address, f: impl FnOnce(&mut U256)) -> anyhow::Result<()>;
     /// Creates a new account at `address` if it does not exist.
     fn set_code(&mut self, address: Address, code: Either<&[u8], H256>) -> anyhow::Result<()>;
-    /// Creates a new account at `address` if it does not exist.
-    fn set_storage(&mut self, address: Address, root: H256) -> anyhow::Result<()>;
     fn reporting_remove(&mut self, address: Address) -> anyhow::Result<Option<Self::Key>>;
     /// _Hash out_ parts of the trie that aren't in `addresses`.
     fn mask(&mut self, addresses: impl IntoIterator<Item = Self::Key>) -> anyhow::Result<()>;
-    fn root(&self) -> H256;
+    fn root(&mut self) -> H256;
 
     /// Create an account at the given address.
     ///
@@ -34,14 +32,15 @@ pub(crate) trait World {
     fn store_hash(&mut self, address: Address, hash: H256, value: H256) -> anyhow::Result<()>;
     fn load_int(&mut self, address: Address, slot: U256) -> anyhow::Result<U256>;
     fn delete_slot(&mut self, address: Address, slot: U256) -> anyhow::Result<Option<MptKey>>;
-    fn storage_root(&mut self, address: Address) -> anyhow::Result<H256>;
     fn mask_storage(&mut self, masks: BTreeMap<Address, BTreeSet<MptKey>>) -> anyhow::Result<()>;
 }
 
 #[derive(Clone, Debug)]
 pub struct Type1World {
-    pub state: StateMpt,
-    pub storage: BTreeMap<H256, StorageTrie>,
+    state: StateMpt,
+    /// Writes to storage should be reconciled with
+    /// [`storage_root`](evm_arithmetization::generation::mpt::AccountRlp)s.
+    storage: BTreeMap<H256, StorageTrie>,
 }
 
 impl Type1World {
@@ -61,10 +60,29 @@ impl Type1World {
         }
         Ok(Self { state, storage })
     }
+    pub fn into_state_and_storage(self) -> (StateMpt, BTreeMap<H256, StorageTrie>) {
+        let Self { state, storage } = self;
+        (state, storage)
+    }
     fn get_storage_mut(&mut self, address: Address) -> anyhow::Result<&mut StorageTrie> {
         self.storage
             .get_mut(&keccak_hash::keccak(address))
             .context("no such storage")
+    }
+    fn on_storage<T>(
+        &mut self,
+        address: Address,
+        f: impl FnOnce(&mut StorageTrie) -> anyhow::Result<T>,
+    ) -> anyhow::Result<T> {
+        let mut acct = self
+            .state
+            .get(keccak_hash::keccak(address))
+            .context("no such account")?;
+        let storage = self.get_storage_mut(address)?;
+        let ret = f(storage)?;
+        acct.storage_root = storage.root();
+        self.state.insert(keccak_hash::keccak(address), acct)?;
+        Ok(ret)
     }
 }
 
@@ -95,19 +113,13 @@ impl World for Type1World {
         acct.code_hash = code.right_or_else(keccak_hash::keccak);
         self.state.insert(key, acct)
     }
-    fn set_storage(&mut self, address: Address, root: H256) -> anyhow::Result<()> {
-        let key = keccak_hash::keccak(address);
-        let mut acct = self.state.get(key).unwrap_or_default();
-        acct.storage_root = root;
-        self.state.insert(key, acct)
-    }
     fn reporting_remove(&mut self, address: Address) -> anyhow::Result<Option<Self::Key>> {
         self.state.reporting_remove(address)
     }
     fn mask(&mut self, addresses: impl IntoIterator<Item = Self::Key>) -> anyhow::Result<()> {
         self.state.mask(addresses)
     }
-    fn root(&self) -> H256 {
+    fn root(&mut self) -> H256 {
         self.state.root()
     }
     fn create_storage(&mut self, address: Address) -> anyhow::Result<()> {
@@ -124,17 +136,18 @@ impl World for Type1World {
     }
 
     fn store_int(&mut self, address: Address, slot: U256, value: U256) -> anyhow::Result<()> {
-        self.get_storage_mut(address)?.insert(
-            MptKey::from_slot_position(slot),
-            alloy::rlp::encode(value.compat()),
-        )?;
-        Ok(())
+        self.on_storage(address, |it| {
+            it.insert(
+                MptKey::from_slot_position(slot),
+                alloy::rlp::encode(value.compat()),
+            )
+        })
     }
 
     fn store_hash(&mut self, address: Address, hash: H256, value: H256) -> anyhow::Result<()> {
-        self.get_storage_mut(address)?
-            .insert(MptKey::from_hash(hash), alloy::rlp::encode(value.compat()))?;
-        Ok(())
+        self.on_storage(address, |it| {
+            it.insert(MptKey::from_hash(hash), alloy::rlp::encode(value.compat()))
+        })
     }
 
     fn load_int(&mut self, address: Address, slot: U256) -> anyhow::Result<U256> {
@@ -146,12 +159,9 @@ impl World for Type1World {
     }
 
     fn delete_slot(&mut self, address: Address, slot: U256) -> anyhow::Result<Option<MptKey>> {
-        self.get_storage_mut(address)?
-            .reporting_remove(MptKey::from_slot_position(slot))
-    }
-
-    fn storage_root(&mut self, address: Address) -> anyhow::Result<H256> {
-        Ok(self.get_storage_mut(address)?.root())
+        self.on_storage(address, |it| {
+            it.reporting_remove(MptKey::from_slot_position(slot))
+        })
     }
 
     fn mask_storage(&mut self, masks: BTreeMap<Address, BTreeSet<MptKey>>) -> anyhow::Result<()> {

--- a/trace_decoder/src/world.rs
+++ b/trace_decoder/src/world.rs
@@ -1,0 +1,153 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use alloy_compat::Compat as _;
+use anyhow::{ensure, Context as _};
+use either::Either;
+use ethereum_types::{Address, U256};
+use evm_arithmetization::generation::mpt::AccountRlp;
+use keccak_hash::H256;
+
+use crate::tries::{MptKey, StorageTrie, TypedMpt};
+
+pub(crate) trait World {
+    type Key;
+    fn contains(&mut self, address: Address) -> anyhow::Result<bool>;
+    /// Creates a new account at `address` if it does not exist.
+    fn update_balance(&mut self, address: Address, f: impl FnOnce(&mut U256))
+        -> anyhow::Result<()>;
+    /// Creates a new account at `address` if it does not exist.
+    fn update_nonce(&mut self, address: Address, f: impl FnOnce(&mut U256)) -> anyhow::Result<()>;
+    /// Creates a new account at `address` if it does not exist.
+    fn set_code(&mut self, address: Address, code: Either<&[u8], H256>) -> anyhow::Result<()>;
+    /// Creates a new account at `address` if it does not exist.
+    fn set_storage(&mut self, address: Address, root: H256) -> anyhow::Result<()>;
+    fn reporting_remove(&mut self, address: Address) -> anyhow::Result<Option<Self::Key>>;
+    /// _Hash out_ parts of the trie that aren't in `addresses`.
+    fn mask(&mut self, addresses: impl IntoIterator<Item = Self::Key>) -> anyhow::Result<()>;
+    fn root(&self) -> H256;
+
+    /// Create an account at the given address.
+    ///
+    /// It may not be an error if the address already exists.
+    fn create_storage(&mut self, address: Address) -> anyhow::Result<()>;
+    fn destroy_storage(&mut self, address: Address) -> anyhow::Result<()>;
+    fn store_int(&mut self, address: Address, slot: U256, value: U256) -> anyhow::Result<()>;
+    fn store_hash(&mut self, address: Address, hash: H256, value: H256) -> anyhow::Result<()>;
+    fn load_int(&mut self, address: Address, slot: U256) -> anyhow::Result<U256>;
+    fn delete_slot(&mut self, address: Address, slot: U256) -> anyhow::Result<Option<MptKey>>;
+    fn storage_root(&mut self, address: Address) -> anyhow::Result<H256>;
+    fn mask_storage(&mut self, masks: BTreeMap<Address, BTreeSet<MptKey>>) -> anyhow::Result<()>;
+}
+
+pub(crate) struct Type1World {
+    pub state: TypedMpt<AccountRlp>,
+    pub storage: BTreeMap<H256, StorageTrie>,
+}
+impl Type1World {
+    fn get_storage_mut(&mut self, address: Address) -> anyhow::Result<&mut StorageTrie> {
+        self.storage
+            .get_mut(&keccak_hash::keccak(address))
+            .context("no such storage")
+    }
+}
+
+impl World for Type1World {
+    type Key = MptKey;
+    fn contains(&mut self, address: Address) -> anyhow::Result<bool> {
+        Ok(self.state.get(MptKey::from_address(address)).is_some())
+    }
+    fn update_balance(
+        &mut self,
+        address: Address,
+        f: impl FnOnce(&mut U256),
+    ) -> anyhow::Result<()> {
+        let key = MptKey::from_address(address);
+        let mut acct = self.state.get(key).unwrap_or_default();
+        f(&mut acct.balance);
+        self.state.insert(key, acct)
+    }
+    fn update_nonce(&mut self, address: Address, f: impl FnOnce(&mut U256)) -> anyhow::Result<()> {
+        let key = MptKey::from_address(address);
+        let mut acct = self.state.get(key).unwrap_or_default();
+        f(&mut acct.nonce);
+        self.state.insert(key, acct)
+    }
+    fn set_code(&mut self, address: Address, code: Either<&[u8], H256>) -> anyhow::Result<()> {
+        let key = MptKey::from_address(address);
+        let mut acct = self.state.get(key).unwrap_or_default();
+        acct.code_hash = code.right_or_else(keccak_hash::keccak);
+        self.state.insert(key, acct)
+    }
+    fn set_storage(&mut self, address: Address, root: H256) -> anyhow::Result<()> {
+        let key = MptKey::from_address(address);
+        let mut acct = self.state.get(key).unwrap_or_default();
+        acct.storage_root = root;
+        self.state.insert(key, acct)
+    }
+    fn reporting_remove(&mut self, address: Address) -> anyhow::Result<Option<Self::Key>> {
+        self.state.reporting_remove(MptKey::from_address(address))
+    }
+    fn mask(&mut self, addresses: impl IntoIterator<Item = Self::Key>) -> anyhow::Result<()> {
+        self.state.mask(addresses)
+    }
+    fn root(&self) -> H256 {
+        self.state.root()
+    }
+    fn create_storage(&mut self, address: Address) -> anyhow::Result<()> {
+        let _clobbered = self
+            .storage
+            .insert(keccak_hash::keccak(address), StorageTrie::default());
+        // ensure!(_clobbered.is_none()); // TODO(0xaatif): fails our tests
+        Ok(())
+    }
+    fn destroy_storage(&mut self, address: Address) -> anyhow::Result<()> {
+        let removed = self.storage.remove(&keccak_hash::keccak(address));
+        ensure!(removed.is_some());
+        Ok(())
+    }
+
+    fn store_int(&mut self, address: Address, slot: U256, value: U256) -> anyhow::Result<()> {
+        self.get_storage_mut(address)?.insert(
+            MptKey::from_slot_position(slot),
+            alloy::rlp::encode(value.compat()),
+        )?;
+        Ok(())
+    }
+
+    fn store_hash(&mut self, address: Address, hash: H256, value: H256) -> anyhow::Result<()> {
+        self.get_storage_mut(address)?
+            .insert(MptKey::from_hash(hash), alloy::rlp::encode(value.compat()))?;
+        Ok(())
+    }
+
+    fn load_int(&mut self, address: Address, slot: U256) -> anyhow::Result<U256> {
+        let bytes = self
+            .get_storage_mut(address)?
+            .get(&MptKey::from_slot_position(slot))
+            .context(format!("no storage at slot {slot} for address {address:x}"))?;
+        Ok(rlp::decode(bytes)?)
+    }
+
+    fn delete_slot(&mut self, address: Address, slot: U256) -> anyhow::Result<Option<MptKey>> {
+        self.get_storage_mut(address)?
+            .reporting_remove(MptKey::from_slot_position(slot))
+    }
+
+    fn storage_root(&mut self, address: Address) -> anyhow::Result<H256> {
+        Ok(self.get_storage_mut(address)?.root())
+    }
+
+    fn mask_storage(&mut self, masks: BTreeMap<Address, BTreeSet<MptKey>>) -> anyhow::Result<()> {
+        let keep = masks
+            .keys()
+            .map(keccak_hash::keccak)
+            .collect::<BTreeSet<_>>();
+        self.storage.retain(|haddr, _| keep.contains(haddr));
+        for (addr, mask) in masks {
+            if let Some(it) = self.storage.get_mut(&keccak_hash::keccak(addr)) {
+                it.mask(mask)?
+            }
+        }
+        Ok(())
+    }
+}

--- a/zero/src/bin/trie_diff.rs
+++ b/zero/src/bin/trie_diff.rs
@@ -147,7 +147,7 @@ async fn main() -> Result<()> {
                     &DebugOutputTries {
                         state_trie: observer.data[prover_tries.batch_index]
                             .tries
-                            .state
+                            .world
                             .as_hashed_partial_trie()
                             .clone(),
                         transaction_trie: observer.data[prover_tries.batch_index]

--- a/zero/src/bin/trie_diff.rs
+++ b/zero/src/bin/trie_diff.rs
@@ -148,7 +148,7 @@ async fn main() -> Result<()> {
                         state_trie: observer.data[prover_tries.batch_index]
                             .tries
                             .world
-                            .as_hashed_partial_trie()
+                            .state_trie()
                             .clone(),
                         transaction_trie: observer.data[prover_tries.batch_index]
                             .tries


### PR DESCRIPTION
Closes #707

Follows #693 
Obsoletes #722 

# Changes
- `Type2World` is ready for testing.
- Remove `TypedMpt`, and just fold it into `StateMpt`.
- Remove the `conv_hash` module.