### PR TITLE
Replace regex in trie diff main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,6 +2848,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8e41c97e6bc7ecb552016274b99fbb5d035e8de288c582d9b933af6677bfda"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e1d8b05d672c53cb9c7b920bbba8783845ae4f0b076e02a3db1d02c81b4163"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5820,6 +5843,7 @@ dependencies = [
  "itertools 0.13.0",
  "jemallocator",
  "keccak-hash 0.10.0",
+ "lazy-regex",
  "lru",
  "mpt_trie",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5852,7 +5852,6 @@ dependencies = [
  "plonky2",
  "plonky2_maybe_rayon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.12.2",
- "regex",
  "rlp",
  "ruint",
  "serde",

--- a/zero/Cargo.toml
+++ b/zero/Cargo.toml
@@ -46,6 +46,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
 zk_evm_common.workspace = true
+lazy-regex = "3.3.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.5.4"

--- a/zero/Cargo.toml
+++ b/zero/Cargo.toml
@@ -25,6 +25,7 @@ hashbrown.workspace = true
 hex.workspace = true
 itertools.workspace = true
 keccak-hash.workspace = true
+lazy-regex = "3.3.0"
 lru.workspace = true
 mpt_trie.workspace = true
 num-traits.workspace = true
@@ -32,7 +33,6 @@ once_cell.workspace = true
 paladin-core.workspace = true
 plonky2.workspace = true
 plonky2_maybe_rayon.workspace = true
-regex = "1.5.4"
 rlp.workspace = true
 ruint = { workspace = true, features = ["num-traits", "primitive-types"] }
 serde.workspace = true
@@ -46,7 +46,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
 zk_evm_common.workspace = true
-lazy-regex = "3.3.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.5.4"

--- a/zero/src/bin/trie_diff.rs
+++ b/zero/src/bin/trie_diff.rs
@@ -20,9 +20,9 @@ use anyhow::Result;
 use clap::{Parser, ValueHint};
 use evm_arithmetization::generation::DebugOutputTries;
 use futures::{future, TryStreamExt};
+use lazy_regex::regex_captures;
 use paladin::directive::{Directive, IndexedStream};
 use paladin::runtime::Runtime;
-use regex::Regex;
 use trace_decoder::observer::TriesObserver;
 use tracing::{error, info};
 use zero::ops::register;
@@ -130,10 +130,11 @@ async fn main() -> Result<()> {
         {
             // Try to parse block and batch index from error message.
             let error_message = e2.to_string();
-            let re = Regex::new(r"block:(\d+) batch:(\d+)")?;
-            if let Some(cap) = re.captures(&error_message) {
-                let block_number: u64 = cap[1].parse()?;
-                let batch_index: usize = cap[2].parse()?;
+            if let Some((_, block_number, block_index)) =
+                regex_captures!(r"block:(\d+) batch:(\d+)", error_message.as_str())
+            {
+                let block_number: u64 = block_number.parse()?;
+                let batch_index: usize = block_index.parse()?;
 
                 let prover_tries =
                     zero::debug_utils::load_tries_from_disk(block_number, batch_index)?;


### PR DESCRIPTION
Closes #721

Replaces existing regex usage with macro from [lazy_regex](https://docs.rs/lazy-regex/latest/lazy_regex/macro.regex_captures.html) crate.

Improves the code by replacing slice indexing with `&str` tuple of the captured values.

Also avoids the regex being compiled in every iteration of the relevant `for` loop.