### PR TITLE
feat: revamp zero prove function

### DIFF
--- a/scripts/prove_stdio.sh
+++ b/scripts/prove_stdio.sh
@@ -121,7 +121,7 @@ cargo build --release --jobs "$num_procs"
 start_time=$(date +%s%N)
 
 cmd=("${REPO_ROOT}/target/release/leader" --runtime in-memory \
-    --load-strategy on-demand -n 1 \
+    --load-strategy on-demand \
     --block-batch-size "$BLOCK_BATCH_SIZE")
 
 if [[ "$USE_TEST_CONFIG" == "use_test_config" ]]; then

--- a/zero/src/ops.rs
+++ b/zero/src/ops.rs
@@ -21,7 +21,7 @@ use crate::{debug_utils::save_inputs_to_disk, prover_state::p_state};
 
 registry!();
 
-#[derive(Deserialize, Serialize, RemoteExecute)]
+#[derive(Deserialize, Serialize, RemoteExecute, Clone)]
 pub struct SegmentProof {
     pub save_inputs_on_error: bool,
 }
@@ -207,7 +207,7 @@ impl Drop for SegmentProofSpan {
     }
 }
 
-#[derive(Deserialize, Serialize, RemoteExecute)]
+#[derive(Deserialize, Serialize, RemoteExecute, Clone)]
 pub struct SegmentAggProof {
     pub save_inputs_on_error: bool,
 }
@@ -289,7 +289,7 @@ impl Monoid for SegmentAggProof {
     }
 }
 
-#[derive(Deserialize, Serialize, RemoteExecute)]
+#[derive(Deserialize, Serialize, RemoteExecute, Clone)]
 pub struct BatchAggProof {
     pub save_inputs_on_error: bool,
 }

--- a/zero/src/prover.rs
+++ b/zero/src/prover.rs
@@ -211,6 +211,9 @@ impl BlockProverInput {
                     let mut segment_counter = 0;
                     let mut segment_proving_tasks = Vec::new();
                     while let Some(segment_data) = segment_rx.recv().await {
+                        if segment_data.is_none() {
+                            break;
+                        }
                         let seg_prove_ops = seg_prove_ops.clone();
                         let proof_runtime = proof_runtime.clone();
                         let segment_proof_tx = segment_proof_tx.clone();
@@ -245,6 +248,7 @@ impl BlockProverInput {
                         segment_proving_tasks.push(segment_proving_task);
                         segment_counter += 1;
                     }
+                    drop(segment_proof_tx);
                     // Wait for all the segment proving tasks of one batch to finish.
                     while let Some((segment_idx, segment_aggregatable_proof)) = segment_proof_rx.recv().await {
                         batch_segment_aggregatable_proofs.push((segment_idx, segment_aggregatable_proof));

--- a/zero/src/prover.rs
+++ b/zero/src/prover.rs
@@ -206,13 +206,12 @@ impl BlockProverInput {
                         // Prove the segment.
                         if let Some(segment_data) = segment_data {
                             debug!("proving the batch {batch_idx} segment data {segment_counter}");
-                            let seg_aggregatable_proof = Directive::map(
-                                IndexedStream::from([segment_data]),
-                                &seg_prove_ops,
-                            )
-                            .run(&proof_runtime.heavy_proof)
-                            .await?;
-                            let seg_aggregatable_proof = seg_aggregatable_proof.into_values_sorted().await?;
+                            let seg_aggregatable_proof =
+                                Directive::map(IndexedStream::from([segment_data]), &seg_prove_ops)
+                                    .run(&proof_runtime.heavy_proof)
+                                    .await?
+                                    .into_values_sorted()
+                                    .await?;
                             batch_segment_aggregatable_proofs.extend(seg_aggregatable_proof);
                         }
                         segment_counter += 1;

--- a/zero/src/prover.rs
+++ b/zero/src/prover.rs
@@ -136,9 +136,8 @@ impl BlockProverInput {
         };
 
         // Generate channels to communicate segments of each batch to a batch proving
-        // task. We generate a segment and send it to the proving task, then
-        // wait for it to be proved before we send another segment. This is done
-        // to avoid memory exhaustion.
+        // task. We generate segments and send them to the proving task, where they
+        // are proven in parallel.
         let (segment_senders, segment_receivers): (Vec<_>, Vec<_>) = (0..batch_count)
             .map(|_idx| {
                 let (segment_tx, segment_rx) =
@@ -220,7 +219,7 @@ impl BlockProverInput {
                         // Prove one segment in a dedicated async task.
                         let segment_proving_task = tokio::spawn(async move {
                             if let Some(segment_data) = segment_data {
-                                debug!("proving the batch {batch_idx} segment data {segment_counter}");
+                                debug!("proving the batch {batch_idx} segment nr. {segment_counter}");
                                 let seg_aggregatable_proof= Directive::map(
                                     IndexedStream::from([segment_data]),
                                     &seg_prove_ops,


### PR DESCRIPTION
Resolves  https://github.com/0xPolygonZero/zk_evm/issues/627
Resolves https://github.com/0xPolygonZero/zk_evm/issues/399
Resolves  https://github.com/0xPolygonZero/zk_evm/issues/403

Segmentation and task dispatch logic has been changed to handle proving of the individual segments of one batch on different workers. Aggregation is performed after the segments of one batch are proven (not waiting of segments of all the batches to be completed). Segments are generated sequentially and consumed immediately.