### PR TITLE
chore: remove conditional ci execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,6 @@ jobs:
       - name: Test in zero_bin subdirectory
         run: |
           cargo test --manifest-path zero/Cargo.toml
-
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
     name: Test mpt_trie
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ ! contains(toJSON(github.event.commits.*.message), '[skip-ci]') }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -50,8 +49,6 @@ jobs:
       RUST_LOG: info
       CARGO_INCREMENTAL: 1
       RUST_BACKTRACE: 1
-
-    if: ${{ ! contains(toJSON(github.event.commits.*.message), '[skip-ci]') }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -73,7 +70,6 @@ jobs:
     name: Test evm_arithmetization
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ ! contains(toJSON(github.event.commits.*.message), '[skip-ci]') }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -97,7 +93,6 @@ jobs:
     name: Test zero_bin
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ ! contains(toJSON(github.event.commits.*.message), '[skip-ci]') }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -123,7 +118,6 @@ jobs:
     name: Test zk_evm_proc_macro
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ ! contains(toJSON(github.event.commits.*.message), '[skip-ci]') }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/jerigon-native.yml
+++ b/.github/workflows/jerigon-native.yml
@@ -19,7 +19,6 @@ jobs:
     name: Native tracer proof generation
     runs-on: zero-ci
     timeout-minutes: 30
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/jerigon-zero.yml
+++ b/.github/workflows/jerigon-zero.yml
@@ -19,7 +19,6 @@ jobs:
     name: Zero tracer proof generation
     runs-on: zero-ci
     timeout-minutes: 30
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/pr_checking.yml
+++ b/.github/workflows/pr_checking.yml
@@ -54,4 +54,3 @@ jobs:
         run: gh pr close ${{ github.event.pull_request.number }} --comment "Spam detected"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/pr_checking.yml
+++ b/.github/workflows/pr_checking.yml
@@ -54,3 +54,4 @@ jobs:
         run: gh pr close ${{ github.event.pull_request.number }} --comment "Spam detected"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Resolves https://github.com/0xPolygonZero/zk_evm/issues/663

Removed workflows manual check for conditional execution of tasks.

Github has already included mechanisms to disable to Ci run. To skip it, it is enough to include skip ci in the commit message (more details [here](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs)). 

