### PR TITLE
feat: Add env support to all leader prog args

### DIFF
--- a/zero/src/bin/leader/cli.rs
+++ b/zero/src/bin/leader/cli.rs
@@ -67,7 +67,7 @@ pub(crate) enum Command {
             short = 'T',
             long,
             env = "ZERO_BIN_RPC_TYPE",
-            default_value = "JERIGON"
+            default_value = "jerigon"
         )]
         rpc_type: RpcType,
         /// The start of the block range to prove (inclusive).

--- a/zero/src/bin/leader/cli.rs
+++ b/zero/src/bin/leader/cli.rs
@@ -63,37 +63,42 @@ pub(crate) enum Command {
         #[arg(short = 'u', long, env="ZERO_BIN_RPC_URL", value_hint = ValueHint::Url)]
         rpc_url: Url,
         // The node RPC type (jerigon / native).
-        #[arg(short = 'T', long, env="ZERO_BIN_RPC_TYPE", default_value = "JERIGON")]
+        #[arg(
+            short = 'T',
+            long,
+            env = "ZERO_BIN_RPC_TYPE",
+            default_value = "JERIGON"
+        )]
         rpc_type: RpcType,
         /// The start of the block range to prove (inclusive).
-        #[arg(short = 's', long, env="ZERO_BIN_START_BLOCK")]
+        #[arg(short = 's', long, env = "ZERO_BIN_START_BLOCK")]
         start_block: BlockId,
         /// The end of the block range to prove (inclusive).
         /// If not provided, leader will work in dynamic mode from `start_block`
         /// following head of the blockchain.
-        #[arg(short = 'e', long, env="ZERO_BIN_END_BLOCK")]
+        #[arg(short = 'e', long, env = "ZERO_BIN_END_BLOCK")]
         end_block: Option<BlockId>,
         /// The checkpoint block.
-        #[arg(short, long, env="ZERO_BIN_CHECKPOINT_BLOCK", default_value = "0")]
+        #[arg(short, long, env = "ZERO_BIN_CHECKPOINT_BLOCK", default_value = "0")]
         checkpoint_block: BlockId,
         /// The previous proof output.
         #[arg(short = 'f', long, env="ZERO_BIN_PREVIOUS_PROOF", value_hint = ValueHint::FilePath)]
         previous_proof: Option<PathBuf>,
         /// Blockchain network block time in milliseconds. This value is used
         /// to determine the blockchain node polling interval.
-        #[arg(short, long, env="ZERO_BIN_BLOCK_TIME", env = "ZERO_BIN_BLOCK_TIME", default_value_t = 2000)]
+        #[arg(short, long, env = "ZERO_BIN_BLOCK_TIME", default_value_t = 2000)]
         block_time: u64,
         /// Backoff in milliseconds for retry requests
-        #[arg(long, env="ZERO_BIN_BACKOFF", default_value_t = 0)]
+        #[arg(long, env = "ZERO_BIN_BACKOFF", default_value_t = 0)]
         backoff: u64,
         /// The maximum number of retries
