### PR TITLE
Fix bytecode hashing for Type2 SMT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,9 +2030,14 @@ dependencies = [
 name = "evm_arithmetization"
 version = "0.4.0"
 dependencies = [
+ "alloy",
+ "alloy-compat",
  "anyhow",
+ "bitvec",
  "bytes",
+ "copyvec",
  "criterion",
+ "either",
  "env_logger 0.11.5",
  "ethereum-types",
  "hashbrown",
@@ -2068,6 +2073,7 @@ dependencies = [
  "tokio",
  "tower-lsp",
  "tracing",
+ "u4",
  "url",
  "zk_evm_common",
  "zk_evm_proc_macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,8 @@ bytes = "1.6.0"
 ciborium = "0.2.2"
 ciborium-io = "0.2.2"
 clap = { version = "4.5.7", features = ["derive", "env"] }
-compat = { path = "compat" }
+alloy-compat = "0.1.0"
+copyvec = "0.2.0"
 criterion = "0.5.1"
 dotenvy = "0.15.7"
 either = "1.12.0"
@@ -104,6 +105,7 @@ url = "2.5.2"
 winnow = "0.6.13"
 
 # local dependencies
+compat = { path = "compat" }
 evm_arithmetization = { path = "evm_arithmetization", version = "0.4.0", default-features = false }
 mpt_trie = { path = "mpt_trie", version = "0.4.1" }
 smt_trie = { path = "smt_trie", version = "0.1.1" }

--- a/evm_arithmetization/Cargo.toml
+++ b/evm_arithmetization/Cargo.toml
@@ -15,8 +15,13 @@ homepage.workspace = true
 keywords.workspace = true
 
 [dependencies]
+alloy.workspace = true
+alloy-compat.workspace = true
 anyhow.workspace = true
+bitvec.workspace = true
 bytes.workspace = true
+copyvec.workspace = true
+either.workspace = true
 env_logger.workspace = true
 ethereum-types.workspace = true
 hashbrown.workspace = true
@@ -43,7 +48,7 @@ serde = { workspace = true, features = ["derive"] }
 serde-big-array.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-smt_trie = { workspace = true, optional = true }
+smt_trie = { workspace = true }
 starky = { workspace = true, features = ["parallel"] }
 static_assertions.workspace = true
 thiserror.workspace = true
@@ -51,6 +56,7 @@ tiny-keccak.workspace = true
 tokio.workspace = true
 tower-lsp = "0.20.0"
 tracing.workspace = true
+u4.workspace = true
 url.workspace = true
 zk_evm_common.workspace = true
 zk_evm_proc_macro.workspace = true
@@ -64,7 +70,7 @@ ripemd.workspace = true
 default = ["eth_mainnet"]
 asmtools = ["hex"]
 polygon_pos = []
-cdk_erigon = ["smt_trie"]
+cdk_erigon = []
 eth_mainnet = []
 
 [[bin]]

--- a/evm_arithmetization/src/lib.rs
+++ b/evm_arithmetization/src/lib.rs
@@ -284,7 +284,9 @@ pub mod witness;
 pub mod curve_pairings;
 pub mod extension_tower;
 pub mod testing_utils;
+pub mod tries;
 pub mod util;
+pub mod world;
 
 // Public definitions and re-exports
 mod public_types;

--- a/evm_arithmetization/src/tries.rs
+++ b/evm_arithmetization/src/tries.rs
@@ -7,9 +7,10 @@ use anyhow::ensure;
 use bitvec::{array::BitArray, slice::BitSlice};
 use copyvec::CopyVec;
 use ethereum_types::{Address, H256, U256};
-use evm_arithmetization::generation::mpt::AccountRlp;
 use mpt_trie::partial_trie::{HashedPartialTrie, Node, OnOrphanedHashNode, PartialTrie as _};
 use u4::{AsNibbles, U4};
+
+use crate::generation::mpt::AccountRlp;
 
 /// Bounded sequence of [`U4`],
 /// used as a key for [MPT](HashedPartialTrie) types in this module.

--- a/smt_trie/src/code.rs
+++ b/smt_trie/src/code.rs
@@ -1,11 +1,11 @@
 /// Functions to hash contract bytecode using Poseidon.
 /// See `hashContractBytecode()` in https://github.com/0xPolygonHermez/zkevm-commonjs/blob/main/src/smt-utils.js for reference implementation.
-use ethereum_types::U256;
+use ethereum_types::H256;
 use plonky2::field::types::Field;
 use plonky2::hash::poseidon::{self, Poseidon};
 
 use crate::smt::{HashOut, F};
-use crate::utils::hashout2u;
+use crate::utils::hashout2h;
 
 pub fn hash_contract_bytecode(mut code: Vec<u8>) -> HashOut {
     poseidon_pad_byte_vec(&mut code);
@@ -43,8 +43,8 @@ pub fn poseidon_pad_byte_vec(bytes: &mut Vec<u8>) {
     *bytes.last_mut().unwrap() |= 0x80;
 }
 
-pub fn hash_bytecode_u256(code: Vec<u8>) -> U256 {
-    hashout2u(hash_contract_bytecode(code))
+pub fn hash_bytecode_h256(code: &[u8]) -> H256 {
+    hashout2h(hash_contract_bytecode(code.to_vec()))
 }
 
 #[cfg(test)]

--- a/smt_trie/src/utils.rs
+++ b/smt_trie/src/utils.rs
@@ -1,4 +1,4 @@
-use ethereum_types::U256;
+use ethereum_types::{H256, U256};
 use plonky2::field::types::{Field, PrimeField64};
 use plonky2::hash::poseidon::Poseidon;
 
@@ -47,6 +47,13 @@ pub(crate) fn limbs2f(limbs: [F; 8]) -> U256 {
 /// Convert a `HashOut` to a `U256`.
 pub fn hashout2u(h: HashOut) -> U256 {
     key2u(Key(h.elements))
+}
+
+/// Convert a `HashOut` to a `H256`.
+pub fn hashout2h(h: HashOut) -> H256 {
+    let mut it = [0; 32];
+    hashout2u(h).to_big_endian(&mut it);
+    H256(it)
 }
 
 /// Convert a `Key` to a `U256`.

--- a/trace_decoder/Cargo.toml
+++ b/trace_decoder/Cargo.toml
@@ -11,14 +11,14 @@ keywords.workspace = true
 
 [dependencies]
 alloy.workspace = true
-alloy-compat = "0.1.0"
+alloy-compat.workspace = true
 anyhow.workspace = true
 bitflags.workspace = true
 bitvec.workspace = true
 bytes.workspace = true
 ciborium.workspace = true
 ciborium-io.workspace = true
-copyvec = "0.2.0"
+copyvec.workspace = true
 either.workspace = true
 enum-as-inner.workspace = true
 ethereum-types.workspace = true
@@ -43,7 +43,7 @@ zk_evm_common.workspace = true
 
 [dev-dependencies]
 alloy.workspace = true
-alloy-compat = "0.1.0"
+alloy-compat.workspace = true
 assert2 = "0.3.15"
 camino = "1.1.9"
 clap.workspace = true

--- a/trace_decoder/src/core.rs
+++ b/trace_decoder/src/core.rs
@@ -159,8 +159,12 @@ pub fn entrypoint(
                     contract_code: contract_code
                         .into_iter()
                         .map(|it| match &world {
-                            Either::Left(_type1) => (KeccakHash::hash(&it), it),
-                            Either::Right(_type2) => (PoseidonHash::hash(&it), it),
+                            Either::Left(_type1) => {
+                                (<Type1World as World>::CodeHasher::hash(&it), it)
+                            }
+                            Either::Right(_type2) => {
+                                (<Type2World as World>::CodeHasher::hash(&it), it)
+                            }
                         })
                         .collect(),
                     block_metadata: b_meta.clone(),

--- a/trace_decoder/src/core.rs
+++ b/trace_decoder/src/core.rs
@@ -11,6 +11,8 @@ use ethereum_types::{Address, BigEndianHash as _, U256};
 use evm_arithmetization::{
     generation::TrieInputs,
     proof::{BlockMetadata, TrieRoots},
+    tries::{MptKey, ReceiptTrie, StateMpt, StorageTrie, TransactionTrie},
+    world::{Hasher, KeccakHash, PoseidonHash, Type1World, Type2World, World},
     GenerationInputs,
 };
 use itertools::Itertools as _;
@@ -19,14 +21,8 @@ use mpt_trie::partial_trie::PartialTrie as _;
 use nunny::NonEmpty;
 use zk_evm_common::gwei_to_wei;
 
+use crate::observer::{DummyObserver, Observer};
 use crate::{
-    observer::{DummyObserver, Observer},
-    world::Type2World,
-    Hasher, KeccakHash, PoseidonHash,
-};
-use crate::{
-    tries::{MptKey, ReceiptTrie, StateMpt, StorageTrie, TransactionTrie},
-    world::{Type1World, World},
     BlockLevelData, BlockTrace, BlockTraceTriePreImages, CombinedPreImages, ContractCodeUsage,
     OtherBlockData, SeparateStorageTriesPreImage, SeparateTriePreImage, SeparateTriePreImages,
     TxnInfo, TxnMeta, TxnTrace,
@@ -180,7 +176,8 @@ pub fn entrypoint(
 /// [`HashedPartialTrie`](mpt_trie::partial_trie::HashedPartialTrie),
 /// or a [`wire`](crate::wire)-encoded representation of one.
 ///
-/// Turn either of those into our [internal representations](crate::tries).
+/// Turn either of those into our [internal
+/// representations](evm_arithmetization::tries).
 #[allow(clippy::type_complexity)]
 fn start(
     pre_images: BlockTraceTriePreImages,

--- a/trace_decoder/src/lib.rs
+++ b/trace_decoder/src/lib.rs
@@ -56,20 +56,17 @@
 /// we can continue to do the main work of "executing" the transactions.
 ///
 /// The core of this library is agnostic over the (combined)
-/// state and storage representation - see [`world::World`] for more.
+/// state and storage representation - see [`evm_arithmetization::world::World`]
+/// for more.
 const _DEVELOPER_DOCS: () = ();
 
 mod interface;
 
 pub use interface::*;
-use keccak_hash::H256;
-use smt_trie::code::hash_bytecode_h256;
 
-mod tries;
 mod type1;
 mod type2;
 mod wire;
-mod world;
 
 pub use core::{entrypoint, WireDisposition};
 
@@ -100,27 +97,6 @@ mod hex {
             None => T::from_hex(&*s),
         }
         .map_err(D::Error::custom)
-    }
-}
-
-/// Utility trait to leverage a specific hash function across Type1 and Type2
-/// zkEVM variants.
-pub(crate) trait Hasher {
-    fn hash(bytes: &[u8]) -> H256;
-}
-
-pub(crate) struct PoseidonHash;
-pub(crate) struct KeccakHash;
-
-impl Hasher for PoseidonHash {
-    fn hash(bytes: &[u8]) -> H256 {
-        hash_bytecode_h256(bytes)
-    }
-}
-
-impl Hasher for KeccakHash {
-    fn hash(bytes: &[u8]) -> H256 {
-        keccak_hash::keccak(bytes)
     }
 }
 

--- a/trace_decoder/src/lib.rs
+++ b/trace_decoder/src/lib.rs
@@ -62,6 +62,8 @@ const _DEVELOPER_DOCS: () = ();
 mod interface;
 
 pub use interface::*;
+use keccak_hash::H256;
+use smt_trie::code::hash_bytecode_h256;
 
 mod tries;
 mod type1;
@@ -98,6 +100,27 @@ mod hex {
             None => T::from_hex(&*s),
         }
         .map_err(D::Error::custom)
+    }
+}
+
+/// Utility trait to leverage a specific hash function across Type1 and Type2
+/// zkEVM variants.
+pub(crate) trait Hasher {
+    fn hash(bytes: &[u8]) -> H256;
+}
+
+pub(crate) struct PoseidonHash;
+pub(crate) struct KeccakHash;
+
+impl Hasher for PoseidonHash {
+    fn hash(bytes: &[u8]) -> H256 {
+        hash_bytecode_h256(bytes)
+    }
+}
+
+impl Hasher for KeccakHash {
+    fn hash(bytes: &[u8]) -> H256 {
+        keccak_hash::keccak(bytes)
     }
 }
 

--- a/trace_decoder/src/observer.rs
+++ b/trace_decoder/src/observer.rs
@@ -1,9 +1,9 @@
 use std::marker::PhantomData;
 
 use ethereum_types::U256;
+use evm_arithmetization::tries::{ReceiptTrie, TransactionTrie};
 
 use crate::core::IntraBlockTries;
-use crate::tries::{ReceiptTrie, TransactionTrie};
 
 /// Observer API for the trace decoder.
 /// Observer is used to collect various debugging and metadata info

--- a/trace_decoder/src/type1.rs
+++ b/trace_decoder/src/type1.rs
@@ -14,6 +14,8 @@ use u4::U4;
 
 use crate::tries::{MptKey, StateMpt, StorageTrie};
 use crate::wire::{Instruction, SmtLeaf};
+use crate::world::{Type1World, World};
+use crate::Hasher as _;
 
 #[derive(Debug, Clone, Default)]
 pub struct Frontend {
@@ -85,11 +87,11 @@ fn visit(
                             match code {
                                 Some(Either::Left(Hash { raw_hash })) => raw_hash.into(),
                                 Some(Either::Right(Code { code })) => {
-                                    let hash = keccak_hash::keccak(&code);
+                                    let hash = <Type1World as World>::CodeHasher::hash(&code);
                                     frontend.code.insert(code);
                                     hash
                                 }
-                                None => keccak_hash::keccak([]),
+                                None => <Type1World as World>::CodeHasher::hash(&[]),
                             }
                         },
                     };

--- a/trace_decoder/src/type1.rs
+++ b/trace_decoder/src/type1.rs
@@ -7,15 +7,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::{bail, ensure, Context as _};
 use either::Either;
 use evm_arithmetization::generation::mpt::AccountRlp;
+use evm_arithmetization::tries::{MptKey, StateMpt, StorageTrie};
+use evm_arithmetization::world::{Hasher as _, Type1World, World};
 use keccak_hash::H256;
 use mpt_trie::partial_trie::OnOrphanedHashNode;
 use nunny::NonEmpty;
 use u4::U4;
 
-use crate::tries::{MptKey, StateMpt, StorageTrie};
 use crate::wire::{Instruction, SmtLeaf};
-use crate::world::{Type1World, World};
-use crate::Hasher as _;
 
 #[derive(Debug, Clone, Default)]
 pub struct Frontend {

--- a/trace_decoder/src/type2.rs
+++ b/trace_decoder/src/type2.rs
@@ -155,8 +155,8 @@ fn visit(
                     collated.nonce = Some(value)
                 }
                 SmtLeafType::Code => {
-                    ensure!(collated.code.is_none());
-                    collated.code = Some(value)
+                    ensure!(collated.code_hash.is_none());
+                    collated.code_hash = Some(value)
                 }
                 SmtLeafType::Storage(slot) => {
                     ensure!(slot.len() <= 32);

--- a/trace_decoder/src/type2.rs
+++ b/trace_decoder/src/type2.rs
@@ -5,16 +5,16 @@ use std::collections::{BTreeMap, HashSet};
 
 use anyhow::{bail, ensure, Context as _};
 use ethereum_types::{Address, U256};
+use evm_arithmetization::{
+    tries::SmtKey,
+    world::{Type2Entry, Type2World},
+};
 use itertools::EitherOrBoth;
 use keccak_hash::H256;
 use nunny::NonEmpty;
 use stackstack::Stack;
 
-use crate::{
-    tries::SmtKey,
-    wire::{Instruction, SmtLeaf, SmtLeafType},
-    world::{Type2Entry, Type2World},
-};
+use crate::wire::{Instruction, SmtLeaf, SmtLeafType};
 
 pub struct Frontend {
     pub world: Type2World,
@@ -175,7 +175,7 @@ fn visit(
 
 #[test]
 fn test_tries() {
-    use crate::world::World as _;
+    use evm_arithmetization::world::World as _;
     for (ix, case) in
         serde_json::from_str::<Vec<super::Case>>(include_str!("cases/hermez_cdk_erigon.json"))
             .unwrap()

--- a/trace_decoder/src/world.rs
+++ b/trace_decoder/src/world.rs
@@ -5,29 +5,11 @@ use anyhow::{ensure, Context as _};
 use either::Either;
 use ethereum_types::{Address, BigEndianHash as _, U256};
 use keccak_hash::H256;
-use smt_trie::code::hash_bytecode_h256;
 
-use crate::tries::{MptKey, SmtKey, StateMpt, StorageTrie};
-
-/// Utility trait to leverage a specific hash function.
-pub(crate) trait Hasher {
-    fn hash(bytes: &[u8]) -> H256;
-}
-
-pub(crate) struct PoseidonHash;
-pub(crate) struct KeccakHash;
-
-impl Hasher for PoseidonHash {
-    fn hash(bytes: &[u8]) -> H256 {
-        hash_bytecode_h256(&bytes)
-    }
-}
-
-impl Hasher for KeccakHash {
-    fn hash(bytes: &[u8]) -> H256 {
-        keccak_hash::keccak(bytes)
-    }
-}
+use crate::{
+    tries::{MptKey, SmtKey, StateMpt, StorageTrie},
+    Hasher, KeccakHash, PoseidonHash,
+};
 
 /// The [core](crate::core) of this crate is agnostic over state and storage
 /// representations.

--- a/trace_decoder/src/world.rs
+++ b/trace_decoder/src/world.rs
@@ -5,8 +5,29 @@ use anyhow::{ensure, Context as _};
 use either::Either;
 use ethereum_types::{Address, BigEndianHash as _, U256};
 use keccak_hash::H256;
+use smt_trie::code::hash_bytecode_h256;
 
 use crate::tries::{MptKey, SmtKey, StateMpt, StorageTrie};
+
+/// Utility trait to leverage a specific hash function.
+pub(crate) trait Hasher {
+    fn hash(bytes: &[u8]) -> H256;
+}
+
+pub(crate) struct PoseidonHash;
+pub(crate) struct KeccakHash;
+
+impl Hasher for PoseidonHash {
+    fn hash(bytes: &[u8]) -> H256 {
+        hash_bytecode_h256(&bytes)
+    }
+}
+
+impl Hasher for KeccakHash {
+    fn hash(bytes: &[u8]) -> H256 {
+        keccak_hash::keccak(bytes)
+    }
+}
 
 /// The [core](crate::core) of this crate is agnostic over state and storage
 /// representations.
@@ -17,6 +38,9 @@ pub(crate) trait World {
     /// (State) subtries may be _hashed out.
     /// This type is a key which may identify a subtrie.
     type SubtriePath;
+
+    /// Hasher to use for contract bytecode.
+    type CodeHasher: Hasher;
 
     //////////////////////
     /// Account operations
@@ -148,6 +172,8 @@ impl Type1World {
 
 impl World for Type1World {
     type SubtriePath = MptKey;
+    type CodeHasher = KeccakHash;
+
     fn contains(&mut self, address: Address) -> anyhow::Result<bool> {
         Ok(self.state.get(keccak_hash::keccak(address)).is_some())
     }
@@ -170,7 +196,7 @@ impl World for Type1World {
     fn set_code(&mut self, address: Address, code: Either<&[u8], H256>) -> anyhow::Result<()> {
         let key = keccak_hash::keccak(address);
         let mut acct = self.state.get(key).unwrap_or_default();
-        acct.code_hash = code.right_or_else(keccak_hash::keccak);
+        acct.code_hash = code.right_or_else(Self::CodeHasher::hash);
         self.state.insert(key, acct)
     }
     fn reporting_destroy(&mut self, address: Address) -> anyhow::Result<Option<Self::SubtriePath>> {
@@ -248,6 +274,8 @@ impl World for Type1World {
 
 impl World for Type2World {
     type SubtriePath = SmtKey;
+    type CodeHasher = PoseidonHash;
+
     fn contains(&mut self, address: Address) -> anyhow::Result<bool> {
         Ok(self.accounts.contains_key(&address))
     }
@@ -269,10 +297,14 @@ impl World for Type2World {
         let acct = self.accounts.entry(address).or_default();
         match code {
             Either::Left(bytes) => {
-                acct.code = Some(keccak_hash::keccak(bytes).into_uint());
-                acct.code_length = Some(U256::from(bytes.len()))
+                acct.code_length = Some(U256::from(bytes.len()));
+                if bytes.is_empty() {
+                    acct.code_hash = None;
+                } else {
+                    acct.code_hash = Some(Self::CodeHasher::hash(bytes).into_uint());
+                }
             }
-            Either::Right(hash) => acct.code = Some(hash.into_uint()),
+            Either::Right(hash) => acct.code_hash = Some(hash.into_uint()),
         };
         Ok(())
     }
@@ -349,7 +381,7 @@ impl World for Type2World {
 pub struct Type2Entry {
     pub balance: Option<U256>,
     pub nonce: Option<U256>,
-    pub code: Option<U256>,
+    pub code_hash: Option<U256>,
     pub code_length: Option<U256>,
     pub storage: BTreeMap<U256, U256>,
 }
@@ -383,7 +415,7 @@ impl Type2World {
             Type2Entry {
                 balance,
                 nonce,
-                code,
+                code_hash,
                 code_length,
                 storage,
             },
@@ -394,7 +426,7 @@ impl Type2World {
             for (value, key_fn) in [
                 (balance, key_balance as fn(_) -> _),
                 (nonce, key_nonce),
-                (code, key_code),
+                (code_hash, key_code),
                 (code_length, key_code_length),
             ] {
                 if let Some(value) = value {


### PR DESCRIPTION
@0xaatif I took a shot at #779 because it was starting to collide with what I was doing on the type2 branch, please let me know what you think.

Also we'd like to move `World` trait and related structs to `evm_arithmetization` instead of the `trace_decoder` for easy reuse across case disjunction on the prover side. Do you have any objection? If not I could even add it to this PR.