### PR TITLE
Move opcode_count Under Test Configuration

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -54,8 +54,6 @@ pub(crate) struct Interpreter<F: RichField> {
     /// The interpreter will halt only if the current context matches
     /// halt_context
     pub(crate) halt_context: Option<usize>,
-    /// Counts the number of appearances of each opcode. For debugging purposes.
-    pub(crate) opcode_count: HashMap<Operation, usize>,
     jumpdest_table: HashMap<usize, BTreeSet<usize>>,
     /// `true` if the we are currently carrying out a jumpdest analysis.
     pub(crate) is_jumpdest_analysis: bool,
@@ -64,6 +62,10 @@ pub(crate) struct Interpreter<F: RichField> {
     pub(crate) clock: usize,
     /// Log of the maximal number of CPU cycles in one segment execution.
     max_cpu_len_log: Option<usize>,
+
+    #[cfg(test)]
+    // Counts the number of appearances of each opcode. For debugging purposes.
+    pub(crate) opcode_count: HashMap<Operation, usize>,
 }
 
 /// Simulates the CPU execution from `state` until the program counter reaches
@@ -178,6 +180,7 @@ impl<F: RichField> Interpreter<F> {
             // while the label `halt` is the halting label in the kernel.
             halt_offsets: vec![DEFAULT_HALT_OFFSET, KERNEL.global_labels["halt_final"]],
             halt_context: None,
+            #[cfg(test)]
             opcode_count: HashMap::new(),
             jumpdest_table: HashMap::new(),
             is_jumpdest_analysis: false,
@@ -209,6 +212,7 @@ impl<F: RichField> Interpreter<F> {
             generation_state: state.soft_clone(),
             halt_offsets: vec![halt_offset],
             halt_context: Some(halt_context),
+            #[cfg(test)]
             opcode_count: HashMap::new(),
             jumpdest_table: HashMap::new(),
             is_jumpdest_analysis: true,
@@ -428,6 +432,7 @@ impl<F: RichField> Interpreter<F> {
         self.max_cpu_len_log
     }
 
+    #[cfg(test)]
     pub(crate) fn reset_opcode_counts(&mut self) {
         self.opcode_count = HashMap::new();
     }
@@ -669,8 +674,11 @@ impl<F: RichField> State<F> for Interpreter<F> {
 
         let op = decode(registers, opcode)?;
 
-        // Increment the opcode count
-        *self.opcode_count.entry(op).or_insert(0) += 1;
+        #[cfg(test)]
+        {
+            // Increment the opcode count
+            *self.opcode_count.entry(op).or_insert(0) += 1;
+        }
 
         fill_op_flag(op, &mut row);
 

--- a/evm_arithmetization/src/generation/segments.rs
+++ b/evm_arithmetization/src/generation/segments.rs
@@ -1,6 +1,7 @@
 //! Module defining the logic around proof segmentation into chunks,
 //! which allows what is commonly known as zk-continuations.
 
+#[cfg(test)]
 use std::collections::HashMap;
 
 use anyhow::Result;
@@ -13,6 +14,7 @@ use crate::cpu::kernel::interpreter::{set_registers_and_run, ExtraSegmentData, I
 use crate::generation::state::State;
 use crate::generation::{collect_debug_tries, debug_inputs, ErrorWithTries, GenerationInputs};
 use crate::witness::memory::MemoryState;
+#[cfg(test)]
 use crate::witness::operation::Operation;
 use crate::witness::state::RegistersState;
 
@@ -32,7 +34,9 @@ pub struct GenerationSegmentData {
     pub(crate) extra_data: ExtraSegmentData,
     /// Log of the maximal cpu length.
     pub(crate) max_cpu_len_log: Option<usize>,
-    /// Counts the number of appearances of each opcode. For debugging purposes.
+
+    #[cfg(test)]
+    // Counts the number of appearances of each opcode. For debugging purposes.
     pub(crate) opcode_counts: HashMap<Operation, usize>,
 }
 
@@ -82,6 +86,7 @@ fn build_segment_data<F: RichField>(
             access_lists_ptrs: interpreter.generation_state.access_lists_ptrs.clone(),
             state_ptrs: interpreter.generation_state.state_ptrs.clone(),
         },
+        #[cfg(test)]
         opcode_counts: interpreter.opcode_count.clone(),
     }
 }
@@ -139,8 +144,11 @@ impl<F: RichField> SegmentDataIterator<F> {
 
         let segment_index = segment_data.segment_index;
 
-        // Reset opcode counts before executing the segment
-        self.interpreter.reset_opcode_counts();
+        #[cfg(test)]
+        {
+            // Reset opcode counts before executing the segment
+            self.interpreter.reset_opcode_counts();
+        }
 
         // Run the interpreter to get `registers_after` and the partial data for the
         // next segment.
@@ -156,7 +164,11 @@ impl<F: RichField> SegmentDataIterator<F> {
             ));
 
             segment_data.registers_after = updated_registers;
-            segment_data.opcode_counts = self.interpreter.opcode_count.clone();
+
+            #[cfg(test)]
+            {
+                segment_data.opcode_counts = self.interpreter.opcode_count.clone();
+            }
 
             Ok(Some(Box::new((segment_data, partial_segment_data))))
         } else {

--- a/evm_arithmetization/src/testing_utils.rs
+++ b/evm_arithmetization/src/testing_utils.rs
@@ -232,3 +232,18 @@ pub fn segment_with_empty_tables() -> Result<(
 
     Ok((trimmed_inputs, segment_data))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_segment_with_empty_tables() -> Result<()> {
+        let (_, segment_data) = segment_with_empty_tables()?;
+
+        let opcode_counts = &segment_data.opcode_counts;
+        assert!(!opcode_counts.contains_key(&Operation::KeccakGeneral));
+
+        Ok(())
+    }
+}

--- a/evm_arithmetization/src/testing_utils.rs
+++ b/evm_arithmetization/src/testing_utils.rs
@@ -16,6 +16,7 @@ pub use crate::cpu::kernel::cancun_constants::*;
 pub use crate::cpu::kernel::constants::global_exit_root::*;
 use crate::generation::{TrieInputs, TrimmedGenerationInputs};
 use crate::proof::TrieRoots;
+#[cfg(test)]
 use crate::witness::operation::Operation;
 use crate::{
     generation::mpt::AccountRlp, proof::BlockMetadata, util::h2u, GenerationInputs,
@@ -228,9 +229,6 @@ pub fn segment_with_empty_tables() -> Result<(
     let mut segment_iterator =
         SegmentDataIterator::<GoldilocksField>::new(&payload, max_cpu_len_log);
     let (trimmed_inputs, segment_data) = segment_iterator.next().unwrap()?;
-
-    let opcode_counts = &segment_data.opcode_counts;
-    assert!(!opcode_counts.contains_key(&Operation::KeccakGeneral));
 
     Ok((trimmed_inputs, segment_data))
 }

--- a/evm_arithmetization/src/testing_utils.rs
+++ b/evm_arithmetization/src/testing_utils.rs
@@ -235,8 +235,8 @@ pub fn segment_with_empty_tables() -> Result<(
 
 #[cfg(test)]
 mod tests {
-    use crate::logic;
     use super::*;
+    use crate::logic;
 
     // Ensures that there are no Keccak and Logic ops in the segment.
     #[test]

--- a/evm_arithmetization/src/testing_utils.rs
+++ b/evm_arithmetization/src/testing_utils.rs
@@ -19,7 +19,7 @@ use crate::proof::TrieRoots;
 #[cfg(test)]
 use crate::witness::operation::Operation;
 use crate::{
-    generation::mpt::AccountRlp, logic, proof::BlockMetadata, util::h2u, GenerationInputs,
+    generation::mpt::AccountRlp, proof::BlockMetadata, util::h2u, GenerationInputs,
     GenerationSegmentData, SegmentDataIterator,
 };
 
@@ -235,6 +235,7 @@ pub fn segment_with_empty_tables() -> Result<(
 
 #[cfg(test)]
 mod tests {
+    use crate::logic;
     use super::*;
 
     // Ensures that there are no Keccak and Logic ops in the segment.


### PR DESCRIPTION
Thanks to @Nashtare for highlighting this issue. This PR moves the opcode_count functionality under the #[cfg(test)] attribute to prevent unnecessary overhead during witness generation in non-test environments.