-        #[arg(long, env="ZERO_BIN_MAX_RETRIES", default_value_t = 0)]
+        #[arg(long, env = "ZERO_BIN_MAX_RETRIES", default_value_t = 0)]
         max_retries: u32,
     },
     /// Reads input from HTTP and writes output to a directory.
     Http {
         /// The port on which to listen.
-        #[arg(short, long, env="ZERO_BIN_PORT", default_value_t = 8080)]
+        #[arg(short, long, env = "ZERO_BIN_PORT", default_value_t = 8080)]
         port: u16,
         /// The directory to which output should be written.
         #[arg(short, long, env="ZERO_BIN_OUTPUT_DIR", value_hint = ValueHint::DirPath)]

--- a/zero/src/bin/leader/cli.rs
+++ b/zero/src/bin/leader/cli.rs
@@ -54,49 +54,49 @@ pub(crate) enum Command {
     /// Reads input from stdin and writes output to stdout.
     Stdio {
         /// The previous proof output.
-        #[arg(long, short = 'f', value_hint = ValueHint::FilePath)]
+        #[arg(short = 'f', long, env="ZERO_BIN_PREVIOUS_PROOF", value_hint = ValueHint::FilePath)]
         previous_proof: Option<PathBuf>,
     },
     /// Reads input from a node rpc and writes output to stdout.
     Rpc {
         // The node RPC URL.
-        #[arg(long, short = 'u', value_hint = ValueHint::Url)]
+        #[arg(short = 'u', long, env="ZERO_BIN_RPC_URL", value_hint = ValueHint::Url)]
         rpc_url: Url,
         // The node RPC type (jerigon / native).
-        #[arg(long, short = 't', default_value = "jerigon")]
+        #[arg(short = 'T', long, env="ZERO_BIN_RPC_TYPE", default_value = "JERIGON")]
         rpc_type: RpcType,
         /// The start of the block range to prove (inclusive).
-        #[arg(long, short = 's')]
+        #[arg(short = 's', long, env="ZERO_BIN_START_BLOCK")]
         start_block: BlockId,
         /// The end of the block range to prove (inclusive).
         /// If not provided, leader will work in dynamic mode from `start_block`
         /// following head of the blockchain.
-        #[arg(long, short = 'e')]
+        #[arg(short = 'e', long, env="ZERO_BIN_END_BLOCK")]
         end_block: Option<BlockId>,
         /// The checkpoint block.
-        #[arg(short, long, default_value = "0")]
+        #[arg(short, long, env="ZERO_BIN_CHECKPOINT_BLOCK", default_value = "0")]
         checkpoint_block: BlockId,
         /// The previous proof output.
-        #[arg(long, short = 'f', value_hint = ValueHint::FilePath)]
+        #[arg(short = 'f', long, env="ZERO_BIN_PREVIOUS_PROOF", value_hint = ValueHint::FilePath)]
         previous_proof: Option<PathBuf>,
         /// Blockchain network block time in milliseconds. This value is used
         /// to determine the blockchain node polling interval.
-        #[arg(short, long, env = "ZERO_BIN_BLOCK_TIME", default_value_t = 2000)]
+        #[arg(short, long, env="ZERO_BIN_BLOCK_TIME", env = "ZERO_BIN_BLOCK_TIME", default_value_t = 2000)]
         block_time: u64,
         /// Backoff in milliseconds for retry requests
-        #[arg(long, default_value_t = 0)]
+        #[arg(long, env="ZERO_BIN_BACKOFF", default_value_t = 0)]
         backoff: u64,
         /// The maximum number of retries
-        #[arg(long, default_value_t = 0)]
+        #[arg(long, env="ZERO_BIN_MAX_RETRIES", default_value_t = 0)]
         max_retries: u32,
     },
     /// Reads input from HTTP and writes output to a directory.
     Http {
         /// The port on which to listen.
-        #[arg(short, long, default_value_t = 8080)]
+        #[arg(short, long, env="ZERO_BIN_PORT", default_value_t = 8080)]
         port: u16,
         /// The directory to which output should be written.
-        #[arg(short, long, value_hint = ValueHint::DirPath)]
+        #[arg(short, long, env="ZERO_BIN_OUTPUT_DIR", value_hint = ValueHint::DirPath)]
         output_dir: PathBuf,
     },
 }

--- a/zero/src/bin/rpc.rs
+++ b/zero/src/bin/rpc.rs
@@ -30,16 +30,16 @@ struct FetchParams {
 #[derive(Args, Clone, Debug)]
 struct RpcToolConfig {
     /// The RPC URL.
-    #[arg(short = 'u', long, value_hint = ValueHint::Url)]
+    #[arg(short = 'u', long, env="ZERO_BIN_RPC_URL", value_hint = ValueHint::Url)]
     rpc_url: Url,
     /// The RPC Tracer Type.
-    #[arg(short = 't', long, default_value = "jerigon")]
+    #[arg(short = 't', long, env="ZERO_BIN_RPC_TYPE", default_value = "jerigon")]
     rpc_type: RpcType,
     /// Backoff in milliseconds for retry requests.
-    #[arg(long, default_value_t = 0)]
+    #[arg(long, env="ZERO_BIN_BACKOFF", default_value_t = 0)]
     backoff: u64,
     /// The maximum number of retries.
-    #[arg(long, default_value_t = 0)]
+    #[arg(long, env="ZERO_BIN_MAX_RETRIES", default_value_t = 0)]
     max_retries: u32,
 }
 
@@ -59,10 +59,10 @@ enum Command {
     },
     Extract {
         /// Transaction hash.
-        #[arg(long, short)]
+        #[arg(short, long, env="ZERO_BIN_TX")]
         tx: String,
         /// Number of transactions in a batch to process at once.
-        #[arg(short, long, default_value_t = 1)]
+        #[arg(short, long, env="ZERO_BIN_BATCH_SIZE", default_value_t = 1)]
         batch_size: usize,
     },
 }

--- a/zero/src/bin/rpc.rs
+++ b/zero/src/bin/rpc.rs
@@ -33,13 +33,18 @@ struct RpcToolConfig {
     #[arg(short = 'u', long, env="ZERO_BIN_RPC_URL", value_hint = ValueHint::Url)]
     rpc_url: Url,
     /// The RPC Tracer Type.
-    #[arg(short = 't', long, env="ZERO_BIN_RPC_TYPE", default_value = "jerigon")]
+    #[arg(
+        short = 't',
+        long,
+        env = "ZERO_BIN_RPC_TYPE",
+        default_value = "jerigon"
+    )]
     rpc_type: RpcType,
     /// Backoff in milliseconds for retry requests.
