### PR TITLE
feat: add ci cargo outdated check

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,12 +3,38 @@ on:
   push:
     paths: 
       - '**/Cargo.toml'
+  #TODO: REMOVE AFTER TESTING
+  pull_request:
+    branches:
+      - "**"
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
+
       - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  outdated_dependencies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Install cargo-outdated
+        run: cargo install cargo-outdated
+
+      - name: Run cargo outdated
+        run: cargo outdated --color always --format list > ./outdated_dependencies.txt
+
+      - name: Upload outdated list
+        uses: actions/upload-artifact@v3
+        with:
+          name: outdated_dependencies
+          path: ./outdated_dependencies.txt

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,10 +3,6 @@ on:
   push:
     paths: 
       - '**/Cargo.toml'
-  #TODO: REMOVE AFTER TESTING
-  pull_request:
-    branches:
-      - "**"
 
 jobs:
   security_audit:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: rustsec/audit-check@v1.4.1
         with:
@@ -23,18 +23,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Install cargo-outdated
-        run: cargo install cargo-outdated
 
       - name: Run cargo outdated
         run: cargo outdated --color always --format list > ./outdated_dependencies.txt
 
       - name: Upload outdated list
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: outdated_dependencies
           path: ./outdated_dependencies.txt


### PR DESCRIPTION
Resolves https://github.com/0xPolygonZero/zk_evm/issues/746

Note: `cargo-outdated` does not error. It produces list of current, compatible and latest versions of the dependencies currently used. This CI job saves the dependency list table as an artifact.