### PR TITLE
Prune child context in create and call faults

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/asm/core/call.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/call.asm
@@ -247,7 +247,9 @@ after_call_instruction_failed:
     %jump(after_call_instruction_contd)
 
 call_insufficient_balance:
-    %stack (new_ctx, kexit_info, callgas, address, value, args_offset, args_size, ret_offset, ret_size) ->
+    // stack: new_ctx, kexit_info, callgas, address, value, args_offset, args_size, ret_offset, ret_size
+    %prune_context
+    %stack (kexit_info, callgas, address, value, args_offset, args_size, ret_offset, ret_size) ->
         (callgas, kexit_info, 0)
     %shl_const(192) SWAP1 SUB
     // stack: kexit_info', 0

--- a/evm_arithmetization/src/cpu/kernel/asm/core/create.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/create.asm
@@ -222,7 +222,7 @@ create_collision:
 // stack: new_ctx, leftover_gas, success, address, kexit_info
 create_first_byte_ef:
     %revert_checkpoint
-     %stack (leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
+    %stack (leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
     EXIT_KERNEL
 
 // stack: code_size, new_ctx, leftover_gas, success, address, kexit_info

--- a/evm_arithmetization/src/cpu/kernel/asm/core/create.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/create.asm
@@ -146,6 +146,8 @@ after_constructor:
     // stack: success, leftover_gas, new_ctx, address, kexit_info
     SWAP2
     // stack: new_ctx, leftover_gas, success, address, kexit_info
+    POP
+
     // EIP-3541: Reject new contract code starting with the 0xEF byte
     PUSH @SEGMENT_RETURNDATA
     GET_CONTEXT
@@ -154,15 +156,14 @@ after_constructor:
     %eq_const(0xEF) %jumpi(create_first_byte_ef)
 
     // Charge gas for the code size.
-    // stack: new_ctx, leftover_gas, success, address, kexit_info
+    // stack: leftover_gas, success, address, kexit_info
     %returndatasize // Size of the code.
-    // stack: code_size, new_ctx, leftover_gas, success, address, kexit_info
+    // stack: code_size, leftover_gas, success, address, kexit_info
     DUP1 %gt_const(@MAX_CODE_SIZE) %jumpi(create_code_too_large)
-    // stack: code_size, new_ctx, leftover_gas, success, address, kexit_info
+    // stack: code_size, leftover_gas, success, address, kexit_info
     %mul_const(@GAS_CODEDEPOSIT)
-    // stack: code_size_cost, new_ctx, leftover_gas, success, address, kexit_info
-    DUP3 DUP2 GT %jumpi(create_oog)
-    SWAP1 POP
+    // stack: code_size_cost, leftover_gas, success, address, kexit_info
+    DUP2 DUP2 GT %jumpi(create_oog)
     SWAP1 SUB
     // stack: leftover_gas, success, address, kexit_info
     %pop_checkpoint
@@ -221,22 +222,20 @@ create_collision:
 // stack: new_ctx, leftover_gas, success, address, kexit_info
 create_first_byte_ef:
     %revert_checkpoint
-    %stack (new_ctx, leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
+     %stack (leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
     EXIT_KERNEL
 
 // stack: code_size, new_ctx, leftover_gas, success, address, kexit_info
 create_code_too_large:
     %revert_checkpoint
-    POP
-    %stack (new_ctx, leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
+    %stack (code_size, leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
     EXIT_KERNEL
 
 // stack: code_size_cost, new_ctx, leftover_gas, success, address, kexit_info
 create_oog:
     %revert_checkpoint
     %mstore_context_metadata(@CTX_METADATA_RETURNDATA_SIZE, 0)
-    POP
-    %stack (new_ctx, leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
+    %stack (code_size_cost, leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
     EXIT_KERNEL
 
 create_too_deep:

--- a/evm_arithmetization/src/cpu/kernel/asm/core/create.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/create.asm
@@ -215,6 +215,9 @@ nonce_overflow:
 create_collision:
     %revert_checkpoint
     %mstore_context_metadata(@CTX_METADATA_RETURNDATA_SIZE, 0)
+    // Collisions are checked when running the constructor and prior entering the new context
+    // (but after writing some values in the new context), contrary to the other checks here. 
+    // This is why we need to prune the new context.
     %prune_context
     %stack (address, kexit_info) -> (kexit_info, 0)
     EXIT_KERNEL

--- a/evm_arithmetization/src/cpu/kernel/asm/core/create.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/create.asm
@@ -123,8 +123,8 @@ run_constructor:
     // stack: new_ctx, address, kexit_info
 
     // All but 1/64 of the sender's remaining gas goes to the constructor.
-    SWAP2
-    // stack: kexit_info, address, new_ctx
+    %stack(new_ctx, address, kexit_info) -> (kexit_info, new_ctx, address, new_ctx)
+    // stack: kexit_info, new_ctx, address, new_ctx
     %drain_all_but_one_64th_gas
     %stack (kexit_info, drained_gas, address, new_ctx) -> (drained_gas, new_ctx, address, kexit_info)
     %set_new_ctx_gas_limit_no_check
@@ -221,16 +221,14 @@ create_collision:
 // stack: new_ctx, leftover_gas, success, address, kexit_info
 create_first_byte_ef:
     %revert_checkpoint
-    %prune_context
-    %stack (leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
+    %stack (new_ctx, leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
     EXIT_KERNEL
 
 // stack: code_size, new_ctx, leftover_gas, success, address, kexit_info
 create_code_too_large:
     %revert_checkpoint
     POP
-    %prune_context
-    %stack (leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
+    %stack (new_ctx, leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
     EXIT_KERNEL
 
 // stack: code_size_cost, new_ctx, leftover_gas, success, address, kexit_info
@@ -238,8 +236,7 @@ create_oog:
     %revert_checkpoint
     %mstore_context_metadata(@CTX_METADATA_RETURNDATA_SIZE, 0)
     POP
-    %prune_context
-    %stack (leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
+    %stack (new_ctx, leftover_gas, success, address, kexit_info) -> (kexit_info, 0)
     EXIT_KERNEL
 
 create_too_deep:

--- a/evm_arithmetization/src/cpu/kernel/asm/core/util.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/core/util.asm
@@ -122,3 +122,38 @@
     PUSH @U256_MAX
     MSTORE_GENERAL
 %endmacro
+
+// Adds stale_ctx to the list of stale contexts. You need to return to a previous, older context with
+// a SET_CONTEXT instruction. By assumption, stale_ctx is greater than the current context.
+global prune_context:
+    // stack: stale_ctx, retdest
+    GET_CONTEXT
+    // stack: curr_ctx, stale_ctx, retdest
+    // When we go to stale_ctx, we want its stack to contain curr_ctx so that we can immediately
+    // call SET_CONTEXT. For that, we need a stack length of 1, and store curr_ctx in Segment::Stack[0].
+    PUSH @SEGMENT_STACK
+    DUP3 ADD
+    // stack: stale_ctx_stack_addr, curr_ctx, stale_ctx, retdest
+    DUP2
+    // stack: curr_ctx, stale_ctx_stack_addr, curr_ctx, stale_ctx, retdest
+    MSTORE_GENERAL
+    // stack: curr_ctx, stale_ctx, retdest
+    PUSH @CTX_METADATA_STACK_SIZE
+    DUP3 ADD
+    // stack: stale_ctx_stack_size_addr, curr_ctx, stale_ctx, retdest
+    PUSH 1
+    MSTORE_GENERAL
+    // stack: curr_ctx, stale_ctx, retdest
+    POP
+    SET_CONTEXT
+    // We're now in stale_ctx, with stack: curr_ctx, retdest
+    %set_and_prune_ctx
+    // We're now in curr_ctx, with stack: retdest
+    JUMP
+
+%macro prune_context
+    // stack: stale_ctx
+    %stack (stale_ctx) -> (stale_ctx, %%after)
+    %jump(prune_context)
+%%after:
+%endmacro

--- a/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm_arithmetization/src/cpu/kernel/asm/memory/syscalls.asm
@@ -391,30 +391,3 @@ mcopy_empty:
     %jump(memcpy_bytes)
 %endmacro
 
-// Adds stale_ctx to the list of stale contexts. You need to return to a previous, older context with
-// a SET_CONTEXT instruction. By assumption, stale_ctx is greater than the current context.
-%macro prune_context
-    // stack: stale_ctx
-    GET_CONTEXT
-    // stack: curr_ctx, stale_ctx
-    // When we go to stale_ctx, we want its stack to contain curr_ctx so that we can immediately
-    // call SET_CONTEXT. For that, we need a stack length of 1, and store curr_ctx in Segment::Stack[0].
-    PUSH @SEGMENT_STACK
-    DUP3 ADD
-    // stack: stale_ctx_stack_addr, curr_ctx, stale_ctx
-    DUP2
-    // stack: curr_ctx, stale_ctx_stack_addr, curr_ctx, stale_ctx
-    MSTORE_GENERAL
-    // stack: curr_ctx, stale_ctx
-    PUSH @CTX_METADATA_STACK_SIZE
-    DUP3 ADD
-    // stack: stale_ctx_stack_size_addr, curr_ctx, stale_ctx
-    PUSH 1
-    MSTORE_GENERAL
-    // stack: curr_ctx, stale_ctx
-    POP
-    SET_CONTEXT
-    // We're now in stale_ctx, with stack: curr_ctx
-    %set_and_prune_ctx
-    // We're now in curr_ctx, with an empty stack.
-%endmacro

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -620,6 +620,11 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         )
     );
 
+    let is_last_segment =
+        segment_data.registers_after.program_counter == KERNEL.global_labels["halt"];
+    if is_last_segment && final_len != 0 {
+        log::warn!("This is the last segment, but MemoryAfter is still not empty!");
+    }
     if final_len == 0 && OPTIONAL_TABLE_INDICES.contains(&MemAfter) {
         log::debug!("MemAfter table not in use");
         table_in_use[*MemAfter] = false;

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -607,7 +607,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         table_in_use[*Table::Poseidon] = false;
     }
 
-    let (tables, final_len) = timed!(
+    let tables = timed!(
         timing,
         "convert trace data to tables",
         state.traces.into_tables(
@@ -620,7 +620,9 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         )
     );
 
-    if final_len == 0 && OPTIONAL_TABLE_INDICES.contains(&MemAfter) {
+    let is_last_segment =
+        segment_data.registers_after.program_counter == KERNEL.global_labels["halt"];
+    if is_last_segment && OPTIONAL_TABLE_INDICES.contains(&MemAfter) {
         log::debug!("MemAfter table not in use");
         table_in_use[*MemAfter] = false;
     }

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -607,7 +607,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         table_in_use[*Table::Poseidon] = false;
     }
 
-    let tables = timed!(
+    let (tables, final_len) = timed!(
         timing,
         "convert trace data to tables",
         state.traces.into_tables(
@@ -620,9 +620,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         )
     );
 
-    let is_last_segment =
-        segment_data.registers_after.program_counter == KERNEL.global_labels["halt"];
-    if is_last_segment && OPTIONAL_TABLE_INDICES.contains(&MemAfter) {
+    if final_len == 0 && OPTIONAL_TABLE_INDICES.contains(&MemAfter) {
         log::debug!("MemAfter table not in use");
         table_in_use[*MemAfter] = false;
     }

--- a/evm_arithmetization/src/witness/traces.rs
+++ b/evm_arithmetization/src/witness/traces.rs
@@ -144,7 +144,7 @@ impl<T: Copy + Field> Traces<T> {
         mut trace_lengths: TraceCheckpoint,
         config: &StarkConfig,
         timing: &mut TimingTree,
-    ) -> [Vec<PolynomialValues<T>>; NUM_TABLES]
+    ) -> ([Vec<PolynomialValues<T>>; NUM_TABLES], usize)
     where
         T: RichField + Extendable<D>,
     {
@@ -240,19 +240,22 @@ impl<T: Copy + Field> Traces<T> {
             final_values.len()
         );
 
-        [
-            arithmetic_trace,
-            byte_packing_trace,
-            cpu_trace,
-            keccak_trace,
-            keccak_sponge_trace,
-            logic_trace,
-            memory_trace,
-            mem_before_trace,
-            mem_after_trace,
-            #[cfg(feature = "cdk_erigon")]
-            poseidon_trace,
-        ]
+        (
+            [
+                arithmetic_trace,
+                byte_packing_trace,
+                cpu_trace,
+                keccak_trace,
+                keccak_sponge_trace,
+                logic_trace,
+                memory_trace,
+                mem_before_trace,
+                mem_after_trace,
+                #[cfg(feature = "cdk_erigon")]
+                poseidon_trace,
+            ],
+            final_values.len(),
+        )
     }
 }
 

--- a/evm_arithmetization/src/witness/traces.rs
+++ b/evm_arithmetization/src/witness/traces.rs
@@ -144,7 +144,7 @@ impl<T: Copy + Field> Traces<T> {
         mut trace_lengths: TraceCheckpoint,
         config: &StarkConfig,
         timing: &mut TimingTree,
-    ) -> ([Vec<PolynomialValues<T>>; NUM_TABLES], usize)
+    ) -> [Vec<PolynomialValues<T>>; NUM_TABLES]
     where
         T: RichField + Extendable<D>,
     {
@@ -240,22 +240,19 @@ impl<T: Copy + Field> Traces<T> {
             final_values.len()
         );
 
-        (
-            [
-                arithmetic_trace,
-                byte_packing_trace,
-                cpu_trace,
-                keccak_trace,
-                keccak_sponge_trace,
-                logic_trace,
-                memory_trace,
-                mem_before_trace,
-                mem_after_trace,
-                #[cfg(feature = "cdk_erigon")]
-                poseidon_trace,
-            ],
-            final_values.len(),
-        )
+        [
+            arithmetic_trace,
+            byte_packing_trace,
+            cpu_trace,
+            keccak_trace,
+            keccak_sponge_trace,
+            logic_trace,
+            memory_trace,
+            mem_before_trace,
+            mem_after_trace,
+            #[cfg(feature = "cdk_erigon")]
+            poseidon_trace,
+        ]
     }
 }
 


### PR DESCRIPTION
In `sys_call`s and `create_common`, `create_context` is called (and some values are set) before actually entering the new context. But between `create_context` and `enter_new_ctx`, some exceptions might arise, and the new context is therefore not pruned when it should. This PR aims at fixing this issue. It also reverts #738, since the changes should no longer be necessary after this fix.

Block 1033 was failing (with a wire set twice) without #738, but passes fine with this PR's changes.