-    #[arg(long, env="ZERO_BIN_BACKOFF", default_value_t = 0)]
+    #[arg(long, env = "ZERO_BIN_BACKOFF", default_value_t = 0)]
     backoff: u64,
     /// The maximum number of retries.
-    #[arg(long, env="ZERO_BIN_MAX_RETRIES", default_value_t = 0)]
+    #[arg(long, env = "ZERO_BIN_MAX_RETRIES", default_value_t = 0)]
     max_retries: u32,
 }
 
@@ -59,10 +64,10 @@ enum Command {
     },
     Extract {
         /// Transaction hash.
-        #[arg(short, long, env="ZERO_BIN_TX")]
+        #[arg(short, long, env = "ZERO_BIN_TX")]
         tx: String,
         /// Number of transactions in a batch to process at once.
-        #[arg(short, long, env="ZERO_BIN_BATCH_SIZE", default_value_t = 1)]
+        #[arg(short, long, env = "ZERO_BIN_BATCH_SIZE", default_value_t = 1)]
         batch_size: usize,
     },
 }

--- a/zero/src/bin/trie_diff.rs
+++ b/zero/src/bin/trie_diff.rs
@@ -44,7 +44,7 @@ pub(crate) struct Cli {
     pub(crate) prover_config: CliProverConfig,
 
     /// The previous proof output.
-    #[arg(long, short = 'f', value_hint = ValueHint::FilePath)]
+    #[arg(short = 'f', long, env="ZERO_BIN_PREVIOUS_PROOF", value_hint = ValueHint::FilePath)]
     previous_proof: Option<PathBuf>,
 }
 

--- a/zero/src/prover/cli.rs
+++ b/zero/src/prover/cli.rs
@@ -15,20 +15,20 @@ fn get_default_output_path() -> PathBuf {
 #[derive(Args, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
 pub struct CliProverConfig {
     /// The log of the max number of CPU cycles per proof.
-    #[arg(short, long, help_heading = HELP_HEADING, default_value_t = 19)]
+    #[arg(short, long, env="ZERO_BIN_MAX_CPU_LEN_LOG", help_heading = HELP_HEADING, default_value_t = 19)]
     max_cpu_len_log: usize,
     /// Number of transactions in a batch to process at once.
-    #[arg(short, long, help_heading = HELP_HEADING, default_value_t = 10)]
+    #[arg(short, long, env="ZERO_BIN_BATCH_SIZE", help_heading = HELP_HEADING, default_value_t = 10)]
     batch_size: usize,
     /// If true, save the public inputs to disk on error.
-    #[arg(short='i', long, help_heading = HELP_HEADING, default_value_t = false)]
+    #[arg(short='i', long, env="ZERO_BIN_SAVE_INPUTS_ON_ERROR", help_heading = HELP_HEADING, default_value_t = false)]
     save_inputs_on_error: bool,
     /// If true, only test the trace decoder and witness generation without
     /// generating a proof.
-    #[arg(long, help_heading = HELP_HEADING, default_value_t = false)]
+    #[arg(long, env="ZERO_BIN_TEST_ONLY", help_heading = HELP_HEADING, default_value_t = false)]
     test_only: bool,
     /// Directory where the generated proofs will be written.
-    #[arg(long, short = 'o', value_hint = ValueHint::FilePath, default_value = get_default_output_path().into_os_string())]
+    #[arg(short = 'o', long, env="ZERO_BIN_PROOF_OUTPUT_DIR", value_hint = ValueHint::FilePath, default_value = get_default_output_path().into_os_string())]
     proof_output_dir: PathBuf,
     /// Keep intermediate proofs. Default action is to
     /// delete them after the final proof is generated.
@@ -41,11 +41,11 @@ pub struct CliProverConfig {
     keep_intermediate_proofs: bool,
     /// Number of blocks in a batch. For every block batch, the prover will
     /// generate one proof file.
-    #[arg(long, default_value_t = 8)]
+    #[arg(long, env="ZERO_BIN_BLOCK_BATCH_SIZE", default_value_t = 8)]
     block_batch_size: usize,
     /// The maximum number of block proving tasks that can run in parallel. Must
     /// be greater than zero.
-    #[arg(long, default_value_t = 16)]
+    #[arg(long, env="ZERO_BIN_BLOCK_POOL_SIZE", default_value_t = 16)]
     block_pool_size: usize,
 }
 

--- a/zero/src/prover/cli.rs
+++ b/zero/src/prover/cli.rs
@@ -41,11 +41,11 @@ pub struct CliProverConfig {
     keep_intermediate_proofs: bool,
     /// Number of blocks in a batch. For every block batch, the prover will
     /// generate one proof file.
-    #[arg(long, env="ZERO_BIN_BLOCK_BATCH_SIZE", default_value_t = 8)]
+    #[arg(long, env = "ZERO_BIN_BLOCK_BATCH_SIZE", default_value_t = 8)]
     block_batch_size: usize,
     /// The maximum number of block proving tasks that can run in parallel. Must
     /// be greater than zero.
-    #[arg(long, env="ZERO_BIN_BLOCK_POOL_SIZE", default_value_t = 16)]
+    #[arg(long, env = "ZERO_BIN_BLOCK_POOL_SIZE", default_value_t = 16)]
     block_pool_size: usize,
 }
 


### PR DESCRIPTION
All leader program args now have a corresponding env variable that can also set it. This should make it easier to deploy in certain settings.

There's a bit of a minor DRY violation with repeating `ZERO_BIN_` for each of the env args, but I don't think there's too much that we can do to get around this even if we consider proc macros. Let me know if anyone has any suggestions, but yeah otherwise I think this is fine.

Finally also note that some of the args are defined in `paladin`, so another PR will be needed to be created there to also add in `env` support.

Issue: #760